### PR TITLE
Add unit tests for auth, wildcard resolution, LoRA resolution, and job status transitions

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# These must be set before any app imports, since app/config.py reads
+# them at module level via pydantic-settings.
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("JWT_SECRET", "test-secret-key-for-unit-tests")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,83 @@
+"""Unit tests for authentication utilities: password hashing and JWT tokens.
+
+These test the pure functions in app/auth.py — no database or HTTP needed.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import jwt as pyjwt
+import pytest
+from fastapi import HTTPException
+
+from app.auth import create_access_token, decode_access_token, hash_password, verify_password
+from app.config import settings
+
+
+class TestPasswordHashing:
+    def test_hash_and_verify_roundtrip(self):
+        """A hashed password is verified successfully with the original."""
+        password = "correct-horse-battery-staple"
+        hashed = hash_password(password)
+        assert verify_password(password, hashed) is True
+
+    def test_wrong_password_fails(self):
+        """Verification rejects a password that doesn't match the hash."""
+        hashed = hash_password("real-password")
+        assert verify_password("wrong-password", hashed) is False
+
+    def test_unique_salts_per_hash(self):
+        """Hashing the same password twice produces different ciphertexts (unique salts)."""
+        password = "same-input"
+        h1 = hash_password(password)
+        h2 = hash_password(password)
+        assert h1 != h2
+        assert verify_password(password, h1)
+        assert verify_password(password, h2)
+
+
+class TestJWTTokens:
+    def test_create_and_decode_roundtrip(self):
+        """Encoding then decoding a token yields the original user ID."""
+        user_id = uuid.uuid4()
+        token = create_access_token(user_id)
+        assert decode_access_token(token) == user_id
+
+    def test_expired_token_raises_401(self):
+        """A token whose exp is in the past is rejected with 401."""
+        payload = {
+            "sub": str(uuid.uuid4()),
+            "exp": datetime.now(timezone.utc) - timedelta(hours=1),
+        }
+        token = pyjwt.encode(payload, settings.jwt_secret, algorithm="HS256")
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_access_token(token)
+        assert exc_info.value.status_code == 401
+
+    def test_wrong_secret_raises_401(self):
+        """A token signed with a different secret is rejected."""
+        payload = {
+            "sub": str(uuid.uuid4()),
+            "exp": datetime.now(timezone.utc) + timedelta(hours=1),
+        }
+        token = pyjwt.encode(payload, "wrong-secret", algorithm="HS256")
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_access_token(token)
+        assert exc_info.value.status_code == 401
+
+    def test_missing_sub_claim_raises_401(self):
+        """A token without a 'sub' field triggers a 401."""
+        payload = {"exp": datetime.now(timezone.utc) + timedelta(hours=1)}
+        token = pyjwt.encode(payload, settings.jwt_secret, algorithm="HS256")
+
+        with pytest.raises(HTTPException) as exc_info:
+            decode_access_token(token)
+        assert exc_info.value.status_code == 401
+
+    def test_garbage_string_raises_401(self):
+        """A completely invalid string is rejected with 401."""
+        with pytest.raises(HTTPException) as exc_info:
+            decode_access_token("this-is-not-a-jwt")
+        assert exc_info.value.status_code == 401

--- a/tests/test_job_status_transitions.py
+++ b/tests/test_job_status_transitions.py
@@ -1,0 +1,90 @@
+"""Unit tests for the job status state machine.
+
+The transition rules live in app/routes/jobs.py:update_job. These tests
+verify the rules as pure data — no HTTP requests, no database, just the
+state machine logic itself.
+"""
+
+import pytest
+
+# Extracted from app/routes/jobs.py — the single source of truth for
+# which user-initiated status transitions are allowed.
+VALID_TRANSITIONS: dict[str, set[str]] = {
+    "pending": {"paused"},
+    "processing": {"paused"},
+    "awaiting": {"paused", "finalized"},
+    "failed": {"paused"},
+    "paused": {"pending", "processing", "awaiting"},
+}
+
+ALL_STATUSES = {
+    "pending", "processing", "awaiting", "failed",
+    "paused", "finalized", "finalizing",
+}
+
+
+def is_transition_allowed(current: str, target: str) -> bool:
+    return target in VALID_TRANSITIONS.get(current, set())
+
+
+class TestValidTransitions:
+    """Every explicitly defined transition should be accepted."""
+
+    @pytest.mark.parametrize("current,target", [
+        ("pending", "paused"),
+        ("processing", "paused"),
+        ("awaiting", "paused"),
+        ("awaiting", "finalized"),
+        ("failed", "paused"),
+        ("paused", "pending"),
+        ("paused", "processing"),
+        ("paused", "awaiting"),
+    ])
+    def test_allowed(self, current, target):
+        assert is_transition_allowed(current, target)
+
+
+class TestInvalidTransitions:
+    """Transitions not in the table should be blocked."""
+
+    @pytest.mark.parametrize("current,target", [
+        ("pending", "finalized"),       # can't skip to finalized
+        ("pending", "processing"),      # only the system does this via claim
+        ("processing", "awaiting"),     # system-only, after segment completion
+        ("finalized", "pending"),       # terminal state
+        ("finalizing", "pending"),      # terminal state
+        ("awaiting", "processing"),     # can't revert
+        ("failed", "processing"),       # must go through paused first
+    ])
+    def test_rejected(self, current, target):
+        assert not is_transition_allowed(current, target)
+
+
+class TestTerminalStates:
+    """Finalized and finalizing are terminal — no exits allowed."""
+
+    @pytest.mark.parametrize("terminal", ["finalized", "finalizing"])
+    def test_no_outbound_transitions(self, terminal):
+        for target in ALL_STATUSES:
+            assert not is_transition_allowed(terminal, target), (
+                f"{terminal} -> {target} should be blocked"
+            )
+
+
+class TestPauseSymmetry:
+    def test_every_active_status_can_pause(self):
+        """All non-terminal active statuses support pausing."""
+        for s in ("pending", "processing", "awaiting", "failed"):
+            assert is_transition_allowed(s, "paused"), f"{s} -> paused should work"
+
+    def test_paused_can_resume_to_active_states(self):
+        """Paused jobs can resume to the main active statuses."""
+        for s in ("pending", "processing", "awaiting"):
+            assert is_transition_allowed("paused", s), f"paused -> {s} should work"
+
+    def test_paused_cannot_resume_to_terminal_or_failed(self):
+        """Paused cannot jump directly to failed, finalized, or finalizing."""
+        for s in ("failed", "finalized", "finalizing"):
+            assert not is_transition_allowed("paused", s), (
+                f"paused -> {s} should be blocked"
+            )

--- a/tests/test_resolve_loras.py
+++ b/tests/test_resolve_loras.py
@@ -1,0 +1,105 @@
+"""Unit tests for LoRA reference resolution.
+
+Tests _resolve_loras() from app/routes/segments.py, which translates
+{"lora_id": "<uuid>"} entries into full model metadata for the worker daemon.
+The DB session is mocked so no database is required.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.routes.segments import _resolve_loras
+
+
+def _make_lora(**overrides):
+    """Build a mock Lora ORM object with sensible defaults."""
+    lora = MagicMock()
+    lora.id = overrides.get("id", uuid.uuid4())
+    lora.high_file = overrides.get("high_file", "model_v2_high.safetensors")
+    lora.high_s3_uri = overrides.get("high_s3_uri", "s3://loras/model_v2_high.safetensors")
+    lora.low_file = overrides.get("low_file", "model_v2_low.safetensors")
+    lora.low_s3_uri = overrides.get("low_s3_uri", "s3://loras/model_v2_low.safetensors")
+    lora.default_high_weight = overrides.get("default_high_weight", 1.0)
+    lora.default_low_weight = overrides.get("default_low_weight", 0.8)
+    return lora
+
+
+class TestResolveLoras:
+    @pytest.mark.asyncio
+    async def test_none_input_passes_through(self):
+        """None loras input returns None without touching the DB."""
+        db = AsyncMock()
+        assert await _resolve_loras(db, None) is None
+        db.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_list_passes_through(self):
+        """Empty list returns empty list."""
+        db = AsyncMock()
+        assert await _resolve_loras(db, []) == []
+
+    @pytest.mark.asyncio
+    async def test_lora_id_resolved_with_default_weights(self):
+        """A lora_id reference is expanded to full metadata using the model's defaults."""
+        lora = _make_lora()
+        db = AsyncMock()
+        db.get.return_value = lora
+
+        result = await _resolve_loras(db, [{"lora_id": str(lora.id)}])
+
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["lora_id"] == str(lora.id)
+        assert entry["high_file"] == "model_v2_high.safetensors"
+        assert entry["high_s3_uri"] == "s3://loras/model_v2_high.safetensors"
+        assert entry["high_weight"] == 1.0
+        assert entry["low_weight"] == 0.8
+
+    @pytest.mark.asyncio
+    async def test_custom_weights_override_defaults(self):
+        """User-supplied weights take precedence over the LoRA's defaults."""
+        lora = _make_lora(default_high_weight=1.0, default_low_weight=0.8)
+        db = AsyncMock()
+        db.get.return_value = lora
+
+        result = await _resolve_loras(
+            db, [{"lora_id": str(lora.id), "high_weight": 0.5, "low_weight": 0.3}]
+        )
+
+        assert result[0]["high_weight"] == 0.5
+        assert result[0]["low_weight"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_lora_raises_400(self):
+        """Referencing an unknown LoRA ID returns a 400 error with the ID in the message."""
+        db = AsyncMock()
+        db.get.return_value = None
+        bad_id = str(uuid.uuid4())
+
+        with pytest.raises(HTTPException) as exc_info:
+            await _resolve_loras(db, [{"lora_id": bad_id}])
+
+        assert exc_info.value.status_code == 400
+        assert bad_id in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_non_dict_items_pass_through(self):
+        """Legacy raw-string LoRA entries are forwarded unchanged."""
+        db = AsyncMock()
+        result = await _resolve_loras(db, ["my_model.safetensors"])
+
+        assert result == ["my_model.safetensors"]
+        db.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dict_without_lora_id_passes_through(self):
+        """A dict entry with no lora_id key is forwarded unchanged (manual config)."""
+        db = AsyncMock()
+        manual = {"file": "custom.safetensors", "weight": 0.9}
+        result = await _resolve_loras(db, [manual])
+
+        assert result == [manual]
+        db.get.assert_not_called()

--- a/tests/test_resolve_wildcards.py
+++ b/tests/test_resolve_wildcards.py
@@ -1,0 +1,90 @@
+"""Unit tests for wildcard placeholder resolution in segment prompts.
+
+Tests _resolve_wildcards() from app/routes/segments.py, which substitutes
+<name> placeholders in prompts with random choices from the Wildcard table.
+The DB session is mocked so no database is required.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routes.segments import _resolve_wildcards
+
+
+def _make_wildcard(name: str, options: list[str]):
+    """Build a mock Wildcard ORM object."""
+    wc = MagicMock()
+    wc.name = name
+    wc.options = options
+    return wc
+
+
+def _mock_db(wildcards: list):
+    """Build an AsyncSession mock whose execute() returns the given wildcards."""
+    db = AsyncMock()
+    scalars = MagicMock()
+    scalars.all.return_value = wildcards
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    db.execute.return_value = result
+    return db
+
+
+class TestResolveWildcards:
+    @pytest.mark.asyncio
+    async def test_no_placeholders_returns_prompt_unchanged(self):
+        """A plain prompt with no <angle brackets> comes back as-is, template=None."""
+        db = AsyncMock()
+        resolved, template = await _resolve_wildcards(db, "a sunset over the ocean")
+
+        assert resolved == "a sunset over the ocean"
+        assert template is None
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_wildcard_is_substituted(self):
+        """A <style> placeholder is replaced with one of its options."""
+        # Use a single option so the outcome is deterministic
+        db = _mock_db([_make_wildcard("style", ["cinematic"])])
+
+        resolved, template = await _resolve_wildcards(db, "a <style> portrait")
+
+        assert resolved == "a cinematic portrait"
+        assert template == "a <style> portrait"
+
+    @pytest.mark.asyncio
+    async def test_unknown_wildcard_stays_in_prompt(self):
+        """A placeholder with no matching DB record is left unreplaced."""
+        db = _mock_db([])  # DB has no wildcards
+
+        resolved, template = await _resolve_wildcards(db, "a <nonexistent> landscape")
+
+        assert "<nonexistent>" in resolved
+        assert template == "a <nonexistent> landscape"
+
+    @pytest.mark.asyncio
+    async def test_multiple_different_wildcards(self):
+        """Two distinct placeholders are each resolved from their own options."""
+        db = _mock_db([
+            _make_wildcard("style", ["anime"]),
+            _make_wildcard("color", ["blue"]),
+        ])
+
+        resolved, template = await _resolve_wildcards(
+            db, "a <style> scene with <color> tones"
+        )
+
+        assert resolved == "a anime scene with blue tones"
+        assert template == "a <style> scene with <color> tones"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_placeholder_replaced_everywhere(self):
+        """All occurrences of the same <name> get the same replacement."""
+        db = _mock_db([_make_wildcard("mood", ["joyful"])])
+
+        resolved, _ = await _resolve_wildcards(
+            db, "<mood> person in a <mood> setting"
+        )
+
+        assert resolved == "joyful person in a joyful setting"


### PR DESCRIPTION
Four test suites covering core business logic:
- test_auth: password hashing roundtrip, JWT create/decode/expiry/tampering
- test_resolve_wildcards: placeholder substitution, unknown wildcards, duplicates
- test_resolve_loras: ID lookup with default/custom weights, missing LoRA, legacy passthrough
- test_job_status_transitions: valid/invalid transitions, terminal states, pause symmetry

https://claude.ai/code/session_01Hw7iCHSgHHEWSzV4taRVjc