### PR TITLE
Add GET /faceswap/presets endpoint to list preset face images from S3

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     jwt_expiry_hours: int = 24
     s3_jobs_bucket: str = "wanly-jobs"
     s3_loras_bucket: str = "wanly-loras"
+    s3_faces_bucket: str = "wanly-faces"
     aws_region: str = "us-west-2"
     civitai_api_token: str = ""
     cors_origins: str = ""

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from slowapi.errors import RateLimitExceeded
 
 from app.config import settings
 from app.limiter import limiter
-from app.routes import auth, files, jobs, loras, segments, wildcards
+from app.routes import auth, faceswap, files, jobs, loras, segments, wildcards
 
 app = FastAPI(title="wanly-api")
 
@@ -27,6 +27,7 @@ if _origins:
 app.include_router(auth.router)
 app.include_router(jobs.router)
 app.include_router(segments.router)
+app.include_router(faceswap.router)
 app.include_router(files.router)
 app.include_router(loras.router)
 app.include_router(wildcards.router)

--- a/app/routes/faceswap.py
+++ b/app/routes/faceswap.py
@@ -1,0 +1,41 @@
+import asyncio
+import logging
+import os
+
+from fastapi import APIRouter, Depends
+
+from app.auth import get_current_user
+from app.config import settings
+from app.models import User
+from app.s3 import _get_client
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _list_face_objects() -> list[dict]:
+    """List all objects in the faces bucket and return preset metadata."""
+    client = _get_client()
+    bucket = settings.s3_faces_bucket
+    resp = client.list_objects_v2(Bucket=bucket)
+    objects = resp.get("Contents", [])
+    presets = []
+    for obj in objects:
+        key = obj["Key"]
+        name = os.path.splitext(os.path.basename(key))[0]
+        presets.append({
+            "key": key,
+            "name": name,
+            "url": f"s3://{bucket}/{key}",
+        })
+    return presets
+
+
+@router.get("/faceswap/presets")
+async def list_faceswap_presets(
+    _user: User = Depends(get_current_user),
+):
+    """List available faceswap preset face images from S3."""
+    presets = await asyncio.to_thread(_list_face_objects)
+    return presets


### PR DESCRIPTION
Adds a new endpoint that lists objects in the wanly-faces S3 bucket,
returning key, display name, and S3 URI for each face image. This
supports the faceswap preset feature in wanly-console.

https://claude.ai/code/session_016BaVKuLyUMTDUytvPcPXqQ