### PR TITLE
Add segment counts to job list response

### DIFF
--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -31,6 +31,8 @@ class JobResponse(BaseModel):
     starting_image: Optional[str]
     priority: int
     status: str
+    segment_count: int = 0
+    completed_segment_count: int = 0
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
Include segment_count and completed_segment_count in JobResponse so the queue table can show progress without fetching each job's detail. Uses a single aggregation query on the segments table.