### PR TITLE
Remove locked-job rejection from reorder endpoint

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -150,14 +150,6 @@ async def reorder_jobs(
     if len(jobs_by_id) != len(body.job_ids):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Some job IDs not found or not owned by you")
 
-    # Processing/finalizing jobs are locked — their priority must not change
-    locked = [str(jid) for jid in body.job_ids if jobs_by_id[jid].status in ("processing", "finalizing")]
-    if locked:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot reorder jobs that are processing or finalizing",
-        )
-
     # Assign priority 0, 1, 2, ... based on array position
     for i, job_id in enumerate(body.job_ids):
         jobs_by_id[job_id].priority = i


### PR DESCRIPTION
Updating a processing/finalizing job's priority is harmless since the daemon has already claimed it. Rejecting the request broke the console's reorder flow when any job was in-flight.