### PR TITLE
Add secondary sort tiebreaker for priority ordering

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -120,12 +120,12 @@ async def list_jobs(
     total = total_result.scalar_one()
 
     if sort == "priority_asc":
-        order = Job.priority.asc()
+        order = [Job.priority.asc(), Job.created_at.asc()]
     else:
-        order = Job.created_at.desc()
+        order = [Job.created_at.desc()]
 
     result = await db.execute(
-        base.order_by(order).offset(offset).limit(limit)
+        base.order_by(*order).offset(offset).limit(limit)
     )
     items = list(result.scalars().all())
 


### PR DESCRIPTION
## Summary
- Adds `Job.created_at.asc()` as a secondary sort when ordering by `priority_asc`, ensuring deterministic results if two jobs ever share the same priority value.

## Test plan
- [ ] Verify `GET /jobs?sort=priority_asc` returns jobs in stable, repeatable order
- [ ] Verify jobs with the same priority are ordered by creation time (oldest first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)