### PR TITLE
Add initial_reference_image to segment claims

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -241,6 +241,7 @@ async def claim_next_segment(
         faceswap_image=segment.faceswap_image,
         faceswap_faces_order=segment.faceswap_faces_order,
         faceswap_faces_index=segment.faceswap_faces_index,
+        initial_reference_image=job.starting_image,
         width=job.width,
         height=job.height,
         fps=job.fps,

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -76,6 +76,7 @@ class SegmentClaimResponse(BaseModel):
     faceswap_image: Optional[str]
     faceswap_faces_order: Optional[str]
     faceswap_faces_index: Optional[str]
+    initial_reference_image: Optional[str] = None
     width: int
     height: int
     fps: int


### PR DESCRIPTION
## Summary
- Adds `initial_reference_image` field to `SegmentClaimResponse` schema
- Populates it with `job.starting_image` in `claim_next_segment()` so every segment claim includes the job's original input image
- Enables the daemon to use PainterLongVideo for identity anchoring on segments > 0

## Context
Chained video segments drift from the original character identity because each segment only sees the last frame of the previous segment. By sending the original input image alongside every claim, the daemon can feed it to PainterLongVideo as a dual-reference identity anchor.

Companion PR: DavidJBarnes/wanly-gpu-daemon (feature/painter-long-video)

## Test plan
- [ ] Verify segment 0 claim includes `initial_reference_image` matching `job.starting_image`
- [ ] Verify segment N>0 claims also include the field
- [ ] Verify existing daemon behavior unchanged if field is ignored (backward compatible, defaults to null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)