### PR TITLE
Reduce docker prune retention to 48h

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
               "docker stop '"$CONTAINER_NAME"' || true && docker rm '"$CONTAINER_NAME"' || true",
               "docker run -d --name '"$CONTAINER_NAME"' --restart unless-stopped --network host --env-file '"$ENV_FILE"' '"$IMAGE"'",
               "for i in 1 2 3 4 5 6; do curl -sf http://localhost:8001/docs && echo \"Health check passed\" && exit 0; echo \"Attempt $i failed, waiting 5s...\"; sleep 5; done; echo \"Health check failed\"; exit 1",
-              "docker image prune -af --filter until=168h"
+              "docker image prune -af --filter until=48h"
             ]' \
             --query 'Command.CommandId' \
             --output text)


### PR DESCRIPTION
## Summary
- Changes `docker image prune` filter from `until=168h` (7 days) to `until=48h` (2 days) to free disk space more aggressively

🤖 Generated with [Claude Code](https://claude.com/claude-code)