### PR TITLE
Add per-job LightX2V strength settings

### DIFF
--- a/alembic/versions/012_add_lightx2v_to_jobs.py
+++ b/alembic/versions/012_add_lightx2v_to_jobs.py
@@ -1,0 +1,30 @@
+"""Add lightx2v strength columns to jobs
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-02-26
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "012"
+down_revision = "011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("lightx2v_strength_high", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column("lightx2v_strength_low", sa.Float(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "lightx2v_strength_low")
+    op.drop_column("jobs", "lightx2v_strength_high")

--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,8 @@ class Job(Base):
     fps = mapped_column(Integer, nullable=False)
     seed = mapped_column(BigInteger, nullable=False)
     starting_image = mapped_column(Text, nullable=True)
+    lightx2v_strength_high = mapped_column(Float, nullable=True)
+    lightx2v_strength_low = mapped_column(Float, nullable=True)
     priority = mapped_column(Integer, nullable=False, default=0)
     status = mapped_column(String(20), nullable=False, default="pending")
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -54,6 +54,8 @@ async def create_job(
         height=body.height,
         fps=body.fps,
         seed=seed,
+        lightx2v_strength_high=body.lightx2v_strength_high,
+        lightx2v_strength_low=body.lightx2v_strength_low,
         priority=next_priority,
     )
     db.add(job)
@@ -158,6 +160,8 @@ async def list_jobs(
                 fps=j.fps,
                 seed=j.seed,
                 starting_image=j.starting_image,
+                lightx2v_strength_high=j.lightx2v_strength_high,
+                lightx2v_strength_low=j.lightx2v_strength_low,
                 priority=j.priority,
                 status=j.status,
                 segment_count=seg_total,
@@ -232,6 +236,8 @@ async def get_job(
         fps=job.fps,
         seed=job.seed,
         starting_image=job.starting_image,
+        lightx2v_strength_high=job.lightx2v_strength_high,
+        lightx2v_strength_low=job.lightx2v_strength_low,
         priority=job.priority,
         status=job.status,
         created_at=job.created_at,
@@ -332,6 +338,8 @@ async def reopen_job(
     return JobDetailResponse(
         id=job.id, name=job.name, width=job.width, height=job.height,
         fps=job.fps, seed=job.seed, starting_image=job.starting_image,
+        lightx2v_strength_high=job.lightx2v_strength_high,
+        lightx2v_strength_low=job.lightx2v_strength_low,
         priority=job.priority, status=job.status,
         created_at=job.created_at, updated_at=job.updated_at,
         segments=segments, videos=job.videos,

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -244,6 +244,8 @@ async def claim_next_segment(
         faceswap_faces_order=segment.faceswap_faces_order,
         faceswap_faces_index=segment.faceswap_faces_index,
         initial_reference_image=job.starting_image,
+        lightx2v_strength_high=job.lightx2v_strength_high,
+        lightx2v_strength_low=job.lightx2v_strength_low,
         width=job.width,
         height=job.height,
         fps=job.fps,

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -18,6 +18,8 @@ class JobCreate(BaseModel):
     height: int
     fps: int
     seed: Optional[int] = None
+    lightx2v_strength_high: Optional[float] = None
+    lightx2v_strength_low: Optional[float] = None
     first_segment: SegmentCreate
 
 
@@ -29,6 +31,8 @@ class JobResponse(BaseModel):
     fps: int
     seed: int
     starting_image: Optional[str]
+    lightx2v_strength_high: Optional[float]
+    lightx2v_strength_low: Optional[float]
     priority: int
     status: str
     segment_count: int = 0

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -80,6 +80,8 @@ class SegmentClaimResponse(BaseModel):
     faceswap_faces_order: Optional[str]
     faceswap_faces_index: Optional[str]
     initial_reference_image: Optional[str] = None
+    lightx2v_strength_high: Optional[float] = None
+    lightx2v_strength_low: Optional[float] = None
     width: int
     height: int
     fps: int


### PR DESCRIPTION
## Summary
- Add nullable `lightx2v_strength_high` and `lightx2v_strength_low` columns to jobs table (migration 012)
- Thread values through JobCreate, JobResponse, JobDetailResponse, and SegmentClaimResponse
- Null means "use daemon default" — existing jobs unaffected

## Test plan
- [ ] Run migration 012 against dev database
- [ ] Create job without lightx2v values — verify nulls stored
- [ ] Create job with lightx2v values — verify stored and returned in responses
- [ ] Claim segment — verify lightx2v values present in claim response

Closes DavidJBarnes/wanly-console#53

🤖 Generated with [Claude Code](https://claude.com/claude-code)