### PR TITLE
Move docker prune before pull to fix disk full deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,12 +56,13 @@ jobs:
             --parameters commands='[
               "set -e",
               "aws ecr get-login-password --region '"$AWS_REGION"' | docker login --username AWS --password-stdin '"$ECR_REGISTRY"'",
+              "docker image prune -af",
               "docker pull '"$IMAGE"'",
               "docker run --rm --network host --env-file '"$ENV_FILE"' '"$IMAGE"' alembic upgrade head",
               "docker stop '"$CONTAINER_NAME"' || true && docker rm '"$CONTAINER_NAME"' || true",
               "docker run -d --name '"$CONTAINER_NAME"' --restart unless-stopped --network host --env-file '"$ENV_FILE"' '"$IMAGE"'",
               "for i in 1 2 3 4 5 6; do curl -sf http://localhost:8001/docs && echo \"Health check passed\" && exit 0; echo \"Attempt $i failed, waiting 5s...\"; sleep 5; done; echo \"Health check failed\"; exit 1",
-              "docker image prune -af --filter until=48h"
+              "docker image prune -af"
             ]' \
             --query 'Command.CommandId' \
             --output text)


### PR DESCRIPTION
## Summary
- Move `docker image prune -af` before `docker pull` so disk space is freed first
- Drop `--filter until=48h` to prune all unused images immediately
- Also keep the post-deploy prune for cleanup

## Test plan
- [ ] Push to main triggers deploy that succeeds on the t3.micro

🤖 Generated with [Claude Code](https://claude.com/claude-code)