### PR TITLE
Add image gallery S3 listing endpoints

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -2,16 +2,22 @@ import asyncio
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
 
-from app.auth import verify_api_key
+from app.auth import get_current_user, verify_api_key
 from app.config import settings
-from app.s3 import upload_bytes
+from app.s3 import (
+    delete_object,
+    get_first_object_key,
+    list_common_prefixes,
+    list_objects,
+    upload_bytes,
+)
 
-router = APIRouter(tags=["images"], dependencies=[Depends(verify_api_key)])
+router = APIRouter(tags=["images"])
 
 
-@router.post("/images/upload")
+@router.post("/images/upload", dependencies=[Depends(verify_api_key)])
 async def upload_image(file: UploadFile, filename: str | None = None):
     data = await file.read()
     if not filename:
@@ -26,3 +32,50 @@ async def upload_image(file: UploadFile, filename: str | None = None):
     bucket = settings.s3_images_bucket
     uri = await asyncio.to_thread(upload_bytes, data, key, bucket)
     return {"path": uri}
+
+
+@router.get("/images/folders", dependencies=[Depends(get_current_user)])
+async def list_folders():
+    """List date folders in the images bucket, newest first."""
+    bucket = settings.s3_images_bucket
+    prefixes = await asyncio.to_thread(list_common_prefixes, bucket)
+    # Sort newest first (prefixes look like "2026-02-27/")
+    prefixes.sort(reverse=True)
+
+    # Get first object in each folder for thumbnails (parallel)
+    async def _thumb(prefix: str) -> dict:
+        name = prefix.rstrip("/")
+        key = await asyncio.to_thread(get_first_object_key, bucket, prefix)
+        thumbnail = f"s3://{bucket}/{key}" if key else None
+        return {"name": name, "thumbnail": thumbnail}
+
+    folders = await asyncio.gather(*[_thumb(p) for p in prefixes])
+    return list(folders)
+
+
+@router.get("/images/folder/{date}", dependencies=[Depends(get_current_user)])
+async def list_folder_images(date: str):
+    """List images in a date folder."""
+    bucket = settings.s3_images_bucket
+    prefix = f"{date}/"
+    objects = await asyncio.to_thread(list_objects, bucket, prefix)
+    return [
+        {
+            "key": obj["Key"],
+            "path": f"s3://{bucket}/{obj['Key']}",
+            "filename": obj["Key"].split("/", 1)[1] if "/" in obj["Key"] else obj["Key"],
+            "size": obj["Size"],
+            "last_modified": obj["LastModified"],
+        }
+        for obj in objects
+    ]
+
+
+@router.delete("/images", dependencies=[Depends(get_current_user)])
+async def delete_image(path: str = Query(...)):
+    """Delete a single image by S3 URI."""
+    bucket = settings.s3_images_bucket
+    if not path.startswith(f"s3://{bucket}/"):
+        raise HTTPException(status_code=400, detail="Path must be in the images bucket")
+    await asyncio.to_thread(delete_object, path)
+    return {"ok": True}


### PR DESCRIPTION
## Summary
- Add `list_common_prefixes()`, `list_objects()`, `get_first_object_key()` to `app/s3.py` for S3 folder/object listing with pagination
- Add `GET /images/folders` — lists date folders (newest first) with parallel thumbnail lookups
- Add `GET /images/folder/{date}` — lists images in a date folder
- Add `DELETE /images?path=...` — deletes a single image from S3 (validates bucket)
- Restructure auth: upload stays API key, new endpoints use JWT (`get_current_user`)

## Test plan
- [ ] Deploy to EC2 and verify `GET /images/folders` returns date folders via Swagger UI with JWT
- [ ] Verify `GET /images/folder/2026-02-27` returns image list
- [ ] Verify `DELETE /images?path=s3://wanly-images/...` removes the object
- [ ] Verify `POST /images/upload` still works with API key auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)