### PR TITLE
Add prompt presets CRUD API

### DIFF
--- a/alembic/versions/013_add_prompt_presets.py
+++ b/alembic/versions/013_add_prompt_presets.py
@@ -1,0 +1,31 @@
+"""Add prompt_presets table
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-02-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "013"
+down_revision = "012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "prompt_presets",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(255), unique=True, nullable=False),
+        sa.Column("prompt", sa.Text(), nullable=False),
+        sa.Column("loras", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("prompt_presets")

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from slowapi.errors import RateLimitExceeded
 
 from app.config import settings
 from app.limiter import limiter
-from app.routes import auth, faceswap, files, images, jobs, loras, segments, tags, wildcards
+from app.routes import auth, faceswap, files, images, jobs, loras, prompt_presets, segments, tags, wildcards
 
 app = FastAPI(title="wanly-api")
 
@@ -33,3 +33,4 @@ app.include_router(files.router)
 app.include_router(loras.router)
 app.include_router(tags.router)
 app.include_router(wildcards.router)
+app.include_router(prompt_presets.router)

--- a/app/models.py
+++ b/app/models.py
@@ -147,3 +147,14 @@ class Wildcard(Base):
     options = mapped_column(JSON, nullable=False, default=list)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+
+class PromptPreset(Base):
+    __tablename__ = "prompt_presets"
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = mapped_column(String(255), unique=True, nullable=False)
+    prompt = mapped_column(Text, nullable=False)
+    loras = mapped_column(JSON, nullable=True)
+    created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))

--- a/app/routes/prompt_presets.py
+++ b/app/routes/prompt_presets.py
@@ -1,0 +1,90 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import PromptPreset, User
+from app.schemas.prompt_presets import PromptPresetCreate, PromptPresetResponse, PromptPresetUpdate
+
+router = APIRouter()
+
+
+@router.get("/prompt-presets", response_model=list[PromptPresetResponse])
+async def list_prompt_presets(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(PromptPreset).order_by(PromptPreset.name))
+    return result.scalars().all()
+
+
+@router.post("/prompt-presets", response_model=PromptPresetResponse, status_code=status.HTTP_201_CREATED)
+async def create_prompt_preset(
+    body: PromptPresetCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    existing = await db.execute(select(PromptPreset).where(PromptPreset.name == body.name))
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Preset '{body.name}' already exists",
+        )
+    preset = PromptPreset(
+        name=body.name,
+        prompt=body.prompt,
+        loras=[l.model_dump() for l in body.loras] if body.loras else None,
+    )
+    db.add(preset)
+    await db.commit()
+    await db.refresh(preset)
+    return preset
+
+
+@router.get("/prompt-presets/{preset_id}", response_model=PromptPresetResponse)
+async def get_prompt_preset(
+    preset_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    preset = await db.get(PromptPreset, preset_id)
+    if preset is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Preset not found")
+    return preset
+
+
+@router.patch("/prompt-presets/{preset_id}", response_model=PromptPresetResponse)
+async def update_prompt_preset(
+    preset_id: UUID,
+    body: PromptPresetUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    preset = await db.get(PromptPreset, preset_id)
+    if preset is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Preset not found")
+    if body.name is not None:
+        preset.name = body.name
+    if body.prompt is not None:
+        preset.prompt = body.prompt
+    if body.loras is not None:
+        preset.loras = [l.model_dump() for l in body.loras]
+    await db.commit()
+    await db.refresh(preset)
+    return preset
+
+
+@router.delete("/prompt-presets/{preset_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_prompt_preset(
+    preset_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    preset = await db.get(PromptPreset, preset_id)
+    if preset is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Preset not found")
+    await db.delete(preset)
+    await db.commit()

--- a/app/schemas/prompt_presets.py
+++ b/app/schemas/prompt_presets.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class LoraSlot(BaseModel):
+    lora_id: str
+    high_weight: float
+    low_weight: float
+
+
+class PromptPresetCreate(BaseModel):
+    name: str
+    prompt: str
+    loras: Optional[list[LoraSlot]] = None
+
+
+class PromptPresetUpdate(BaseModel):
+    name: Optional[str] = None
+    prompt: Optional[str] = None
+    loras: Optional[list[LoraSlot]] = None
+
+
+class PromptPresetResponse(BaseModel):
+    id: UUID
+    name: str
+    prompt: str
+    loras: Optional[list[LoraSlot]] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- New `prompt_presets` table with Alembic migration (013)
- CRUD endpoints: `GET/POST /prompt-presets`, `GET/PATCH/DELETE /prompt-presets/{id}`
- Each preset stores a name, prompt text, and optional LoRA slot configurations (lora_id + weights)

## Test plan
- [ ] Run `alembic upgrade head` on RDS to create `prompt_presets` table
- [ ] Test all 5 CRUD endpoints via Swagger UI at `/docs`
- [ ] Verify unique name constraint rejects duplicates
- [ ] Verify LoRA JSON stored and returned correctly

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)