### PR TITLE
Reduce duplicate S3 uploads for starting images

### DIFF
--- a/alembic/versions/014_add_starting_image_hash.py
+++ b/alembic/versions/014_add_starting_image_hash.py
@@ -1,0 +1,24 @@
+"""Add starting_image_hash to jobs
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-03-03
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "014"
+down_revision = "013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("starting_image_hash", sa.String(64), nullable=True))
+    op.create_index("ix_jobs_starting_image_hash", "jobs", ["starting_image_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_starting_image_hash", table_name="jobs")
+    op.drop_column("jobs", "starting_image_hash")

--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,7 @@ class Job(Base):
     fps = mapped_column(Integer, nullable=False)
     seed = mapped_column(BigInteger, nullable=False)
     starting_image = mapped_column(Text, nullable=True)
+    starting_image_hash = mapped_column(String(64), nullable=True, index=True)
     lightx2v_strength_high = mapped_column(Float, nullable=True)
     lightx2v_strength_low = mapped_column(Float, nullable=True)
     priority = mapped_column(Integer, nullable=False, default=0)

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import json
 import os
 import random
@@ -63,13 +64,29 @@ async def create_job(
     db.add(job)
     await db.flush()  # Get job.id
 
-    # Upload starting image to S3 if provided
+    # Upload starting image to S3 if provided (with hash-based dedup)
     if starting_image is not None:
         image_data = await starting_image.read()
-        ext = os.path.splitext(starting_image.filename or "image.png")[1] or ".png"
-        key = f"{job.id}/starting_image{ext}"
-        uri = await asyncio.to_thread(upload_bytes, image_data, key, settings.s3_jobs_bucket)
-        job.starting_image = uri
+        image_hash = hashlib.sha256(image_data).hexdigest()
+
+        # Check if this exact image already exists for this user
+        existing = await db.execute(
+            select(Job.starting_image)
+            .where(Job.user_id == user.id, Job.starting_image_hash == image_hash)
+            .limit(1)
+        )
+        existing_uri = existing.scalar_one_or_none()
+
+        if existing_uri:
+            job.starting_image = existing_uri
+        else:
+            ext = os.path.splitext(starting_image.filename or "image.png")[1] or ".png"
+            key = f"{job.id}/starting_image{ext}"
+            uri = await asyncio.to_thread(upload_bytes, image_data, key, settings.s3_jobs_bucket)
+            job.starting_image = uri
+        job.starting_image_hash = image_hash
+    elif body.starting_image_uri:
+        job.starting_image = body.starting_image_uri
 
     # Upload faceswap image to S3 if provided
     faceswap_uri = None

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -20,6 +20,7 @@ class JobCreate(BaseModel):
     seed: Optional[int] = None
     lightx2v_strength_high: Optional[float] = None
     lightx2v_strength_low: Optional[float] = None
+    starting_image_uri: Optional[str] = None
     first_segment: SegmentCreate
 
 


### PR DESCRIPTION
## Summary
- **Hash-based dedup**: SHA-256 hash starting images on upload; reuse existing S3 object if same image was already uploaded by user
- **URI pass-through**: Accept `starting_image_uri` in job creation to skip download+re-upload (ImageRepo path)
- **Migration 014**: Adds indexed `starting_image_hash` column to jobs table

## Test plan
- [ ] Upload same image for two jobs — second job should skip S3 upload and reuse existing URI
- [ ] Verify jobs with new images still upload normally
- [ ] Run migration 014 on RDS

🤖 Generated with [Claude Code](https://claude.com/claude-code)