### PR TITLE
Fix GET /files auth for browser media loads

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 import bcrypt
 import jwt
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,6 +19,33 @@ api_key_header = APIKeyHeader(name="X-API-Key")
 async def verify_api_key(key: str = Depends(api_key_header)):
     if not settings.api_key or key != settings.api_key:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+
+async def verify_api_key_or_token(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Accept either X-API-Key header (daemon) or ?token= query param (browser).
+
+    For browser media loads (<img src>, <video src>) that can't send custom headers.
+    """
+    # Try API key first
+    api_key = request.headers.get("x-api-key")
+    if api_key:
+        if settings.api_key and api_key == settings.api_key:
+            return
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+    # Try JWT query param
+    token = request.query_params.get("token")
+    if token:
+        user_id = decode_access_token(token)
+        result = await db.execute(select(User).where(User.id == user_id))
+        if result.scalar_one_or_none() is not None:
+            return
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
 
 
 def hash_password(password: str) -> str:

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -8,7 +8,7 @@ from fastapi.responses import Response
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import get_current_user, verify_api_key
+from app.auth import get_current_user, verify_api_key, verify_api_key_or_token
 from app.config import settings
 from app.database import get_db
 from app.enums import JobStatus, SegmentStatus, VideoStatus
@@ -49,7 +49,7 @@ async def upload_file(
     return {"path": uri}
 
 
-@router.get("/files", dependencies=[Depends(verify_api_key)])
+@router.get("/files", dependencies=[Depends(verify_api_key_or_token)])
 async def download_file(path: str, request: Request):
     """Download a file from S3 by its S3 URI.
 

--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
 
-from app.auth import get_current_user, verify_api_key
+from app.auth import get_current_user
 from app.config import settings
 from app.s3 import (
     delete_object,
@@ -17,7 +17,7 @@ from app.s3 import (
 router = APIRouter(tags=["images"])
 
 
-@router.post("/images/upload", dependencies=[Depends(verify_api_key)])
+@router.post("/images/upload", dependencies=[Depends(get_current_user)])
 async def upload_image(file: UploadFile, filename: str | None = None):
     data = await file.read()
     if not filename:


### PR DESCRIPTION
## Summary
- `GET /files` now accepts **either** `X-API-Key` header (daemon) or `?token=<JWT>` query param (browser)
- Browser `<img src>` and `<video src>` tags can't send custom headers, so the JWT is passed as a query param
- `POST /images/upload` switched from API key auth back to JWT auth (it's a browser-only route)
- Companion PR: DavidJBarnes/wanly-console fix/files-auth-token

## Test plan
- [ ] Merge API PR first, deploy
- [ ] Merge console PR, deploy
- [ ] Verify segment thumbnails, video previews, and image library all load correctly
- [ ] Verify daemon can still download files via X-API-Key

🤖 Generated with [Claude Code](https://claude.com/claude-code)