### PR TITLE
Add AI prompt generation via Ollama

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -14,6 +14,11 @@ class Settings(BaseSettings):
     civitai_api_token: str = ""
     cors_origins: str = ""
     login_rate_limit: str = "5/minute"
+    ollama_url: str = "http://2070.zero:11434"
+    ollama_vision_model: str = "huihui_ai/qwen2.5-vl-abliterated:7b"
+    ollama_text_model: str = "dolphin-mistral:7b"
+    ollama_vision_prompt: str = "Describe this image in explicit detail in under 100 words. Include all people, their positions, actions, body language, setting, lighting, and camera angle."
+    ollama_text_prompt: str = "Write a single concise paragraph describing how this scene continues as a 5-second video clip. The camera remains completely static — no pans, zooms, or angle changes. Only describe body movements, rhythm, position changes, and physical reactions. Use explicit adult terminology for positions and actions. Keep it under 100 words."
 
     model_config = {"env_file": ".env"}
 

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from slowapi.errors import RateLimitExceeded
 
 from app.config import settings
 from app.limiter import limiter
-from app.routes import auth, faceswap, files, images, jobs, loras, prompt_presets, segments, tags, wildcards
+from app.routes import auth, faceswap, files, images, jobs, loras, prompt_gen, prompt_presets, segments, tags, wildcards
 
 logger = logging.getLogger(__name__)
 
@@ -45,4 +45,5 @@ app.include_router(files.router)
 app.include_router(loras.router)
 app.include_router(tags.router)
 app.include_router(wildcards.router)
+app.include_router(prompt_gen.router)
 app.include_router(prompt_presets.router)

--- a/app/routes/prompt_gen.py
+++ b/app/routes/prompt_gen.py
@@ -1,0 +1,125 @@
+import asyncio
+import base64
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.auth import get_current_user
+from app.config import settings
+from app.models import User
+from app.s3 import download_bytes
+from app.schemas.prompt_gen import (
+    PromptGenRequest,
+    PromptGenResponse,
+    PromptTemplatesResponse,
+    PromptTemplatesUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# In-memory template overrides (reset on restart)
+_template_overrides: dict[str, str] = {}
+
+
+def _get_template(key: str) -> str:
+    return _template_overrides.get(key, getattr(settings, f"ollama_{key}"))
+
+
+@router.post("/prompt/generate", response_model=PromptGenResponse)
+async def generate_prompt(
+    body: PromptGenRequest,
+    user: User = Depends(get_current_user),
+):
+    # Step 1: Resolve image to base64
+    if body.image_s3_uri:
+        try:
+            raw = await asyncio.to_thread(download_bytes, body.image_s3_uri)
+            image_b64 = base64.b64encode(raw).decode()
+        except Exception:
+            logger.exception("Failed to download image from S3: %s", body.image_s3_uri)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Failed to download image from S3",
+            )
+    else:
+        image_b64 = body.image_base64
+
+    ollama_url = settings.ollama_url
+
+    # Step 2: Vision model — describe the image
+    vision_payload = {
+        "model": _get_template("vision_model"),
+        "prompt": _get_template("vision_prompt"),
+        "images": [image_b64],
+        "stream": False,
+    }
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        try:
+            resp = await client.post(f"{ollama_url}/api/generate", json=vision_payload)
+            resp.raise_for_status()
+            description = resp.json()["response"]
+        except Exception:
+            logger.exception("Ollama vision call failed")
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Ollama vision model failed — is Ollama running?",
+            )
+
+    # Step 3: Text model — generate video prompt from description
+    prefix = body.prompt_prefix
+    intro = f"Here is a still image description of {prefix}:" if prefix else "Here is a still image description:"
+    text_prompt = f"{intro}\n\n{description}\n\n{_get_template('text_prompt')}"
+
+    text_payload = {
+        "model": _get_template("text_model"),
+        "prompt": text_prompt,
+        "stream": False,
+    }
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        try:
+            resp = await client.post(f"{ollama_url}/api/generate", json=text_payload)
+            resp.raise_for_status()
+            generated_prompt = resp.json()["response"]
+        except Exception:
+            logger.exception("Ollama text call failed")
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Ollama text model failed — is Ollama running?",
+            )
+
+    return PromptGenResponse(prompt=generated_prompt.strip(), description=description.strip())
+
+
+@router.get("/prompt/templates", response_model=PromptTemplatesResponse)
+async def get_templates(user: User = Depends(get_current_user)):
+    return PromptTemplatesResponse(
+        vision_prompt=_get_template("vision_prompt"),
+        text_prompt=_get_template("text_prompt"),
+        vision_model=_get_template("vision_model"),
+        text_model=_get_template("text_model"),
+    )
+
+
+@router.put("/prompt/templates", response_model=PromptTemplatesResponse)
+async def update_templates(
+    body: PromptTemplatesUpdate,
+    user: User = Depends(get_current_user),
+):
+    if body.vision_prompt is not None:
+        _template_overrides["vision_prompt"] = body.vision_prompt
+    if body.text_prompt is not None:
+        _template_overrides["text_prompt"] = body.text_prompt
+    if body.vision_model is not None:
+        _template_overrides["vision_model"] = body.vision_model
+    if body.text_model is not None:
+        _template_overrides["text_model"] = body.text_model
+
+    return PromptTemplatesResponse(
+        vision_prompt=_get_template("vision_prompt"),
+        text_prompt=_get_template("text_prompt"),
+        vision_model=_get_template("vision_model"),
+        text_model=_get_template("text_model"),
+    )

--- a/app/schemas/prompt_gen.py
+++ b/app/schemas/prompt_gen.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from pydantic import BaseModel, model_validator
+
+
+class PromptGenRequest(BaseModel):
+    image_base64: Optional[str] = None
+    image_s3_uri: Optional[str] = None
+    prompt_prefix: Optional[str] = None
+
+    @model_validator(mode="after")
+    def exactly_one_image_source(self):
+        has_base64 = bool(self.image_base64)
+        has_s3 = bool(self.image_s3_uri)
+        if not has_base64 and not has_s3:
+            raise ValueError("Either image_base64 or image_s3_uri is required")
+        if has_base64 and has_s3:
+            raise ValueError("Provide only one of image_base64 or image_s3_uri")
+        return self
+
+
+class PromptGenResponse(BaseModel):
+    prompt: str
+    description: str
+
+
+class PromptTemplatesResponse(BaseModel):
+    vision_prompt: str
+    text_prompt: str
+    vision_model: str
+    text_model: str
+
+
+class PromptTemplatesUpdate(BaseModel):
+    vision_prompt: Optional[str] = None
+    text_prompt: Optional[str] = None
+    vision_model: Optional[str] = None
+    text_model: Optional[str] = None


### PR DESCRIPTION
## Summary
- **POST /prompt/generate**: 2-step Ollama pipeline — vision model describes image, text model generates video prompt from description + optional user prefix
- **GET/PUT /prompt/templates**: In-memory template overrides for vision/text prompts and models (resets on restart)
- Supports both base64 image upload and S3 URI (server-side download) as image sources

## Test plan
- [ ] Hit POST /prompt/generate via Swagger UI with a test base64 image
- [ ] Test with S3 URI pointing to an existing job image
- [ ] Verify GET /prompt/templates returns defaults
- [ ] Verify PUT /prompt/templates updates and persists until restart
- [ ] Test error handling when Ollama is unreachable (502 response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)