### PR TITLE
Use template placeholders + bump Ollama timeout

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
     ollama_vision_model: str = "huihui_ai/qwen2.5-vl-abliterated:7b"
     ollama_text_model: str = "dolphin-mistral:7b"
     ollama_vision_prompt: str = "Describe this image in explicit detail in under 100 words. Include all people, their positions, actions, body language, setting, lighting, and camera angle."
-    ollama_text_prompt: str = "Write a single concise paragraph describing how this scene continues as a 5-second video clip. The camera remains completely static — no pans, zooms, or angle changes. Only describe body movements, rhythm, position changes, and physical reactions. Use explicit adult terminology for positions and actions. Keep it under 100 words."
+    ollama_text_prompt: str = "Here is a still image description of {prefix}:\n\n{description}\n\nWrite a single concise paragraph describing how this scene continues as a 5-second video clip. The camera remains completely static — no pans, zooms, or angle changes. Only describe body movements, rhythm, position changes, and physical reactions. Use explicit adult terminology for positions and actions. Keep it under 100 words."
 
     model_config = {"env_file": ".env"}
 

--- a/app/routes/prompt_gen.py
+++ b/app/routes/prompt_gen.py
@@ -56,7 +56,7 @@ async def generate_prompt(
         "images": [image_b64],
         "stream": False,
     }
-    async with httpx.AsyncClient(timeout=120.0) as client:
+    async with httpx.AsyncClient(timeout=300.0) as client:
         try:
             resp = await client.post(f"{ollama_url}/api/generate", json=vision_payload)
             resp.raise_for_status()
@@ -69,16 +69,19 @@ async def generate_prompt(
             )
 
     # Step 3: Text model — generate video prompt from description
-    prefix = body.prompt_prefix
-    intro = f"Here is a still image description of {prefix}:" if prefix else "Here is a still image description:"
-    text_prompt = f"{intro}\n\n{description}\n\n{_get_template('text_prompt')}"
+    prefix = body.prompt_prefix or ""
+    template = _get_template("text_prompt")
+    # Strip " of {prefix}" when no prefix provided
+    if not prefix and " of {prefix}" in template:
+        template = template.replace(" of {prefix}", "")
+    text_prompt = template.replace("{prefix}", prefix).replace("{description}", description)
 
     text_payload = {
         "model": _get_template("text_model"),
         "prompt": text_prompt,
         "stream": False,
     }
-    async with httpx.AsyncClient(timeout=120.0) as client:
+    async with httpx.AsyncClient(timeout=300.0) as client:
         try:
             resp = await client.post(f"{ollama_url}/api/generate", json=text_payload)
             resp.raise_for_status()


### PR DESCRIPTION
## Summary
- Text prompt template now uses `{prefix}` and `{description}` placeholders instead of hardcoded assembly
- Bumped Ollama HTTP timeout from 120s to 300s to handle cold model loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)