### PR TITLE
Make text prompt a full template with {prefix} and {description} plac…

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,7 +18,7 @@ class Settings(BaseSettings):
     ollama_vision_model: str = "huihui_ai/qwen2.5-vl-abliterated:7b"
     ollama_text_model: str = "dolphin-mistral:7b"
     ollama_vision_prompt: str = "Describe this image in explicit detail in under 100 words. Include all people, their positions, actions, body language, setting, lighting, and camera angle."
-    ollama_text_prompt: str = "Write a single concise paragraph describing how this scene continues as a 5-second video clip. The camera remains completely static — no pans, zooms, or angle changes. Only describe body movements, rhythm, position changes, and physical reactions. Use explicit adult terminology for positions and actions. Keep it under 100 words."
+    ollama_text_prompt: str = "Here is a still image description of {prefix}:\n\n{description}\n\nWrite a single concise paragraph describing how this scene continues as a 5-second video clip. The camera remains completely static — no pans, zooms, or angle changes. Only describe body movements, rhythm, position changes, and physical reactions. Use explicit adult terminology for positions and actions. Keep it under 100 words."
 
     model_config = {"env_file": ".env"}
 

--- a/app/routes/prompt_gen.py
+++ b/app/routes/prompt_gen.py
@@ -69,9 +69,12 @@ async def generate_prompt(
             )
 
     # Step 3: Text model — generate video prompt from description
-    prefix = body.prompt_prefix
-    intro = f"Here is a still image description of {prefix}:" if prefix else "Here is a still image description:"
-    text_prompt = f"{intro}\n\n{description}\n\n{_get_template('text_prompt')}"
+    prefix = body.prompt_prefix or ""
+    template = _get_template("text_prompt")
+    # Strip " of {prefix}" when no prefix provided
+    if not prefix and " of {prefix}" in template:
+        template = template.replace(" of {prefix}", "")
+    text_prompt = template.replace("{prefix}", prefix).replace("{description}", description)
 
     text_payload = {
         "model": _get_template("text_model"),


### PR DESCRIPTION
…eholders

The text prompt template now includes the intro/description assembly so users can see and customize the full prompt structure in the templates editor.