### PR TITLE
Switch vision model to joycaption-beta

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
     cors_origins: str = ""
     login_rate_limit: str = "5/minute"
     ollama_url: str = "http://2070.zero:11434"
-    ollama_vision_model: str = "huihui_ai/qwen2.5-vl-abliterated:7b"
+    ollama_vision_model: str = "user-v4/joycaption-beta:latest"
     ollama_text_model: str = "dolphin-mistral:7b"
     ollama_vision_prompt: str = "Describe this image in explicit detail in under 100 words. Include all people, their positions, actions, body language, setting, lighting, and camera angle."
     ollama_text_prompt: str = "Here is a still image description of {prefix}:\n\n{description}\n\nWrite a single concise paragraph describing how this scene continues as a 5-second video clip. The camera remains completely static — no pans, zooms, or angle changes. Only describe body movements, rhythm, position changes, and physical reactions. Use explicit adult terminology for positions and actions. Keep it under 100 words."


### PR DESCRIPTION
## Summary
- Change default Ollama vision model from `huihui_ai/qwen2.5-vl-abliterated:7b` to `user-v4/joycaption-beta:latest`

## Test plan
- [ ] Verify joycaption-beta model is pulled on 2070
- [ ] Test prompt generation with new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)