### PR TITLE
Allow API key auth on /images/upload

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile
 
-from app.auth import get_current_user
+from app.auth import get_current_user, verify_api_key_or_token
 from app.config import settings
 from app.s3 import (
     delete_object,
@@ -17,7 +17,7 @@ from app.s3 import (
 router = APIRouter(tags=["images"])
 
 
-@router.post("/images/upload", dependencies=[Depends(get_current_user)])
+@router.post("/images/upload", dependencies=[Depends(verify_api_key_or_token)])
 async def upload_image(file: UploadFile, filename: str | None = None):
     data = await file.read()
     if not filename:


### PR DESCRIPTION
## Summary
- `/images/upload` was using `get_current_user` (JWT only), causing 401 for a1111 which sends `X-API-Key`
- Switched to `verify_api_key_or_token` which accepts both JWT Bearer tokens and API keys

## Test plan
- [ ] Upload image via a1111 with X-API-Key header — should succeed
- [ ] Upload image via console (JWT) — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)