### PR TITLE
Revert vision model to qwen2.5-vl-abliterated

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,7 @@ class Settings(BaseSettings):
     cors_origins: str = ""
     login_rate_limit: str = "5/minute"
     ollama_url: str = "http://2070.zero:11434"
-    ollama_vision_model: str = "user-v4/joycaption-beta:latest"
+    ollama_vision_model: str = "huihui_ai/qwen2.5-vl-abliterated:7b"
     ollama_text_model: str = "dolphin-mistral:7b"
     ollama_vision_prompt: str = "Describe this image in explicit detail in under 100 words. Include all people, their positions, actions, body language, setting, lighting, and camera angle."
     ollama_text_prompt: str = "Here is a still image description of {prefix}:\n\n{description}\n\nWrite a single concise paragraph describing how this scene continues as a 5-second video clip. The camera remains completely static — no pans, zooms, or angle changes. Only describe body movements, rhythm, position changes, and physical reactions. Use explicit adult terminology for positions and actions. Keep it under 100 words."


### PR DESCRIPTION
## Summary
- Reverts Ollama vision model from `user-v4/joycaption-beta:latest` (Q8_0, ~8GB) back to `huihui_ai/qwen2.5-vl-abliterated:7b` (Q4_K_M, ~6GB)
- joycaption-beta exceeds the 2070's 8GB VRAM, causing `GGML_ASSERT(buffer) failed` / `cudaMalloc: out of memory` on every prompt generation request

## Test plan
- [ ] Trigger prompt generation from console and verify Ollama responds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)