### PR TITLE
Add all Lora fields to PATCH endpoint

### DIFF
--- a/app/schemas/loras.py
+++ b/app/schemas/loras.py
@@ -23,6 +23,11 @@ class LoraUpdate(BaseModel):
     trigger_words: Optional[str] = None
     default_prompt: Optional[str] = None
     source_url: Optional[str] = None
+    preview_image: Optional[str] = None
+    high_file: Optional[str] = None
+    high_s3_uri: Optional[str] = None
+    low_file: Optional[str] = None
+    low_s3_uri: Optional[str] = None
     default_high_weight: Optional[float] = None
     default_low_weight: Optional[float] = None
 


### PR DESCRIPTION
## Summary
- Added `preview_image`, `high_file`, `high_s3_uri`, `low_file`, `low_s3_uri` to `LoraUpdate` schema
- These fields were missing, making it impossible to update file references via `PATCH /loras/{id}`

## Test plan
- [ ] PATCH a lora with `high_file` and `low_file` values
- [ ] Verify the response includes updated fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)