### PR TITLE
Add negative prompt to app settings

### DIFF
--- a/alembic/versions/017_seed_negative_prompt_setting.py
+++ b/alembic/versions/017_seed_negative_prompt_setting.py
@@ -1,0 +1,33 @@
+"""Seed negative_prompt app setting
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-03-13
+"""
+
+from alembic import op
+
+revision = "017"
+down_revision = "016"
+branch_labels = None
+depends_on = None
+
+_DEFAULT_NEGATIVE_PROMPT = (
+    "\u8272\u8c03\u8273\u4e3d\uff0c\u8fc7\u66dd\uff0c\u9759\u6001\uff0c\u7ec6\u8282\u6a21\u7cca\u4e0d\u6e05\uff0c\u5b57\u5e55\uff0c\u98ce\u683c\uff0c\u4f5c\u54c1\uff0c\u753b\u4f5c\uff0c"
+    "\u753b\u9762\uff0c\u9759\u6b62\uff0c\u6574\u4f53\u53d1\u7070\uff0c\u6700\u5dee\u8d28\u91cf\uff0c\u4f4e\u8d28\u91cf\uff0cJPEG\u538b\u7f29\u6b8b\u7559\uff0c"
+    "\u4e11\u964b\u7684\uff0c\u6b8b\u7f3a\u7684\uff0c\u591a\u4f59\u7684\u624b\u6307\uff0c\u753b\u5f97\u4e0d\u597d\u7684\u624b\u90e8\uff0c"
+    "\u753b\u5f97\u4e0d\u597d\u7684\u8138\u90e8\uff0c\u7578\u5f62\u7684\uff0c\u6bc1\u5bb9\u7684\uff0c\u5f62\u6001\u7578\u5f62\u7684\u80a2\u4f53\uff0c"
+    "\u624b\u6307\u878d\u5408\uff0c\u9759\u6b62\u4e0d\u52a8\u7684\u753b\u9762\uff0c\u6742\u4e71\u7684\u80cc\u666f\uff0c\u4e09\u6761\u817f\uff0c"
+    "\u80cc\u666f\u4eba\u5f88\u591a\uff0c\u5012\u7740\u8d70"
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        f"INSERT INTO app_settings (key, value) VALUES ('negative_prompt', '{_DEFAULT_NEGATIVE_PROMPT}') "
+        "ON CONFLICT (key) DO NOTHING"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM app_settings WHERE key = 'negative_prompt'")

--- a/app/routes/app_settings.py
+++ b/app/routes/app_settings.py
@@ -17,6 +17,7 @@ _DEFAULTS = {
     "cfg_low": "1",
     "lightx2v_strength_high": "2.0",
     "lightx2v_strength_low": "1.0",
+    "negative_prompt": "",
 }
 
 
@@ -32,6 +33,7 @@ def _to_response(settings: dict[str, str]) -> AppSettingsResponse:
         cfg_low=float(settings["cfg_low"]),
         lightx2v_strength_high=float(settings["lightx2v_strength_high"]),
         lightx2v_strength_low=float(settings["lightx2v_strength_low"]),
+        negative_prompt=settings["negative_prompt"],
     )
 
 

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import selectinload
 from app.auth import get_current_user, verify_api_key
 from app.database import get_db
 from app.enums import JobStatus, SegmentStatus, VideoStatus
-from app.models import Job, Lora, Segment, User, Video, Wildcard
+from app.models import AppSetting, Job, Lora, Segment, User, Video, Wildcard
 from app.s3 import delete_object
 from app.schemas.segments import SegmentClaimResponse, SegmentCreate, SegmentResponse, SegmentStatusUpdate, WorkerSegmentResponse
 from app.stitch import stitch_video
@@ -226,6 +226,10 @@ async def claim_next_segment(
             if prev_segment is not None:
                 resolved_start_image = prev_segment.last_frame_path
 
+    # Fetch negative_prompt from app settings
+    neg_setting = await db.get(AppSetting, "negative_prompt")
+    negative_prompt = neg_setting.value if neg_setting else None
+
     await db.commit()
     await db.refresh(segment)
 
@@ -249,6 +253,7 @@ async def claim_next_segment(
         lightx2v_strength_low=job.lightx2v_strength_low,
         cfg_high=job.cfg_high,
         cfg_low=job.cfg_low,
+        negative_prompt=negative_prompt,
         width=job.width,
         height=job.height,
         fps=job.fps,

--- a/app/schemas/app_settings.py
+++ b/app/schemas/app_settings.py
@@ -8,6 +8,7 @@ class AppSettingsResponse(BaseModel):
     cfg_low: float
     lightx2v_strength_high: float
     lightx2v_strength_low: float
+    negative_prompt: str
 
 
 class AppSettingsUpdate(BaseModel):
@@ -15,3 +16,4 @@ class AppSettingsUpdate(BaseModel):
     cfg_low: Optional[float] = None
     lightx2v_strength_high: Optional[float] = None
     lightx2v_strength_low: Optional[float] = None
+    negative_prompt: Optional[str] = None

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -85,6 +85,7 @@ class SegmentClaimResponse(BaseModel):
     lightx2v_strength_low: Optional[float] = None
     cfg_high: Optional[float] = None
     cfg_low: Optional[float] = None
+    negative_prompt: Optional[str] = None
     width: int
     height: int
     fps: int

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -1,0 +1,166 @@
+"""Tests for app settings: schemas, response conversion, and endpoint auth."""
+
+import pytest
+
+from app.schemas.app_settings import AppSettingsResponse, AppSettingsUpdate
+
+
+class TestAppSettingsSchemas:
+    """Validate the Pydantic schemas for settings."""
+
+    def test_response_includes_negative_prompt(self):
+        """AppSettingsResponse must include negative_prompt as a string."""
+        resp = AppSettingsResponse(
+            cfg_high=1.0,
+            cfg_low=1.0,
+            lightx2v_strength_high=2.0,
+            lightx2v_strength_low=1.0,
+            negative_prompt="bad quality, blurry",
+        )
+        assert resp.negative_prompt == "bad quality, blurry"
+
+    def test_response_requires_negative_prompt(self):
+        """AppSettingsResponse should fail without negative_prompt."""
+        with pytest.raises(Exception):
+            AppSettingsResponse(
+                cfg_high=1.0,
+                cfg_low=1.0,
+                lightx2v_strength_high=2.0,
+                lightx2v_strength_low=1.0,
+            )
+
+    def test_update_negative_prompt_optional(self):
+        """AppSettingsUpdate allows negative_prompt to be omitted."""
+        update = AppSettingsUpdate()
+        assert update.negative_prompt is None
+
+    def test_update_with_negative_prompt(self):
+        """AppSettingsUpdate accepts a negative_prompt string."""
+        update = AppSettingsUpdate(negative_prompt="ugly, deformed")
+        assert update.negative_prompt == "ugly, deformed"
+
+    def test_update_negative_prompt_excluded_when_none(self):
+        """exclude_none should drop negative_prompt when not set."""
+        update = AppSettingsUpdate(cfg_high=1.5)
+        dumped = update.model_dump(exclude_none=True)
+        assert "negative_prompt" not in dumped
+        assert dumped["cfg_high"] == 1.5
+
+    def test_update_negative_prompt_included_when_set(self):
+        """exclude_none should keep negative_prompt when explicitly set."""
+        update = AppSettingsUpdate(negative_prompt="blurry")
+        dumped = update.model_dump(exclude_none=True)
+        assert dumped["negative_prompt"] == "blurry"
+
+    def test_update_empty_string_is_not_none(self):
+        """An empty string negative_prompt should be preserved (not treated as None)."""
+        update = AppSettingsUpdate(negative_prompt="")
+        dumped = update.model_dump(exclude_none=True)
+        assert "negative_prompt" in dumped
+        assert dumped["negative_prompt"] == ""
+
+
+class TestToResponse:
+    """Test the _to_response helper in the settings route."""
+
+    def test_to_response_includes_negative_prompt(self):
+        from app.routes.app_settings import _to_response
+
+        settings = {
+            "cfg_high": "1.5",
+            "cfg_low": "1.0",
+            "lightx2v_strength_high": "2.0",
+            "lightx2v_strength_low": "1.0",
+            "negative_prompt": "ugly, blurry",
+        }
+        resp = _to_response(settings)
+        assert resp.negative_prompt == "ugly, blurry"
+        assert resp.cfg_high == 1.5
+
+    def test_to_response_empty_negative_prompt(self):
+        from app.routes.app_settings import _to_response
+
+        settings = {
+            "cfg_high": "1",
+            "cfg_low": "1",
+            "lightx2v_strength_high": "2.0",
+            "lightx2v_strength_low": "1.0",
+            "negative_prompt": "",
+        }
+        resp = _to_response(settings)
+        assert resp.negative_prompt == ""
+
+
+class TestDefaultsIncludeNegativePrompt:
+    """Verify the _DEFAULTS dict has the negative_prompt key."""
+
+    def test_defaults_has_negative_prompt(self):
+        from app.routes.app_settings import _DEFAULTS
+
+        assert "negative_prompt" in _DEFAULTS
+
+
+class TestSettingsEndpointAuth:
+    """Verify settings endpoints require authentication."""
+
+    @pytest.mark.asyncio
+    async def test_get_settings_without_auth_returns_401(self):
+        from httpx import ASGITransport, AsyncClient
+        from app.main import app
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/settings")
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_put_settings_without_auth_returns_401(self):
+        from httpx import ASGITransport, AsyncClient
+        from app.main import app
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.put("/settings", json={"negative_prompt": "test"})
+        assert resp.status_code == 401
+
+
+class TestSegmentClaimResponseSchema:
+    """Verify SegmentClaimResponse includes negative_prompt."""
+
+    def _make_claim_kwargs(self, **overrides):
+        from uuid import uuid4
+
+        defaults = dict(
+            id=uuid4(),
+            job_id=uuid4(),
+            index=0,
+            prompt="test prompt",
+            duration_seconds=5.0,
+            speed=1.0,
+            start_image=None,
+            loras=None,
+            faceswap_enabled=False,
+            faceswap_method=None,
+            faceswap_source_type=None,
+            faceswap_image=None,
+            faceswap_faces_order=None,
+            faceswap_faces_index=None,
+            width=832,
+            height=480,
+            fps=30,
+            seed=42,
+        )
+        defaults.update(overrides)
+        return defaults
+
+    def test_segment_claim_response_has_negative_prompt(self):
+        from app.schemas.segments import SegmentClaimResponse
+
+        resp = SegmentClaimResponse(**self._make_claim_kwargs(negative_prompt="ugly, blurry"))
+        assert resp.negative_prompt == "ugly, blurry"
+
+    def test_segment_claim_response_negative_prompt_optional(self):
+        from app.schemas.segments import SegmentClaimResponse
+
+        resp = SegmentClaimResponse(**self._make_claim_kwargs())
+        assert resp.negative_prompt is None


### PR DESCRIPTION
## Summary
- Migration 017 seeds `negative_prompt` in `app_settings` with the current hardcoded Chinese negative prompt
- `GET/PUT /settings` now includes `negative_prompt` (string field)
- Segment claim response passes `negative_prompt` from `app_settings` to daemon
- 14 unit tests covering schemas, response conversion, defaults, endpoint auth, and claim response

## Test plan
- [ ] Run migration 017
- [ ] `GET /settings` returns `negative_prompt` field
- [ ] `PUT /settings` with `negative_prompt` persists the value
- [ ] Daemon segment claim includes `negative_prompt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)