### PR TITLE
Add segment end-transition support (fade through black)

### DIFF
--- a/alembic/versions/018_add_segment_transition.py
+++ b/alembic/versions/018_add_segment_transition.py
@@ -1,0 +1,22 @@
+"""Add transition column to segments
+
+Revision ID: 018
+Revises: 017
+Create Date: 2026-03-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "018"
+down_revision = "017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("transition", sa.String(20), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "transition")

--- a/app/models.py
+++ b/app/models.py
@@ -78,6 +78,7 @@ class Segment(Base):
     faceswap_faces_order = mapped_column(Text, nullable=True)
     faceswap_faces_index = mapped_column(Text, nullable=True)
     auto_finalize = mapped_column(Boolean, nullable=False, default=False)
+    transition = mapped_column(String(20), nullable=True, default=None)
     status = mapped_column(String(20), nullable=False, default=SegmentStatus.PENDING)
     worker_id = mapped_column(UUID(as_uuid=True), nullable=True)
     worker_name = mapped_column(String(255), nullable=True)

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -18,6 +18,7 @@ class SegmentCreate(BaseModel):
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
     auto_finalize: bool = False
+    transition: Optional[str] = None
 
 
 class SegmentResponse(BaseModel):
@@ -37,6 +38,7 @@ class SegmentResponse(BaseModel):
     faceswap_faces_order: Optional[str]
     faceswap_faces_index: Optional[str]
     auto_finalize: bool
+    transition: Optional[str]
     status: str
     worker_id: Optional[UUID]
     worker_name: Optional[str]

--- a/app/stitch.py
+++ b/app/stitch.py
@@ -16,6 +16,50 @@ from app.s3 import download_file, upload_file
 
 logger = logging.getLogger(__name__)
 
+FADE_DURATION = 1.0
+
+
+def _apply_fades(input_path: str, output_path: str, duration: float,
+                 fade_in: bool, fade_out: bool) -> None:
+    """Re-encode a segment with fade-in and/or fade-out filters."""
+    vfilters = []
+    if fade_in:
+        vfilters.append(f"fade=t=in:st=0:d={FADE_DURATION}")
+    if fade_out:
+        fade_start = max(duration - FADE_DURATION, 0)
+        vfilters.append(f"fade=t=out:st={fade_start}:d={FADE_DURATION}")
+
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", input_path,
+        "-vf", ",".join(vfilters),
+        "-c:v", "libx264", "-preset", "fast", "-crf", "18",
+        "-c:a", "aac",
+        output_path,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, timeout=300)
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffmpeg fade failed: {proc.stderr.decode()[-500:]}")
+
+
+def _compute_fades(segments: list) -> list[tuple[bool, bool]]:
+    """Return (fade_in, fade_out) for each segment based on transition settings.
+
+    A segment's transition controls what happens *after* it (fade-out on itself,
+    fade-in on the next segment). The last segment's transition is ignored.
+    """
+    n = len(segments)
+    result = [(False, False)] * n
+    for i in range(n):
+        fade_in = False
+        fade_out = False
+        if i > 0 and segments[i - 1].transition == "fade":
+            fade_in = True
+        if i < n - 1 and segments[i].transition == "fade":
+            fade_out = True
+        result[i] = (fade_in, fade_out)
+    return result
+
 
 async def stitch_video(video_id: UUID, job_id: UUID) -> None:
     """Background task: download segment videos, concat with ffmpeg, upload result."""
@@ -56,10 +100,29 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                     await asyncio.to_thread(download_file, seg.output_path, str(local_path))
                     local_files.append(local_name)
 
+                # Apply fade transitions where needed
+                needs_fade = _compute_fades(segments)
+                concat_names = []
+                for i, (seg, local_name) in enumerate(zip(segments, local_files)):
+                    fade_in, fade_out = needs_fade[i]
+                    if fade_in or fade_out:
+                        faded_name = f"seg_{seg.index:03d}_faded.mp4"
+                        await asyncio.to_thread(
+                            _apply_fades,
+                            str(tmppath / local_name),
+                            str(tmppath / faded_name),
+                            seg.duration_seconds,
+                            fade_in,
+                            fade_out,
+                        )
+                        concat_names.append(faded_name)
+                    else:
+                        concat_names.append(local_name)
+
                 # Write ffmpeg concat list
                 concat_list = tmppath / "concat.txt"
                 concat_list.write_text(
-                    "\n".join(f"file '{name}'" for name in local_files)
+                    "\n".join(f"file '{name}'" for name in concat_names)
                 )
 
                 # Run ffmpeg concat (no re-encoding)


### PR DESCRIPTION
## Summary
- Add `transition` column to segments table (nullable, values: `null`/`"fade"`)
- Add Alembic migration 018
- Add `transition` field to `SegmentCreate` and `SegmentResponse` schemas
- Implement fade-in/fade-out processing in stitch pipeline — segments with `transition="fade"` get re-encoded with ffmpeg fade filters before concat; segments without transitions skip re-encoding

## Test plan
- [ ] Run migration on dev DB
- [ ] Create job with 2+ segments, set `transition="fade"` on segment 1
- [ ] Finalize — confirm fade-out on seg 1 and fade-in on seg 2
- [ ] Create job with no transitions — confirm fast `-c copy` concat (no re-encoding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)