### PR TITLE
Segment transitions + trim with frame preview

### DIFF
--- a/alembic/versions/019_add_segment_trim_fields.py
+++ b/alembic/versions/019_add_segment_trim_fields.py
@@ -1,0 +1,24 @@
+"""Add trim_start_frames and trim_end_frames to segments
+
+Revision ID: 019
+Revises: 018
+Create Date: 2026-03-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "019"
+down_revision = "018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("trim_start_frames", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("segments", sa.Column("trim_end_frames", sa.Integer(), nullable=False, server_default="0"))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "trim_end_frames")
+    op.drop_column("segments", "trim_start_frames")

--- a/app/models.py
+++ b/app/models.py
@@ -79,6 +79,8 @@ class Segment(Base):
     faceswap_faces_index = mapped_column(Text, nullable=True)
     auto_finalize = mapped_column(Boolean, nullable=False, default=False)
     transition = mapped_column(String(20), nullable=True, default=None)
+    trim_start_frames = mapped_column(Integer, nullable=False, default=0)
+    trim_end_frames = mapped_column(Integer, nullable=False, default=0)
     status = mapped_column(String(20), nullable=False, default=SegmentStatus.PENDING)
     worker_id = mapped_column(UUID(as_uuid=True), nullable=True)
     worker_name = mapped_column(String(255), nullable=True)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -1,8 +1,13 @@
 import asyncio
+import base64
+import json
 import logging
 import random
 import re
+import subprocess
+import tempfile
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
@@ -14,8 +19,17 @@ from app.auth import get_current_user, verify_api_key
 from app.database import get_db
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.models import AppSetting, Job, Lora, Segment, User, Video, Wildcard
-from app.s3 import delete_object
-from app.schemas.segments import SegmentClaimResponse, SegmentCreate, SegmentResponse, SegmentStatusUpdate, WorkerSegmentResponse
+from app.s3 import delete_object, download_file
+from app.schemas.segments import (
+    FramePreview,
+    FramePreviewResponse,
+    SegmentClaimResponse,
+    SegmentCreate,
+    SegmentResponse,
+    SegmentStatusUpdate,
+    SegmentTrimUpdate,
+    WorkerSegmentResponse,
+)
 from app.stitch import stitch_video
 
 logger = logging.getLogger(__name__)
@@ -338,6 +352,118 @@ async def update_segment_transition(
     await db.commit()
     await db.refresh(segment)
     return segment
+
+
+@router.patch("/segments/{segment_id}/trim", response_model=SegmentResponse)
+async def update_segment_trim(
+    segment_id: UUID,
+    body: SegmentTrimUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Segment)
+        .join(Job, Segment.job_id == Job.id)
+        .where(Segment.id == segment_id, Job.user_id == user.id)
+    )
+    segment = result.scalar_one_or_none()
+    if segment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Segment not found")
+
+    job = await db.get(Job, segment.job_id)
+    total_frames = int(segment.duration_seconds * job.fps)
+    if body.trim_start_frames + body.trim_end_frames >= total_frames:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Trim exceeds total frames ({total_frames})",
+        )
+
+    segment.trim_start_frames = body.trim_start_frames
+    segment.trim_end_frames = body.trim_end_frames
+    await db.commit()
+    await db.refresh(segment)
+    return segment
+
+
+@router.get("/segments/{segment_id}/frames", response_model=FramePreviewResponse)
+async def get_segment_frames(
+    segment_id: UUID,
+    position: str = Query(..., pattern="^(start|end)$"),
+    count: int = Query(5, ge=1, le=20),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Segment)
+        .join(Job, Segment.job_id == Job.id)
+        .where(Segment.id == segment_id, Job.user_id == user.id)
+    )
+    segment = result.scalar_one_or_none()
+    if segment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Segment not found")
+    if not segment.output_path:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Segment has no output video")
+
+    job = await db.get(Job, segment.job_id)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmppath = Path(tmpdir)
+        video_path = tmppath / "segment.mp4"
+        await asyncio.to_thread(download_file, segment.output_path, str(video_path))
+
+        # Get total frame count via ffprobe
+        probe_cmd = [
+            "ffprobe", "-v", "error",
+            "-select_streams", "v:0",
+            "-count_frames",
+            "-show_entries", "stream=nb_read_frames,r_frame_rate",
+            "-of", "json",
+            str(video_path),
+        ]
+        probe = await asyncio.to_thread(subprocess.run, probe_cmd, capture_output=True, timeout=60)
+        if probe.returncode != 0:
+            raise HTTPException(status_code=500, detail="ffprobe failed")
+        probe_data = json.loads(probe.stdout)
+        stream = probe_data["streams"][0]
+        total_frames = int(stream["nb_read_frames"])
+        r_rate = stream["r_frame_rate"]
+        num, den = r_rate.split("/")
+        fps = float(num) / float(den)
+
+        # Determine frame range
+        count = min(count, total_frames)
+        if position == "start":
+            start_frame = 0
+            end_frame = count - 1
+        else:
+            start_frame = max(total_frames - count, 0)
+            end_frame = total_frames - 1
+
+        # Extract frames
+        extract_cmd = [
+            "ffmpeg", "-y",
+            "-i", str(video_path),
+            "-vf", f"select='between(n\\,{start_frame}\\,{end_frame})',scale=320:-1",
+            "-vsync", "vfr",
+            str(tmppath / "frame_%03d.jpg"),
+        ]
+        extract = await asyncio.to_thread(subprocess.run, extract_cmd, capture_output=True, timeout=60)
+        if extract.returncode != 0:
+            raise HTTPException(status_code=500, detail="ffmpeg frame extraction failed")
+
+        # Build response
+        frames = []
+        for i in range(count):
+            frame_path = tmppath / f"frame_{i+1:03d}.jpg"
+            if not frame_path.exists():
+                break
+            b64 = base64.b64encode(frame_path.read_bytes()).decode()
+            frames.append(FramePreview(
+                frame_index=start_frame + i,
+                data_url=f"data:image/jpeg;base64,{b64}",
+            ))
+
+        return FramePreviewResponse(total_frames=total_frames, fps=fps, frames=frames)
 
 
 @router.post("/segments/{segment_id}/retry", response_model=SegmentResponse)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -331,7 +331,7 @@ async def update_segment_transition(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Segment not found")
 
     transition = body.get("transition")
-    if transition is not None and transition not in ("fade",):
+    if transition is not None and transition not in ("fade", "flash"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid transition: {transition}")
 
     segment.transition = transition

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class SegmentCreate(BaseModel):
@@ -39,6 +39,8 @@ class SegmentResponse(BaseModel):
     faceswap_faces_index: Optional[str]
     auto_finalize: bool
     transition: Optional[str]
+    trim_start_frames: int
+    trim_end_frames: int
     status: str
     worker_id: Optional[UUID]
     worker_name: Optional[str]
@@ -94,6 +96,22 @@ class SegmentClaimResponse(BaseModel):
     seed: int
 
     model_config = {"from_attributes": True}
+
+
+class SegmentTrimUpdate(BaseModel):
+    trim_start_frames: int = Field(ge=0)
+    trim_end_frames: int = Field(ge=0)
+
+
+class FramePreview(BaseModel):
+    frame_index: int
+    data_url: str
+
+
+class FramePreviewResponse(BaseModel):
+    total_frames: int
+    fps: float
+    frames: list[FramePreview]
 
 
 class SegmentStatusUpdate(BaseModel):

--- a/app/stitch.py
+++ b/app/stitch.py
@@ -57,11 +57,45 @@ def _generate_black(output_path: str, duration: float, width: int, height: int, 
         raise RuntimeError(f"ffmpeg black gen failed: {proc.stderr.decode()[-500:]}")
 
 
+def _apply_trim(input_path: str, output_path: str, fps: int,
+                 trim_start_frames: int, trim_end_frames: int) -> float:
+    """Re-encode a segment with frames trimmed from start/end. Returns new duration."""
+    # Get actual duration via ffprobe
+    probe = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "default=noprint_wrappers=1:nokey=1", input_path],
+        capture_output=True, timeout=60,
+    )
+    if probe.returncode != 0:
+        raise RuntimeError(f"ffprobe failed: {probe.stderr.decode()[-500:]}")
+    actual_duration = float(probe.stdout.decode().strip())
+
+    start_time = trim_start_frames / fps
+    end_trim_time = trim_end_frames / fps
+    new_duration = actual_duration - start_time - end_trim_time
+    if new_duration <= 0:
+        raise ValueError(f"Trim removes entire video: start={start_time}s end_trim={end_trim_time}s duration={actual_duration}s")
+
+    cmd = [
+        "ffmpeg", "-y",
+        "-ss", str(start_time),
+        "-i", input_path,
+        "-t", str(new_duration),
+        "-c:v", "libx264", "-preset", "fast", "-crf", "18",
+        "-c:a", "aac",
+        output_path,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, timeout=300)
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffmpeg trim failed: {proc.stderr.decode()[-500:]}")
+    return new_duration
+
+
 def _compute_fades(segments: list) -> list[tuple[bool, bool]]:
     """Return (fade_in, fade_out) for each segment based on transition settings.
 
     A segment's transition controls what happens *after* it (fade-out on itself,
-    fade-in on the next segment). The last segment's transition is ignored.
+    fade-in on the next segment). The last segment can also fade out (fade to black).
     """
     n = len(segments)
     result = [(False, False)] * n
@@ -70,7 +104,7 @@ def _compute_fades(segments: list) -> list[tuple[bool, bool]]:
         fade_out = False
         if i > 0 and segments[i - 1].transition == "fade":
             fade_in = True
-        if i < n - 1 and segments[i].transition == "fade":
+        if segments[i].transition == "fade":
             fade_out = True
         result[i] = (fade_in, fade_out)
     return result
@@ -115,6 +149,22 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                     await asyncio.to_thread(download_file, seg.output_path, str(local_path))
                     local_files.append(local_name)
 
+                # Trim pass: apply trim to segments with non-zero trim values
+                durations = [seg.duration_seconds for seg in segments]
+                for i, seg in enumerate(segments):
+                    if seg.trim_start_frames > 0 or seg.trim_end_frames > 0:
+                        trimmed_name = f"seg_{seg.index:03d}_trimmed.mp4"
+                        new_dur = await asyncio.to_thread(
+                            _apply_trim,
+                            str(tmppath / local_files[i]),
+                            str(tmppath / trimmed_name),
+                            job.fps,
+                            seg.trim_start_frames,
+                            seg.trim_end_frames,
+                        )
+                        local_files[i] = trimmed_name
+                        durations[i] = new_dur
+
                 # Apply transitions
                 needs_fade = _compute_fades(segments)
                 concat_names = []
@@ -126,7 +176,7 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                             _apply_fades,
                             str(tmppath / local_name),
                             str(tmppath / faded_name),
-                            seg.duration_seconds,
+                            durations[i],
                             fade_in,
                             fade_out,
                         )
@@ -135,7 +185,7 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                         concat_names.append(local_name)
 
                     # Insert black clip for "flash" transition
-                    if i < len(segments) - 1 and seg.transition == "flash":
+                    if seg.transition == "flash":
                         black_name = f"black_{seg.index:03d}.mp4"
                         await asyncio.to_thread(
                             _generate_black,
@@ -178,7 +228,7 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                 )
 
             # Update video record
-            total_duration = sum(s.duration_seconds for s in segments)
+            total_duration = sum(durations)
             video.output_path = s3_uri
             video.duration_seconds = total_duration
             video.status = VideoStatus.COMPLETED

--- a/app/stitch.py
+++ b/app/stitch.py
@@ -17,6 +17,7 @@ from app.s3 import download_file, upload_file
 logger = logging.getLogger(__name__)
 
 FADE_DURATION = 1.0
+FLASH_DURATION = 1.0
 
 
 def _apply_fades(input_path: str, output_path: str, duration: float,
@@ -40,6 +41,20 @@ def _apply_fades(input_path: str, output_path: str, duration: float,
     proc = subprocess.run(cmd, capture_output=True, timeout=300)
     if proc.returncode != 0:
         raise RuntimeError(f"ffmpeg fade failed: {proc.stderr.decode()[-500:]}")
+
+
+def _generate_black(output_path: str, duration: float, width: int, height: int, fps: int) -> None:
+    """Generate a short black video clip."""
+    cmd = [
+        "ffmpeg", "-y",
+        "-f", "lavfi", "-i", f"color=c=black:s={width}x{height}:d={duration}:r={fps}",
+        "-c:v", "libx264", "-preset", "fast", "-crf", "18",
+        "-an",
+        output_path,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, timeout=60)
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffmpeg black gen failed: {proc.stderr.decode()[-500:]}")
 
 
 def _compute_fades(segments: list) -> list[tuple[bool, bool]]:
@@ -100,7 +115,7 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                     await asyncio.to_thread(download_file, seg.output_path, str(local_path))
                     local_files.append(local_name)
 
-                # Apply fade transitions where needed
+                # Apply transitions
                 needs_fade = _compute_fades(segments)
                 concat_names = []
                 for i, (seg, local_name) in enumerate(zip(segments, local_files)):
@@ -118,6 +133,19 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                         concat_names.append(faded_name)
                     else:
                         concat_names.append(local_name)
+
+                    # Insert black clip for "flash" transition
+                    if i < len(segments) - 1 and seg.transition == "flash":
+                        black_name = f"black_{seg.index:03d}.mp4"
+                        await asyncio.to_thread(
+                            _generate_black,
+                            str(tmppath / black_name),
+                            FLASH_DURATION,
+                            job.width,
+                            job.height,
+                            job.fps,
+                        )
+                        concat_names.append(black_name)
 
                 # Write ffmpeg concat list
                 concat_list = tmppath / "concat.txt"


### PR DESCRIPTION
## Summary
- Segment transition support (fade/flash between segments)
- `trim_start_frames` and `trim_end_frames` columns on segments (migration 019)
- `PATCH /segments/{id}/trim` endpoint with validation (trim < total frames)
- `GET /segments/{id}/frames` endpoint extracts frame thumbnails via ffmpeg as base64 data URLs
- Trim pass in stitch pipeline: applies before transitions, uses trimmed durations for fades
- Last segment can now have fade-out/flash transition (fade to black at end of video)

## Test plan
- [ ] Run migration 019, verify trim columns exist with default 0
- [ ] `PATCH /segments/{id}/trim` — set values, verify persist and returned in job detail
- [ ] Validate trim exceeding frame count returns 400
- [ ] `GET /segments/{id}/frames?position=start&count=5` — verify base64 thumbnails returned
- [ ] Stitch with trim + fade on same segment
- [ ] Last segment fade-out produces video that fades to black

🤖 Generated with [Claude Code](https://claude.com/claude-code)