### PR TITLE
Add image move between folders

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -12,6 +12,7 @@ from app.s3 import (
     get_first_object_key,
     list_common_prefixes,
     list_objects,
+    move_object,
     upload_bytes,
 )
 
@@ -98,6 +99,27 @@ async def list_folder_images(date: str):
         for obj in objects
         if not obj["Key"].endswith("/.folder")
     ]
+
+
+@router.post("/images/move", dependencies=[Depends(get_current_user)])
+async def move_images(body: dict):
+    """Move one or more images to a target folder (S3 copy + delete)."""
+    keys: list[str] = body.get("keys", [])
+    target_folder: str = body.get("target_folder", "").strip()
+    if not keys:
+        raise HTTPException(status_code=400, detail="No keys provided")
+    if not target_folder:
+        raise HTTPException(status_code=400, detail="target_folder is required")
+    bucket = settings.s3_images_bucket
+
+    async def _move_one(src_key: str) -> str:
+        filename = src_key.split("/", 1)[1] if "/" in src_key else src_key
+        dst_key = f"{target_folder}/{filename}"
+        await asyncio.to_thread(move_object, bucket, src_key, dst_key)
+        return dst_key
+
+    moved = await asyncio.gather(*[_move_one(k) for k in keys])
+    return {"moved": len(moved)}
 
 
 @router.delete("/images", dependencies=[Depends(get_current_user)])

--- a/app/s3.py
+++ b/app/s3.py
@@ -124,6 +124,18 @@ def get_first_object_key(bucket: str, prefix: str) -> str | None:
     return None
 
 
+def move_object(bucket: str, src_key: str, dst_key: str) -> None:
+    """Copy an object within the same bucket then delete the original."""
+    client = _get_client()
+    client.copy_object(
+        Bucket=bucket,
+        CopySource={"Bucket": bucket, "Key": src_key},
+        Key=dst_key,
+    )
+    client.delete_object(Bucket=bucket, Key=src_key)
+    logger.info("Moved %s/%s → %s/%s", bucket, src_key, bucket, dst_key)
+
+
 def parse_s3_uri(uri: str) -> tuple[str, str]:
     """Parse s3://bucket/key into (bucket, key)."""
     parts = uri.replace("s3://", "").split("/", 1)


### PR DESCRIPTION
## Summary
- `POST /images/move` — accepts `keys[]` and `target_folder`, moves images between S3 prefixes (copy + delete)
- New `s3.move_object()` helper for same-bucket copy + delete
- Supports bulk and single image moves

## Test plan
- [ ] Move single image via API, verify it appears in target folder and is gone from source
- [ ] Move multiple images in one request
- [ ] Verify error on empty keys or missing target_folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)