### PR TITLE
Fix segment delete losing S3 files after re-indexing

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -19,7 +19,7 @@ from app.auth import get_current_user, verify_api_key
 from app.database import get_db
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.models import AppSetting, Job, Lora, Segment, User, Video, Wildcard
-from app.s3 import delete_object, download_file
+from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
     FramePreview,
     FramePreviewResponse,
@@ -602,11 +602,30 @@ async def delete_segment(
         select(Segment).where(Segment.job_id == job.id).order_by(Segment.index)
     )
     remaining = remaining_result.scalars().all()
+    old_indices = {seg.id: seg.index for seg in remaining}
     for i, seg in enumerate(remaining):
         seg.index = -(i + 1)
     await db.flush()
     for i, seg in enumerate(remaining):
         seg.index = i
+
+    # Rename S3 files for segments whose index changed
+    for seg in remaining:
+        old_idx = old_indices[seg.id]
+        if old_idx == seg.index:
+            continue
+        for attr in ("output_path", "last_frame_path"):
+            old_path = getattr(seg, attr)
+            if not old_path:
+                continue
+            try:
+                bucket, old_key = parse_s3_uri(old_path)
+                new_key = old_key.replace(f"/{old_idx}_", f"/{seg.index}_", 1)
+                if new_key != old_key:
+                    await asyncio.to_thread(move_object, bucket, old_key, new_key)
+                    setattr(seg, attr, f"s3://{bucket}/{new_key}")
+            except Exception:
+                logger.warning("Failed to rename S3 object for segment %s: %s", seg.id, old_path)
 
     # Update job status if needed
     has_failed = await db.execute(


### PR DESCRIPTION
## Summary
- When a segment is deleted, remaining segments are re-indexed to close the gap
- Previously, S3 file paths (`output_path`, `last_frame_path`) were not updated to match new indices
- This caused 404 errors when the console tried to load the stale paths
- Now renames S3 objects (copy + delete) and updates DB paths for any segment whose index changed

## Test plan
- [ ] Create job with 3+ completed segments
- [ ] Delete a middle segment (e.g. segment 1 of 0-2)
- [ ] Verify remaining segments' videos and last frames still load correctly
- [ ] Verify S3 keys match the new indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)