### PR TITLE
Fix logout when viewing worker detail page

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -21,6 +21,29 @@ async def verify_api_key(key: str = Depends(api_key_header)):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
 
+async def verify_api_key_or_bearer(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Accept either X-API-Key header (daemon) or Authorization Bearer JWT (console)."""
+    api_key = request.headers.get("x-api-key")
+    if api_key:
+        if settings.api_key and api_key == settings.api_key:
+            return
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        user_id = decode_access_token(token)
+        result = await db.execute(select(User).where(User.id == user_id))
+        if result.scalar_one_or_none() is not None:
+            return
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+
 async def verify_api_key_or_token(
     request: Request,
     db: AsyncSession = Depends(get_db),

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -15,7 +15,7 @@ from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.auth import get_current_user, verify_api_key
+from app.auth import get_current_user, verify_api_key, verify_api_key_or_bearer
 from app.database import get_db
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.models import AppSetting, Job, Lora, Segment, User, Video, Wildcard
@@ -99,7 +99,7 @@ async def _resolve_wildcards(db: AsyncSession, prompt: str) -> tuple[str, str | 
     return resolved, template
 
 
-@router.get("/segments", response_model=list[WorkerSegmentResponse], dependencies=[Depends(verify_api_key)])
+@router.get("/segments", response_model=list[WorkerSegmentResponse], dependencies=[Depends(verify_api_key_or_bearer)])
 async def list_segments(
     worker_id: UUID = Query(...),
     limit: int = Query(50, ge=1, le=200),


### PR DESCRIPTION
## Summary
- Add `verify_api_key_or_bearer` auth dependency that accepts either X-API-Key (daemon) or Bearer JWT (console)
- Use it on `GET /segments` so the console can fetch worker history without getting 401
- The 401 was triggering the console's axios interceptor which cleared the token and redirected to login

## Test plan
- [ ] Click a worker card in the console — should navigate to detail page without logging out
- [ ] Verify worker work history loads correctly
- [ ] Verify daemon can still call `GET /segments` with X-API-Key

🤖 Generated with [Claude Code](https://claude.com/claude-code)