### PR TITLE
fix: use last_frame_path instead of output_path for reference frames

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -246,8 +246,8 @@ async def claim_next_segment(
                 previous_motion_keywords = prev_segment.motion_keywords
                 if prev_segment.reference_frames:
                     reference_frames = prev_segment.reference_frames.copy()
-                if prev_segment.output_path and prev_segment.output_path not in reference_frames:
-                    reference_frames.append(prev_segment.output_path)
+                if prev_segment.last_frame_path and prev_segment.last_frame_path not in reference_frames:
+                    reference_frames.append(prev_segment.last_frame_path)
                     reference_frames = reference_frames[-3:]
 
     # Fetch negative_prompt from app settings


### PR DESCRIPTION
## Summary

- Fixes RuntimeError when processing reference frames by using the extracted last frame image instead of the video file path
- The daemon expects images for CLIP Vision processing, but was receiving video paths from output_path