### PR TITLE
feat: Add motion_magnitude field to Segment model and API

### DIFF
--- a/alembic/versions/021_add_segment_motion_magnitude.py
+++ b/alembic/versions/021_add_segment_motion_magnitude.py
@@ -1,0 +1,22 @@
+"""Add motion_magnitude to segments
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-04-06
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "021"
+down_revision = "020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("motion_magnitude", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "motion_magnitude")

--- a/app/models.py
+++ b/app/models.py
@@ -82,6 +82,7 @@ class Segment(Base):
     trim_start_frames = mapped_column(Integer, nullable=False, default=0)
     trim_end_frames = mapped_column(Integer, nullable=False, default=0)
     motion_keywords = mapped_column(JSON, nullable=True)
+    motion_magnitude = mapped_column(Float, nullable=True)
     reference_frames = mapped_column(JSON, nullable=True)
     status = mapped_column(String(20), nullable=False, default=SegmentStatus.PENDING)
     worker_id = mapped_column(UUID(as_uuid=True), nullable=True)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -230,6 +230,7 @@ async def claim_next_segment(
     resolved_start_image = segment.start_image
     previous_segment = None
     previous_motion_keywords = None
+    previous_motion_magnitude = None
     reference_frames = []
     if resolved_start_image is None:
         if segment.index == 0:
@@ -244,6 +245,7 @@ async def claim_next_segment(
                 resolved_start_image = prev_segment.last_frame_path
                 previous_segment = prev_segment
                 previous_motion_keywords = prev_segment.motion_keywords
+                previous_motion_magnitude = prev_segment.motion_magnitude
                 if prev_segment.reference_frames:
                     reference_frames = prev_segment.reference_frames.copy()
                 if prev_segment.last_frame_path and prev_segment.last_frame_path not in reference_frames:
@@ -275,6 +277,7 @@ async def claim_next_segment(
         initial_reference_image=job.starting_image,
         motion_keywords=segment.motion_keywords,
         previous_motion_keywords=previous_motion_keywords,
+        previous_motion_magnitude=previous_motion_magnitude,
         reference_frames=reference_frames if reference_frames else None,
         lightx2v_strength_high=job.lightx2v_strength_high,
         lightx2v_strength_low=job.lightx2v_strength_low,
@@ -313,6 +316,8 @@ async def update_segment(
         segment.progress_log = body.progress_log
     if body.motion_keywords is not None:
         segment.motion_keywords = body.motion_keywords
+    if body.motion_magnitude is not None:
+        segment.motion_magnitude = body.motion_magnitude
 
     await db.flush()
 

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -42,6 +42,7 @@ class SegmentResponse(BaseModel):
     trim_start_frames: int
     trim_end_frames: int
     motion_keywords: Optional[list[str]] = None
+    motion_magnitude: Optional[float] = None
     reference_frames: Optional[list[str]] = None
     status: str
     worker_id: Optional[UUID]
@@ -88,7 +89,9 @@ class SegmentClaimResponse(BaseModel):
     faceswap_faces_index: Optional[str]
     initial_reference_image: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
+    motion_magnitude: Optional[float] = None
     previous_motion_keywords: Optional[list[str]] = None
+    previous_motion_magnitude: Optional[float] = None
     reference_frames: Optional[list[str]] = None
     lightx2v_strength_high: Optional[float] = None
     lightx2v_strength_low: Optional[float] = None
@@ -126,3 +129,5 @@ class SegmentStatusUpdate(BaseModel):
     error_message: Optional[str] = None
     progress_log: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
+    motion_magnitude: Optional[float] = None
+    motion_magnitude: Optional[float] = None


### PR DESCRIPTION
## Summary
- Add motion_magnitude Float column to Segment model
- Add motion_magnitude to SegmentResponse and SegmentStatusUpdate schemas
- Add previous_motion_magnitude to SegmentClaimResponse for segment continuity
- Store motion_magnitude when segment completes
- Add migration 021 for motion_magnitude column