### PR TITLE
fix: Use bearer auth for image upload endpoint

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 
-from app.auth import get_current_user, verify_api_key_or_token
+from app.auth import get_current_user, verify_api_key_or_bearer
 from app.config import settings
 from app.s3 import (
     delete_object,
@@ -21,7 +21,7 @@ router = APIRouter(tags=["images"])
 _FOLDER_NAME_RE = re.compile(r"^[a-zA-Z0-9 _-]+$")
 
 
-@router.post("/images/upload", dependencies=[Depends(verify_api_key_or_token)])
+@router.post("/images/upload", dependencies=[Depends(verify_api_key_or_bearer)])
 async def upload_image(
     file: UploadFile,
     filename: str | None = None,


### PR DESCRIPTION
## Summary
- `/images/upload` was guarded by `verify_api_key_or_token`, which only accepts `X-API-Key` header or `?token=` query param
- The console sends auth as `Authorization: Bearer <jwt>`, so every upload returned 401 and the response interceptor wiped the token and redirected to `/login`
- Switch to `verify_api_key_or_bearer` to match `/jobs`, `/loras/upload`, etc.

The `_or_token` variant exists specifically for `<img>`/`<video>` media loads that can't set custom headers (see `getFileUrl`) — it's the wrong fit for an authenticated POST from the SPA.

## Test plan
- [ ] Upload an image to an existing folder from the console on mobile — upload succeeds, no redirect to login
- [ ] Upload an image from desktop — still works
- [ ] Media loads (`<img>` via `getFileUrl`) with `?token=` still work