### PR TITLE
fix: Cache headers so thumbnails aren't re-fetched on every page load

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -66,7 +66,13 @@ async def download_file(path: str):
             detail=f"File not found: {e}",
         )
 
-    return RedirectResponse(url=url, status_code=307)
+    # Cache the redirect for less than the presigned URL's 1h lifetime so the
+    # browser never replays a cached redirect pointing to an expired signature.
+    return RedirectResponse(
+        url=url,
+        status_code=307,
+        headers={"Cache-Control": "public, max-age=300"},
+    )
 
 
 @router.post("/segments/{segment_id}/upload", response_model=SegmentResponse, dependencies=[Depends(verify_api_key)])

--- a/app/s3.py
+++ b/app/s3.py
@@ -16,10 +16,13 @@ def _get_client():
     return _client
 
 
+_IMMUTABLE_CACHE_CONTROL = "public, max-age=86400, immutable"
+
+
 def upload_bytes(data: bytes, key: str, bucket: str) -> str:
     """Upload bytes to S3. Returns the S3 URI."""
     client = _get_client()
-    client.put_object(Bucket=bucket, Key=key, Body=data)
+    client.put_object(Bucket=bucket, Key=key, Body=data, CacheControl=_IMMUTABLE_CACHE_CONTROL)
     uri = f"s3://{bucket}/{key}"
     logger.info("Uploaded %d bytes to %s", len(data), uri)
     return uri
@@ -28,7 +31,7 @@ def upload_bytes(data: bytes, key: str, bucket: str) -> str:
 def upload_file(path: str, key: str, bucket: str) -> str:
     """Upload a local file to S3 using multipart. Returns the S3 URI."""
     client = _get_client()
-    client.upload_file(path, bucket, key)
+    client.upload_file(path, bucket, key, ExtraArgs={"CacheControl": _IMMUTABLE_CACHE_CONTROL})
     uri = f"s3://{bucket}/{key}"
     logger.info("Uploaded file %s to %s", path, uri)
     return uri


### PR DESCRIPTION
## Summary
- S3 uploads (`upload_bytes`, `upload_file`) now set `CacheControl: public, max-age=86400, immutable` on new objects.
- `/api/files` 307 redirect now returns `Cache-Control: public, max-age=300` — capped well under the presigned URL's 3600s lifetime so browsers never replay a cached redirect pointing to an expired signature.

## Why
Thumbnails on /jobs and /videos were re-downloaded on every mount (hard refresh or client-side nav back). Neither the redirect nor the S3 object had a `Cache-Control` header, so the browser had nothing to cache by.

The console's existing `v=completed_at` cache-buster on `JobDetail` (commit 52e4ee3) still works — changing `v` changes the cache key.

## Test plan
- [ ] Deploy via CI
- [ ] Load /jobs, reload — confirm thumbnails served from disk cache in DevTools Network tab
- [ ] Trigger a segment regeneration via JobDetail — confirm `v=<new completed_at>` forces a fresh fetch
- [ ] New S3 uploads land with `CacheControl: public, max-age=86400, immutable` (verify via `aws s3api head-object`)