### PR TITLE
perf: Extend file cache window to 5h and set ContentType on upload

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -66,12 +66,12 @@ async def download_file(path: str):
             detail=f"File not found: {e}",
         )
 
-    # Cache the redirect for less than the presigned URL's 1h lifetime so the
+    # Cache the redirect for less than the presigned URL's 6h lifetime so the
     # browser never replays a cached redirect pointing to an expired signature.
     return RedirectResponse(
         url=url,
         status_code=307,
-        headers={"Cache-Control": "public, max-age=300"},
+        headers={"Cache-Control": "public, max-age=18000"},
     )
 
 

--- a/app/s3.py
+++ b/app/s3.py
@@ -1,4 +1,5 @@
 import logging
+import mimetypes
 
 import boto3
 
@@ -19,10 +20,21 @@ def _get_client():
 _IMMUTABLE_CACHE_CONTROL = "public, max-age=86400, immutable"
 
 
+def _content_type_for(key: str) -> str:
+    guess, _ = mimetypes.guess_type(key)
+    return guess or "binary/octet-stream"
+
+
 def upload_bytes(data: bytes, key: str, bucket: str) -> str:
     """Upload bytes to S3. Returns the S3 URI."""
     client = _get_client()
-    client.put_object(Bucket=bucket, Key=key, Body=data, CacheControl=_IMMUTABLE_CACHE_CONTROL)
+    client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=data,
+        CacheControl=_IMMUTABLE_CACHE_CONTROL,
+        ContentType=_content_type_for(key),
+    )
     uri = f"s3://{bucket}/{key}"
     logger.info("Uploaded %d bytes to %s", len(data), uri)
     return uri
@@ -31,7 +43,15 @@ def upload_bytes(data: bytes, key: str, bucket: str) -> str:
 def upload_file(path: str, key: str, bucket: str) -> str:
     """Upload a local file to S3 using multipart. Returns the S3 URI."""
     client = _get_client()
-    client.upload_file(path, bucket, key, ExtraArgs={"CacheControl": _IMMUTABLE_CACHE_CONTROL})
+    client.upload_file(
+        path,
+        bucket,
+        key,
+        ExtraArgs={
+            "CacheControl": _IMMUTABLE_CACHE_CONTROL,
+            "ContentType": _content_type_for(key),
+        },
+    )
     uri = f"s3://{bucket}/{key}"
     logger.info("Uploaded file %s to %s", path, uri)
     return uri
@@ -168,8 +188,12 @@ def move_object(bucket: str, src_key: str, dst_key: str) -> None:
     logger.info("Moved %s/%s → %s/%s", bucket, src_key, bucket, dst_key)
 
 
-def generate_presigned_url(uri: str, expires: int = 3600) -> str:
-    """Generate a presigned GET URL for an S3 URI. Default expiry: 1 hour."""
+def generate_presigned_url(uri: str, expires: int = 21600) -> str:
+    """Generate a presigned GET URL for an S3 URI. Default expiry: 6 hours.
+
+    The /api/files redirect caches for <6h so the browser never replays a
+    cached redirect that points to an expired signature.
+    """
     bucket, key = parse_s3_uri(uri)
     client = _get_client()
     return client.generate_presigned_url(


### PR DESCRIPTION
## Summary
- Presigned URL expiry: 1h → 6h (`s3.py`).
- `/api/files` 307 `Cache-Control`: 300s → 18000s (~5h), still under the 6h presigned lifetime so browsers never replay a cached redirect pointing to an expired signature.
- Uploads set `ContentType` from the key suffix (`image/png`, `video/mp4`, etc.) instead of shipping everything as `binary/octet-stream`.

## Why
Follow-up to #69. The 5-min cache window was the safe floor given a 1h presigned lifetime; bumping both gives ~50× the in-session cache hits for thumbnails and video playback.

ContentType was sloppy but mostly harmless — fixing it improves right-click-save filenames and any downstream consumer that dispatches on MIME.

## Test plan
- [ ] Deploy via CI
- [ ] Hit /jobs, inspect a thumbnail response in DevTools → `Cache-Control: public, max-age=18000`
- [ ] Reload within 5h → thumbnails served from disk cache (no network for 307 or bytes)
- [ ] Upload a new starting image → confirm object lands with `ContentType: image/png` via `aws s3api head-object`
- [ ] Backfill existing objects' ContentType separately (one-shot script, not part of this PR)