### PR TITLE
fix: Add /images/download endpoint to bypass S3 CORS (#130)

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -4,11 +4,13 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
+from fastapi.responses import Response
 
 from app.auth import get_current_user, verify_api_key_or_bearer
 from app.config import settings
 from app.s3 import (
     delete_object,
+    download_bytes,
     get_first_object_key,
     list_common_prefixes,
     list_objects,
@@ -130,3 +132,25 @@ async def delete_image(path: str = Query(...)):
         raise HTTPException(status_code=400, detail="Path must be in the images bucket")
     await asyncio.to_thread(delete_object, path)
     return {"ok": True}
+
+
+_CONTENT_TYPES = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp"}
+
+
+@router.get("/images/download", dependencies=[Depends(verify_api_key_or_bearer)])
+async def download_image_bytes(path: str = Query(...)):
+    """Return raw image bytes for canvas processing in the browser.
+
+    Unlike /files, this does not redirect to S3. Returning bytes directly means
+    FastAPI's CORS middleware covers the response, so the console can fetch() the
+    image and draw it to a canvas without triggering cross-origin taint.
+    """
+    bucket = settings.s3_images_bucket
+    if not path.startswith(f"s3://{bucket}/"):
+        raise HTTPException(status_code=400, detail="Path must be in the images bucket")
+    try:
+        data = await asyncio.to_thread(download_bytes, path)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Image not found: {e}")
+    ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    return Response(content=data, media_type=_CONTENT_TYPES.get(ext, "application/octet-stream"))


### PR DESCRIPTION
## Summary

- Adds `GET /images/download` which streams image bytes directly through the API instead of redirecting to S3
- The existing `/files` endpoint does a `307` redirect to a presigned S3 URL — the S3 bucket has no CORS headers, so `fetch()` calls from the console are blocked by the browser
- This endpoint returns bytes directly, so FastAPI's `CORSMiddleware` covers the response and the console can use `fetch()` + canvas without cross-origin issues

## Why not configure S3 CORS?

This approach keeps the fix entirely in the API layer with no AWS infrastructure changes. The endpoint is scoped to the images bucket only and uses the same `verify_api_key_or_bearer` auth as the rest of the image routes.

## Test plan

- [ ] API deploys without error
- [ ] `GET /images/download?path=s3://wanly-images/...&token=...` returns image bytes with correct `Content-Type`
- [ ] 400 returned for paths outside the images bucket
- [ ] 404 returned for non-existent paths
- [ ] Console Crop & Resize saves successfully (requires console PR #129 too)