### PR TITLE
fix: /images/download 401 — wrong auth dependency

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
 
-from app.auth import get_current_user, verify_api_key_or_bearer
+from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
 from app.config import settings
 from app.s3 import (
     delete_object,
@@ -137,7 +137,7 @@ async def delete_image(path: str = Query(...)):
 _CONTENT_TYPES = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp"}
 
 
-@router.get("/images/download", dependencies=[Depends(verify_api_key_or_bearer)])
+@router.get("/images/download", dependencies=[Depends(verify_api_key_or_token)])
 async def download_image_bytes(path: str = Query(...)):
     """Return raw image bytes for canvas processing in the browser.
 


### PR DESCRIPTION
## Root cause

PR #71 added `/images/download` using `verify_api_key_or_bearer`, but the console calls it via `fetch(getImageDownloadUrl(...))` where the JWT is in the `?token=` query param — the same pattern as `/files`. `verify_api_key_or_bearer` only inspects headers, so every request returned 401.

## Fix

Changed to `verify_api_key_or_token`, which checks the `?token=` query param. This is the correct dependency for any endpoint whose URL is constructed by `getFileUrl()`/`getImageDownloadUrl()`.

## Why the pattern difference exists

- Axios-based API calls → interceptor adds `Authorization: Bearer` header → use `verify_api_key_or_bearer`
- URL-param-based calls (`<img src>`, direct `fetch()`) → token in `?token=` → use `verify_api_key_or_token`

## Test plan

- [ ] `GET /images/download?path=s3://wanly-images/...&token=<jwt>` returns 200 with image bytes
- [ ] Console Crop & Resize saves without error