### PR TITLE
fix: accept API key or Bearer JWT on GET /images/folders

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -65,7 +65,7 @@ async def create_folder(body: dict):
     return {"name": name}
 
 
-@router.get("/images/folders", dependencies=[Depends(get_current_user)])
+@router.get("/images/folders", dependencies=[Depends(verify_api_key_or_bearer)])
 async def list_folders():
     """List date folders in the images bucket, newest first."""
     bucket = settings.s3_images_bucket


### PR DESCRIPTION
## Summary
- Changed `GET /images/folders` auth from `get_current_user` (JWT-only) to `verify_api_key_or_bearer` (accepts both `X-API-Key` header and `Authorization: Bearer` JWT)
- Allows daemon workers using API keys to list image folders, matching the auth pattern already used on `POST /images/upload` and other endpoints