### PR TITLE
feat: add GET /images/jobs endpoint for image-to-job lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Sync dependencies
+        run: uv sync
+      - name: Lint
+        run: uv run ruff check .
+      - name: Type check (if mypy configured)
+        run: uv run mypy . --ignore-missing-imports || echo "mypy not configured — skipping"
+      - name: Test
+        run: uv run pytest -q || [ $? -eq 5 ]  # allow "no tests collected" during scaffolding

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,32 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql+asyncpg://test:test@localhost/test
+      JWT_SECRET: ci-test-secret-key
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - name: Sync dependencies
-        run: uv sync
-      - name: Lint
-        run: uv run ruff check .
-      - name: Type check (if mypy configured)
-        run: uv run mypy . --ignore-missing-imports || echo "mypy not configured — skipping"
+      - name: Install dependencies
+        run: pip install -r requirements.txt pytest pytest-asyncio
       - name: Test
-        run: uv run pytest -q || [ $? -eq 5 ]  # allow "no tests collected" during scaffolding
+        run: python -m pytest -q

--- a/.github/workflows/deepseek-review.yml
+++ b/.github/workflows/deepseek-review.yml
@@ -1,0 +1,65 @@
+name: DeepSeek Code Review
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+permissions:
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.label.name == 'ai review'
+    runs-on: ubuntu-latest
+    name: DeepSeek Code Review
+    steps:
+      - name: Run DeepSeek Review
+        uses: hustcer/deepseek-review@v1
+        with:
+          chat-token: ${{ secrets.DEEPSEEK_API_KEY }}
+          model: deepseek-chat
+          base-url: https://api.deepseek.com/v1
+          max-length: 50000
+          sys-prompt: >
+            You are a senior full-stack engineer reviewing code for Wanly, an AI video generation
+            pipeline. Wanly has two codebases: a Python backend (FastAPI + SQLAlchemy + Postgres + S3)
+            and a TypeScript frontend (React 19 + MUI + Vite).
+
+            **This repo is the BACKEND (wanly-api).** It handles:
+            - Job orchestration (video generation jobs with segments)
+            - Worker management (GPU workers via ComfyUI)
+            - S3-backed image/video storage
+            - LoRA and prompt preset libraries
+            - Video stitching pipeline
+
+            Perform a thorough code review focusing on:
+
+            ### 1. Correctness & Logic
+            - Does the code do what the PR description claims?
+            - Are there edge cases, null-reference risks, or race conditions?
+            - Are SQLAlchemy queries correct (eager loading, N+1 risks)?
+            - Are async patterns correct (gather, to_thread, background tasks)?
+
+            ### 2. Security
+            - Is user authorization applied consistently (get_current_user)?
+            - Are API key / token checks correct on every endpoint?
+            - Are S3 paths validated against expected buckets?
+            - Any credential leaks, injection risks, or missing access controls?
+
+            ### 3. Performance
+            - N+1 query risks in SQLAlchemy?
+            - Proper use of async gather for parallel operations?
+            - Any blocking calls that should be async?
+
+            ### 4. Code Quality
+            - Python type hints correct and complete?
+            - Consistent error handling (HTTPException with correct status codes)?
+            - Proper use of Pydantic models (model_validate vs from_orm)?
+            - Router organization clear?
+
+            **Output format:**
+            - Start with a 1-2 sentence summary
+            - List issues by severity: 🔴 Critical, 🟡 Warning, 🔵 Suggestion
+            - Include file paths and line references where possible
+            - End with an overall assessment (Approve / Approve with comments / Request changes)

--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -5,9 +5,13 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
 from app.config import settings
+from app.database import get_db
+from app.models import Job
 from app.s3 import (
     delete_object,
     download_bytes,
@@ -135,6 +139,26 @@ async def delete_image(path: str = Query(...)):
 
 
 _CONTENT_TYPES = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp"}
+
+
+@router.get("/images/jobs", dependencies=[Depends(get_current_user)])
+async def get_image_jobs(
+    path: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+    user = Depends(get_current_user),
+):
+    """Return jobs that use the given image as their starting image."""
+    result = await db.execute(
+        select(Job.id, Job.name, Job.created_at)
+        .where(Job.user_id == user.id, Job.starting_image == path)
+        .order_by(Job.created_at.desc())
+        .limit(50)
+    )
+    rows = result.all()
+    return [
+        {"id": str(row[0]), "name": row[1], "created_at": row[2].isoformat()}
+        for row in rows
+    ]
 
 
 @router.get("/images/download", dependencies=[Depends(verify_api_key_or_token)])


### PR DESCRIPTION
## Summary

Adds a new endpoint `GET /images/jobs?path=...` that returns jobs which use a given image as their starting image.

### Details
- Queries the `jobs` table for rows where `starting_image` matches the provided S3 path
- Scoped to the current user
- Ordered by `created_at` descending, limited to 50 results
- Returns `{id, name, created_at}` for each matching job

### Paired with
- [wanly-console#134](https://github.com/DavidJBarnes/wanly-console/pull/134)