### PR TITLE
feat: sort image folders by creation date

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -15,7 +15,7 @@ from app.models import Job
 from app.s3 import (
     delete_object,
     download_bytes,
-    get_first_object_key,
+    get_folder_info,
     list_common_prefixes,
     list_objects,
     move_object,
@@ -71,20 +71,20 @@ async def create_folder(body: dict):
 
 @router.get("/images/folders", dependencies=[Depends(verify_api_key_or_bearer)])
 async def list_folders():
-    """List date folders in the images bucket, newest first."""
+    """List folders in the images bucket, sorted by creation date newest first."""
     bucket = settings.s3_images_bucket
     prefixes = await asyncio.to_thread(list_common_prefixes, bucket)
-    # Sort newest first (prefixes look like "2026-02-27/")
-    prefixes.sort(reverse=True)
 
-    # Get first object in each folder for thumbnails (parallel)
-    async def _thumb(prefix: str) -> dict:
+    async def _folder_info(prefix: str) -> dict:
         name = prefix.rstrip("/")
-        key = await asyncio.to_thread(get_first_object_key, bucket, prefix)
-        thumbnail = f"s3://{bucket}/{key}" if key else None
-        return {"name": name, "thumbnail": thumbnail}
+        info = await asyncio.to_thread(get_folder_info, bucket, prefix)
+        thumbnail = f"s3://{bucket}/{info["key"]}" if info and info.get("key") else None
+        created_at = info["created_at"] if info else None
+        return {"name": name, "thumbnail": thumbnail, "created_at": created_at}
 
-    folders = await asyncio.gather(*[_thumb(p) for p in prefixes])
+    folders = await asyncio.gather(*[_folder_info(p) for p in prefixes])
+    # Sort by created_at descending (newest first); folders with no date go last
+    folders.sort(key=lambda f: f["created_at"] or "", reverse=True)
     return list(folders)
 
 

--- a/app/s3.py
+++ b/app/s3.py
@@ -166,14 +166,32 @@ def list_objects(bucket: str, prefix: str) -> list[dict]:
     return objects
 
 
-def get_first_object_key(bucket: str, prefix: str) -> str | None:
-    """First non-marker object key under a prefix (for folder thumbnails)."""
+def get_folder_info(bucket: str, prefix: str) -> dict | None:
+    """Return thumbnail key and creation date for a folder prefix.
+
+    Uses the .folder marker's LastModified for creation time if present,
+    otherwise falls back to the first non-marker object.
+    """
     client = _get_client()
-    resp = client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=5)
-    for obj in resp.get("Contents", []):
-        if not obj["Key"].endswith("/.folder"):
-            return obj["Key"]
-    return None
+    resp = client.list_objects_v2(Bucket=bucket, Prefix=prefix, MaxKeys=20)
+    contents = resp.get("Contents", [])
+    if not contents:
+        return None
+
+    marker = None
+    first_image = None
+    for obj in contents:
+        if obj["Key"].endswith("/.folder"):
+            marker = obj
+        elif first_image is None:
+            first_image = obj
+        if marker and first_image:
+            break
+
+    key = first_image["Key"] if first_image else None
+    created_at_obj = marker if marker else first_image
+    created_at = created_at_obj["LastModified"].isoformat() if created_at_obj else None
+    return {"key": key, "created_at": created_at}
 
 
 def move_object(bucket: str, src_key: str, dst_key: str) -> None:


### PR DESCRIPTION
Folders on the Image Repo page were sorted reverse-alphabetically by name — which happened to work for date-based names like `2026-02-27` but failed for custom-named folders.

**Changes:**
- New `get_folder_info()` in `s3.py` returns both the thumbnail key and the folder's creation time (sourced from the `.folder` marker's LastModified, falling back to the first image)
- `GET /images/folders` now returns a `created_at` field and sorts by it descending
- Custom-named folders now interleave correctly with date-based ones