### PR TITLE
feat: include faceswap_enabled in job list response

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -228,6 +228,17 @@ async def list_jobs(
         for row in counts_result.all():
             counts_map[row[0]] = (row[1], row[2])
 
+    # Aggregate faceswap status per job
+    faceswap_map: dict[UUID, bool] = {}
+    if job_ids:
+        faceswap_result = await db.execute(
+            select(Segment.job_id, func.bool_or(Segment.faceswap_enabled))
+            .where(Segment.job_id.in_(job_ids))
+            .group_by(Segment.job_id)
+        )
+        for row in faceswap_result.all():
+            faceswap_map[row[0]] = bool(row[1])
+
     # Fetch active segment info for estimation
     active_statuses = {SegmentStatus.PENDING, SegmentStatus.CLAIMED, SegmentStatus.PROCESSING}
     active_jobs = [j for j in items if j.status in (JobStatus.PENDING, JobStatus.PROCESSING)]
@@ -279,6 +290,7 @@ async def list_jobs(
                 segment_count=seg_total,
                 completed_segment_count=seg_completed,
                 estimated_run_time=est_map.get(j.id),
+                faceswap_enabled=faceswap_map.get(j.id, False),
                 created_at=j.created_at,
                 updated_at=j.updated_at,
             )

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -44,6 +44,7 @@ class JobResponse(BaseModel):
     segment_count: int = 0
     completed_segment_count: int = 0
     estimated_run_time: Optional[float] = None
+    faceswap_enabled: bool = False
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
Adds `faceswap_enabled: bool` to the `GET /jobs` response. Aggregates using PostgreSQL `bool_or` on the segments table — returns `true` if any segment for the job has faceswap enabled.

Paired with the console PR that displays a Faceswap column in the job queue table.