### PR TITLE
feat: add video tags (free-form text tags on videos)

### DIFF
--- a/alembic/versions/025_add_video_tags.py
+++ b/alembic/versions/025_add_video_tags.py
@@ -1,0 +1,25 @@
+"""Add tags column to videos
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-05-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "025"
+down_revision = "024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "videos",
+        sa.Column("tags", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("videos", "tags")

--- a/alembic/versions/026_add_video_tags_index.py
+++ b/alembic/versions/026_add_video_tags_index.py
@@ -1,0 +1,22 @@
+"""Add index on video tags column
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-05-08
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "026"
+down_revision = "025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_videos_tags", "videos", ["tags"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_videos_tags")

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from slowapi.errors import RateLimitExceeded
 from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
 from app.limiter import limiter
-from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, prompt_presets, segments, tags, wildcards, workers
+from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, prompt_presets, segments, tags, videos, wildcards, workers
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +61,7 @@ app.include_router(faceswap.router)
 app.include_router(files.router)
 app.include_router(loras.router)
 app.include_router(tags.router)
+app.include_router(videos.router)
 app.include_router(wildcards.router)
 app.include_router(prompt_presets.router)
 app.include_router(workers.router)

--- a/app/models.py
+++ b/app/models.py
@@ -111,6 +111,7 @@ class Video(Base):
     duration_seconds = mapped_column(Float, nullable=True)
     status = mapped_column(String(20), nullable=False, default=VideoStatus.PENDING)
     error_message = mapped_column(Text, nullable=True)
+    tags = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     completed_at = mapped_column(DateTime(timezone=True), nullable=True)
 

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -252,16 +252,16 @@ async def list_jobs(
         for row in faceswap_result.all():
             faceswap_map[row[0]] = bool(row[1])
 
-    # Fetch tags from each job's first completed video
+    # Fetch tags from the first completed video per job
     tags_map: dict[UUID, str | None] = {}
     if job_ids:
         tags_result = await db.execute(
             select(Video.job_id, Video.tags)
             .where(Video.job_id.in_(job_ids), Video.status == "completed")
-            .distinct(Video.job_id)
         )
         for row in tags_result.all():
-            tags_map[row[0]] = row[1]
+            if row[0] not in tags_map:
+                tags_map[row[0]] = row[1]
 
     # Fetch active segment info for estimation
     active_statuses = {SegmentStatus.PENDING, SegmentStatus.CLAIMED, SegmentStatus.PROCESSING}

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -12,6 +12,8 @@ from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from sqlalchemy import or_
+
 from app.auth import get_current_user
 from app.config import settings
 from app.database import get_db
@@ -186,14 +188,24 @@ async def list_jobs(
     status_filter: str | None = Query(None, alias="status"),
     sort: str = Query("created_at_desc"),
     name: str | None = Query(None, min_length=1, max_length=255, description="Filter jobs by name (case-insensitive partial match)"),
+    search: str | None = Query(None, min_length=1, max_length=255, alias="q", description="Search jobs by name or video tags (case-insensitive partial match)"),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     base = select(Job).where(Job.user_id == user.id)
     if name:
-        # Escape SQL LIKE wildcards in user input to prevent unintended matches
         safe = name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         base = base.where(Job.name.ilike(f"%{safe}%", escape="\\"))
+    if search:
+        safe = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        pattern = f"%{safe}%"
+        tag_job_ids = select(Video.job_id).where(Video.tags.ilike(pattern, escape="\\")).subquery()
+        base = base.where(
+            or_(
+                Job.name.ilike(pattern, escape="\\"),
+                Job.id.in_(select(tag_job_ids.c.job_id)),
+            )
+        )
     if status_filter:
         statuses = [s.strip() for s in status_filter.split(",") if s.strip()]
         base = base.where(Job.status.in_(statuses))
@@ -239,6 +251,17 @@ async def list_jobs(
         )
         for row in faceswap_result.all():
             faceswap_map[row[0]] = bool(row[1])
+
+    # Fetch tags from each job's first completed video
+    tags_map: dict[UUID, str | None] = {}
+    if job_ids:
+        tags_result = await db.execute(
+            select(Video.job_id, Video.tags)
+            .where(Video.job_id.in_(job_ids), Video.status == "completed")
+            .distinct(Video.job_id)
+        )
+        for row in tags_result.all():
+            tags_map[row[0]] = row[1]
 
     # Fetch active segment info for estimation
     active_statuses = {SegmentStatus.PENDING, SegmentStatus.CLAIMED, SegmentStatus.PROCESSING}
@@ -292,6 +315,7 @@ async def list_jobs(
                 completed_segment_count=seg_completed,
                 estimated_run_time=est_map.get(j.id),
                 faceswap_enabled=faceswap_map.get(j.id, False),
+                tags=tags_map.get(j.id),
                 created_at=j.created_at,
                 updated_at=j.updated_at,
             )

--- a/app/routes/videos.py
+++ b/app/routes/videos.py
@@ -1,0 +1,39 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import Job, User, Video
+from app.schemas.videos import VideoResponse
+
+router = APIRouter()
+
+
+class VideoTagsUpdate(BaseModel):
+    tags: str | None = None
+
+
+@router.patch("/videos/{video_id}/tags", response_model=VideoResponse)
+async def update_video_tags(
+    video_id: UUID,
+    body: VideoTagsUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(Video)
+        .join(Job, Video.job_id == Job.id)
+        .where(Video.id == video_id, Job.user_id == user.id)
+    )
+    video = result.scalar_one_or_none()
+    if video is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video not found")
+
+    video.tags = body.tags
+    await db.commit()
+    await db.refresh(video)
+    return video

--- a/app/routes/videos.py
+++ b/app/routes/videos.py
@@ -1,7 +1,9 @@
 from uuid import UUID
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,11 +12,13 @@ from app.database import get_db
 from app.models import Job, User, Video
 from app.schemas.videos import VideoResponse
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 
 class VideoTagsUpdate(BaseModel):
-    tags: str | None = None
+    tags: str | None = Field(None, max_length=500, description="Comma-separated tags")
 
 
 @router.patch("/videos/{video_id}/tags", response_model=VideoResponse)
@@ -28,12 +32,19 @@ async def update_video_tags(
         select(Video)
         .join(Job, Video.job_id == Job.id)
         .where(Video.id == video_id, Job.user_id == user.id)
+        .with_for_update()
     )
     video = result.scalar_one_or_none()
     if video is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Video not found")
 
-    video.tags = body.tags
-    await db.commit()
-    await db.refresh(video)
+    try:
+        video.tags = body.tags
+        await db.commit()
+        await db.refresh(video)
+    except Exception as e:
+        await db.rollback()
+        logger.error("Failed to update tags for video %s: %s", video_id, e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update tags")
+
     return video

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -45,6 +45,7 @@ class JobResponse(BaseModel):
     completed_segment_count: int = 0
     estimated_run_time: Optional[float] = None
     faceswap_enabled: bool = False
+    tags: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 

--- a/app/schemas/videos.py
+++ b/app/schemas/videos.py
@@ -12,6 +12,7 @@ class VideoResponse(BaseModel):
     duration_seconds: Optional[float]
     status: str
     error_message: Optional[str]
+    tags: Optional[str] = None
     created_at: datetime
     completed_at: Optional[datetime]
 


### PR DESCRIPTION
## Summary

- Adds free-form text tags to videos (comma-separated)
- Tags are editable from the Job Detail page in the finalized video card
- Tags are searchable from the Videos page via the existing search bar (matches both job name and video tags)
- Tags are stored on the `videos.tags` column in the database

## Backend Changes

- **Migration**: `025_add_video_tags.py` — adds `tags` column to `videos` table
- **Model**: Added `tags` field to `Video` model
- **Schemas**: Added `tags` to `VideoResponse` and `JobResponse`
- **New route**: `PATCH /videos/{id}/tags` — updates video tags with ownership verification
- **Jobs route**: Added `q` search param to `GET /jobs` that searches both job name and video tags; populates `tags` on `JobResponse` from the first completed video

## Related

Closes #155