### PR TITLE
fix: move tags from Video to Job model for anytime editing

### DIFF
--- a/alembic/versions/027_add_job_tags.py
+++ b/alembic/versions/027_add_job_tags.py
@@ -1,0 +1,27 @@
+"""Add tags column to jobs
+
+Revision ID: 027
+Revises: 026
+Create Date: 2026-05-08
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "027"
+down_revision = "026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("tags", sa.Text(), nullable=True),
+    )
+    op.create_index("ix_jobs_tags", "jobs", ["tags"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_tags")
+    op.drop_column("jobs", "tags")

--- a/alembic/versions/027_add_job_tags.py
+++ b/alembic/versions/027_add_job_tags.py
@@ -21,6 +21,21 @@ def upgrade() -> None:
     )
     op.create_index("ix_jobs_tags", "jobs", ["tags"])
 
+    # Backfill tags from the first completed video for existing jobs
+    op.execute(
+        """
+        UPDATE jobs
+        SET tags = sub.tags
+        FROM (
+            SELECT DISTINCT ON (videos.job_id) videos.job_id, videos.tags
+            FROM videos
+            WHERE videos.status = 'completed' AND videos.tags IS NOT NULL
+            ORDER BY videos.job_id, videos.completed_at
+        ) sub
+        WHERE jobs.id = sub.job_id
+        """
+    )
+
 
 def downgrade() -> None:
     op.drop_index("ix_jobs_tags")

--- a/app/models.py
+++ b/app/models.py
@@ -46,6 +46,7 @@ class Job(Base):
     cfg_low = mapped_column(Float, nullable=True)
     priority = mapped_column(Integer, nullable=False, default=0)
     status = mapped_column(String(20), nullable=False, default=JobStatus.PENDING)
+    tags = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -188,7 +188,7 @@ async def list_jobs(
     status_filter: str | None = Query(None, alias="status"),
     sort: str = Query("created_at_desc"),
     name: str | None = Query(None, min_length=1, max_length=255, description="Filter jobs by name (case-insensitive partial match)"),
-    search: str | None = Query(None, min_length=1, max_length=255, alias="q", description="Search jobs by name or video tags (case-insensitive partial match)"),
+    search: str | None = Query(None, min_length=1, max_length=255, alias="q", description="Search jobs by name or tags (case-insensitive partial match)"),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -199,11 +199,10 @@ async def list_jobs(
     if search:
         safe = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         pattern = f"%{safe}%"
-        tag_job_ids = select(Video.job_id).where(Video.tags.ilike(pattern, escape="\\")).subquery()
         base = base.where(
             or_(
                 Job.name.ilike(pattern, escape="\\"),
-                Job.id.in_(select(tag_job_ids.c.job_id)),
+                Job.tags.ilike(pattern, escape="\\"),
             )
         )
     if status_filter:
@@ -251,17 +250,6 @@ async def list_jobs(
         )
         for row in faceswap_result.all():
             faceswap_map[row[0]] = bool(row[1])
-
-    # Fetch tags from the first completed video per job
-    tags_map: dict[UUID, str | None] = {}
-    if job_ids:
-        tags_result = await db.execute(
-            select(Video.job_id, Video.tags)
-            .where(Video.job_id.in_(job_ids), Video.status == "completed")
-        )
-        for row in tags_result.all():
-            if row[0] not in tags_map:
-                tags_map[row[0]] = row[1]
 
     # Fetch active segment info for estimation
     active_statuses = {SegmentStatus.PENDING, SegmentStatus.CLAIMED, SegmentStatus.PROCESSING}
@@ -315,7 +303,7 @@ async def list_jobs(
                 completed_segment_count=seg_completed,
                 estimated_run_time=est_map.get(j.id),
                 faceswap_enabled=faceswap_map.get(j.id, False),
-                tags=tags_map.get(j.id),
+                tags=j.tags,
                 created_at=j.created_at,
                 updated_at=j.updated_at,
             )
@@ -412,6 +400,7 @@ async def get_job(
         cfg_low=job.cfg_low,
         priority=job.priority,
         status=job.status,
+        tags=job.tags,
         estimated_run_time=job_est,
         created_at=job.created_at,
         updated_at=job.updated_at,
@@ -439,6 +428,9 @@ async def update_job(
 
     if body.name is not None:
         job.name = body.name
+
+    if body.tags is not None:
+        job.tags = body.tags
 
     if body.status is not None:
         allowed = JOB_VALID_TRANSITIONS.get(job.status, set())
@@ -527,6 +519,7 @@ async def reopen_job(
         lightx2v_strength_low=job.lightx2v_strength_low,
         cfg_high=job.cfg_high, cfg_low=job.cfg_low,
         priority=job.priority, status=job.status,
+        tags=job.tags,
         estimated_run_time=job_est,
         created_at=job.created_at, updated_at=job.updated_at,
         segments=seg_responses, videos=job.videos,

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -421,7 +421,9 @@ async def update_job(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    result = await db.execute(select(Job).where(Job.id == job_id, Job.user_id == user.id))
+    result = await db.execute(
+        select(Job).where(Job.id == job_id, Job.user_id == user.id).with_for_update()
+    )
     job = result.scalar_one_or_none()
     if job is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -71,6 +71,7 @@ class JobDetailResponse(JobResponse):
 class JobUpdate(BaseModel):
     name: Optional[str] = None
     status: Optional[str] = None
+    tags: Optional[str] = None
 
 
 class WorkerStatsItem(BaseModel):

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.schemas.segments import SegmentCreate, SegmentResponse
 from app.schemas.videos import VideoResponse
@@ -71,7 +71,7 @@ class JobDetailResponse(JobResponse):
 class JobUpdate(BaseModel):
     name: Optional[str] = None
     status: Optional[str] = None
-    tags: Optional[str] = None
+    tags: Optional[str] = Field(None, max_length=500, description="Comma-separated tags")
 
 
 class WorkerStatsItem(BaseModel):


### PR DESCRIPTION
## Summary

Moves tags from the Video model to the Job model so tags can be added/edited at any stage of the job lifecycle (not only after finalization when a video record exists).

## Changes

- **Migration 027**: Adds `tags` column + index to `jobs` table
- **Job model**: Added `tags` field
- **JobUpdate schema**: Added optional `tags` field
- **Jobs route**: `PATCH /jobs/{id}` now accepts `tags`; `GET /jobs` search (`q`) queries `Job.tags` directly; tags populated inline from `Job.tags`
- Removed the old `Video.tags` population query from the jobs list endpoint