### PR TITLE
feat: Faceswap-only segment reprocessing (#85)

### DIFF
--- a/alembic/versions/029_add_segment_reprocess_type.py
+++ b/alembic/versions/029_add_segment_reprocess_type.py
@@ -1,0 +1,22 @@
+"""Add reprocess_type to segments
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-05-13
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "029"
+down_revision = "028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("reprocess_type", sa.String(20), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "reprocess_type")

--- a/app/models.py
+++ b/app/models.py
@@ -87,6 +87,7 @@ class Segment(Base):
     motion_magnitude = mapped_column(Float, nullable=True)
     reference_frames = mapped_column(JSON, nullable=True)
     negative_prompt = mapped_column(Text, nullable=True)
+    reprocess_type = mapped_column(String(20), nullable=True)
     status = mapped_column(String(20), nullable=False, default=SegmentStatus.PENDING)
     worker_id = mapped_column(UUID(as_uuid=True), nullable=True)
     worker_name = mapped_column(String(255), nullable=True)

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -106,6 +106,7 @@ async def upload_segment_output(
     segment.output_path = video_uri
     segment.last_frame_path = frame_uri
     segment.status = SegmentStatus.COMPLETED
+    segment.reprocess_type = None
 
     from datetime import datetime, timezone
     segment.completed_at = datetime.now(timezone.utc)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -297,6 +297,8 @@ async def claim_next_segment(
         cfg_high=job.cfg_high,
         cfg_low=job.cfg_low,
         negative_prompt=negative_prompt,
+        reprocess_type=segment.reprocess_type,
+        output_path=segment.output_path,
         width=job.width,
         height=job.height,
         fps=job.fps,
@@ -604,10 +606,9 @@ async def reprocess_segment(
     segment.faceswap_faces_order = body.faceswap_faces_order
     segment.faceswap_faces_index = body.faceswap_faces_index
 
-    # Reset segment for re-processing
+    # Reset segment for faceswap-only reprocessing (preserve existing output)
+    segment.reprocess_type = "faceswap"
     segment.status = SegmentStatus.PENDING
-    segment.output_path = None
-    segment.last_frame_path = None
     segment.worker_id = None
     segment.worker_name = None
     segment.claimed_at = None

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -100,6 +100,8 @@ class SegmentClaimResponse(BaseModel):
     cfg_high: Optional[float] = None
     cfg_low: Optional[float] = None
     negative_prompt: Optional[str] = None
+    reprocess_type: Optional[str] = None
+    output_path: Optional[str] = None
     width: int
     height: int
     fps: int


### PR DESCRIPTION
## Summary
- Add `reprocess_type` column to segments table (migration 029)
- Reprocess endpoint now preserves existing `output_path` and sets `reprocess_type="faceswap"` instead of clearing the video and triggering full regeneration
- Claim endpoint returns `reprocess_type` and `output_path` so the daemon knows to run faceswap-only
- Upload endpoint clears `reprocess_type` after successful completion

## Context
The original implementation (#86) reset the segment to PENDING and cleared the output, causing the daemon to regenerate the entire video from scratch. This change makes reprocessing apply faceswap to the existing completed video only — much faster and matches the intended behavior.

## Test plan
- [ ] Run migration 029
- [ ] Reprocess a completed segment with faceswap enabled
- [ ] Verify segment retains `output_path` while in PENDING state
- [ ] Verify daemon receives `reprocess_type=faceswap` and `output_path` in claim response
- [ ] Verify `reprocess_type` is cleared after daemon uploads result