### PR TITLE
feat: add image tagging support

### DIFF
--- a/alembic/versions/030_add_image_meta.py
+++ b/alembic/versions/030_add_image_meta.py
@@ -1,0 +1,33 @@
+"""Add image_meta table for image tags
+
+Revision ID: 030
+Revises: 029
+Create Date: 2026-06-03
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "030"
+down_revision = "029"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "image_meta",
+        sa.Column("path", sa.Text(), nullable=False),
+        sa.Column("tags", sa.Text(), nullable=True),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("path"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("image_meta")

--- a/app/models.py
+++ b/app/models.py
@@ -198,6 +198,14 @@ class Favorite(Base):
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
+class ImageMeta(Base):
+    __tablename__ = "image_meta"
+
+    path = mapped_column(Text, primary_key=True)
+    tags = mapped_column(Text, nullable=True)
+    updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+
 class Worker(Base):
     __tablename__ = "workers"
 

--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -12,7 +12,8 @@ from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_
 from app.config import settings
 from app.database import get_db
 from app.enums import JobStatus
-from app.models import Favorite, Job
+from app.models import Favorite, ImageMeta, Job
+from app.schemas.images import ImageTagsUpdate
 from app.s3 import (
     delete_object,
     download_bytes,
@@ -103,6 +104,7 @@ async def list_folder_images(
 
     paths = [f"s3://{bucket}/{obj['Key']}" for obj in objects if not obj["Key"].endswith("/.folder")]
     in_use_set: set[str] = set()
+    tags_map: dict[str, str] = {}
     if paths:
         result = await db.execute(
             select(Job.starting_image)
@@ -110,6 +112,13 @@ async def list_folder_images(
             .distinct()
         )
         in_use_set = {row[0] for row in result.all()}
+
+        meta_result = await db.execute(
+            select(ImageMeta.path, ImageMeta.tags).where(ImageMeta.path.in_(paths))
+        )
+        for row in meta_result.all():
+            if row[1]:
+                tags_map[row[0]] = row[1]
 
     return [
         {
@@ -119,6 +128,7 @@ async def list_folder_images(
             "size": obj["Size"],
             "last_modified": obj["LastModified"],
             "in_use": f"s3://{bucket}/{obj['Key']}" in in_use_set,
+            "tags": tags_map.get(f"s3://{bucket}/{obj['Key']}"),
         }
         for obj in objects
         if not obj["Key"].endswith("/.folder")
@@ -152,6 +162,17 @@ async def list_favorite_images(
         }
 
     items = await asyncio.gather(*[_meta(ref) for ref in refs])
+
+    uris = [item["path"] for item in items if item is not None]
+    if uris:
+        meta_result = await db.execute(
+            select(ImageMeta.path, ImageMeta.tags).where(ImageMeta.path.in_(uris))
+        )
+        tags_map = {row[0]: row[1] for row in meta_result.all() if row[1]}
+        for item in items:
+            if item is not None:
+                item["tags"] = tags_map.get(item["path"])
+
     return [item for item in items if item is not None]
 
 
@@ -184,6 +205,41 @@ async def delete_image(path: str = Query(...)):
         raise HTTPException(status_code=400, detail="Path must be in the images bucket")
     await asyncio.to_thread(delete_object, path)
     return {"ok": True}
+
+
+@router.patch("/images/tags", dependencies=[Depends(get_current_user)])
+async def update_image_tags(
+    path: str = Query(...),
+    body: ImageTagsUpdate = None,
+    db: AsyncSession = Depends(get_db),
+):
+    """Update tags for an image by S3 URI."""
+    bucket = settings.s3_images_bucket
+    if not path.startswith(f"s3://{bucket}/"):
+        raise HTTPException(status_code=400, detail="Path must be in the images bucket")
+
+    result = await db.execute(select(ImageMeta).where(ImageMeta.path == path))
+    meta = result.scalar_one_or_none()
+
+    if body and body.tags:
+        tags_val = body.tags.strip()
+        if not tags_val:
+            tags_val = None
+    else:
+        tags_val = None
+
+    if tags_val is None:
+        if meta:
+            await db.delete(meta)
+    else:
+        if meta:
+            meta.tags = tags_val
+        else:
+            meta = ImageMeta(path=path, tags=tags_val)
+            db.add(meta)
+
+    await db.commit()
+    return {"path": path, "tags": tags_val}
 
 
 _CONTENT_TYPES = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp"}

--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
@@ -240,6 +240,56 @@ async def update_image_tags(
 
     await db.commit()
     return {"path": path, "tags": tags_val}
+
+
+@router.get("/images/search", dependencies=[Depends(get_current_user)])
+async def search_images(
+    q: str = Query(..., min_length=1, max_length=500),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    user = Depends(get_current_user),
+):
+    """Search images across all folders by tags (case-insensitive partial match)."""
+    safe = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{safe}%"
+
+    count_q = select(func.count()).select_from(ImageMeta).where(
+        ImageMeta.tags.ilike(pattern, escape="\\")
+    )
+    total = (await db.execute(count_q)).scalar() or 0
+
+    meta_q = (
+        select(ImageMeta)
+        .where(ImageMeta.tags.ilike(pattern, escape="\\"))
+        .order_by(ImageMeta.updated_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    meta_rows = (await db.execute(meta_q)).scalars().all()
+
+    async def _meta(meta: ImageMeta) -> dict:
+        bucket = settings.s3_images_bucket
+        obj = await asyncio.to_thread(head_object, meta.path)
+        if not obj:
+            return None
+        key = obj["Key"]
+        return {
+            "key": key,
+            "path": meta.path,
+            "filename": key.split("/", 1)[1] if "/" in key else key,
+            "size": obj["Size"],
+            "last_modified": obj["LastModified"],
+            "tags": meta.tags,
+        }
+
+    items = []
+    for row in meta_rows:
+        item = await _meta(row)
+        if item:
+            items.append(item)
+
+    return {"items": items, "total": total, "limit": limit, "offset": offset}
 
 
 _CONTENT_TYPES = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp"}

--- a/app/schemas/images.py
+++ b/app/schemas/images.py
@@ -1,0 +1,7 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ImageTagsUpdate(BaseModel):
+    tags: Optional[str] = Field(None, max_length=500, description="Comma-separated tags")


### PR DESCRIPTION
## Overview
Adds tagging support for images, following the same pattern used for videos.

## Backend Changes
- **New `image_meta` table** with `path` (PK, S3 URI) and `tags` (Text) columns
- **Alembic migration 030** to create the table
- **`PATCH /images/tags?path=...`** endpoint to upsert or clear tags for an image by S3 URI
- **`tags` field** now included in `GET /images/folder/{date}` and `GET /images/favorites` responses
- New `ImageTagsUpdate` Pydantic schema

When tags are cleared (empty/null), the meta row is deleted to keep the table lean.

## Frontend Changes (separate PR in wanly-console)
- Adds `tags` field to `ImageFile` type
- Adds `updateImageTags()` API client function
- Tag editor UI (TextField + Chip array) in the image lightbox dialog with 500ms debounced saves