### PR TITLE
feat: accept tags in JobCreate and propagate to Video

### DIFF
--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -123,7 +123,7 @@ async def upload_segment_output(
     if len(active_segments) == 0:
         if segment.auto_finalize:
             job.status = JobStatus.FINALIZED
-            video_record = Video(job_id=job.id, status=VideoStatus.PENDING)
+            video_record = Video(job_id=job.id, status=VideoStatus.PENDING, tags=job.tags)
             db.add(video_record)
             await db.flush()
             background_tasks.add_task(stitch_video, video_record.id, job.id)

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -102,6 +102,7 @@ async def create_job(
         cfg_high=body.cfg_high,
         cfg_low=body.cfg_low,
         priority=next_priority,
+        tags=body.tags,
     )
     db.add(job)
     await db.flush()  # Get job.id
@@ -441,7 +442,7 @@ async def update_job(
             )
         job.status = body.status
         if body.status == JobStatus.FINALIZED:
-            video = Video(job_id=job.id, status=VideoStatus.PENDING)
+            video = Video(job_id=job.id, status=VideoStatus.PENDING, tags=job.tags)
             db.add(video)
             await db.flush()
             background_tasks.add_task(stitch_video, video.id, job.id)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -349,7 +349,7 @@ async def update_segment(
         if len(active_segments) == 0:
             if segment.auto_finalize and body.status == SegmentStatus.COMPLETED:
                 job.status = JobStatus.FINALIZED
-                video = Video(job_id=job.id, status=VideoStatus.PENDING)
+                video = Video(job_id=job.id, status=VideoStatus.PENDING, tags=job.tags)
                 db.add(video)
                 await db.flush()
                 background_tasks.add_task(stitch_video, video.id, job.id)

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -25,6 +25,7 @@ class JobCreate(BaseModel):
     starting_image_uri: Optional[str] = None
     starting_image_hash: Optional[str] = None
     first_segment: SegmentCreate
+    tags: Optional[str] = Field(None, max_length=500)
 
 
 class JobResponse(BaseModel):


### PR DESCRIPTION
Adds optional tags field to JobCreate and ensures tags flow from Job to Video.

- Add optional `tags` field to `JobCreate` Pydantic schema
- Set `job.tags` from `body.tags` in `POST /jobs` handler
- Copy `job.tags` to `video.tags` when creating Video records at all 3 creation sites (jobs.py, segments.py, files.py)