### PR TITLE
fix: restore migration 031 to unblock API deploys

### DIFF
--- a/alembic/versions/031_add_sampler_params_to_segment.py
+++ b/alembic/versions/031_add_sampler_params_to_segment.py
@@ -1,0 +1,35 @@
+"""Add sampler params (steps_total, high_noise_steps, shift_high, shift_low) to segments
+
+Revision ID: 031
+Revises: 030
+Create Date: 2026-06-26
+
+NOTE: This migration was applied to production (DB stamped at 031) as part of a
+sampler-params feature that was later reverted. The revert removed this file,
+which left every deploy unable to locate revision 031 (`alembic upgrade head`
+aborts). Restoring the file heals the chain: it is a no-op on prod (the columns
+already exist) and builds cleanly on a fresh DB. The columns are currently unused
+by the model/schema (the feature stays reverted); they are nullable and harmless.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "031"
+down_revision = "030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("steps_total", sa.Integer(), nullable=True))
+    op.add_column("segments", sa.Column("high_noise_steps", sa.Integer(), nullable=True))
+    op.add_column("segments", sa.Column("shift_high", sa.Float(), nullable=True))
+    op.add_column("segments", sa.Column("shift_low", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "shift_low")
+    op.drop_column("segments", "shift_high")
+    op.drop_column("segments", "high_noise_steps")
+    op.drop_column("segments", "steps_total")


### PR DESCRIPTION
Production deploys have been failing at `alembic upgrade head` with **Can't locate revision identified by '031'**.

**Cause:** migration 031 (sampler params on segments) was deployed (prod DB stamped `031`), then a `git revert` of the feature commit also deleted the migration file. The DB is ahead of the code, so alembic can't locate `031`.

**Fix:** restore only the migration file (revision 031, down_revision 030). No-op on prod (columns already exist); clean on fresh DBs. Feature code stays reverted; columns are nullable/unused. This also unblocks the `/images/untagged` deploy (#90).