### PR TITLE
feat: add REMIX to GenerationMode enum

### DIFF
--- a/app/enums.py
+++ b/app/enums.py
@@ -42,6 +42,7 @@ class GenerationMode(StrEnum):
     IDENTITY = "identity"      # Wan22 Base (Character Identity) — resident, ~16m
     EXPRESSION = "expression"  # Wan22 Base (Identity + Expression) — de-distill/offload, ~21m
     DASIWA = "dasiwa"          # DaSiWa (Fast) — distilled remix, ~13m, weaker identity
+    REMIX = "remix"            # Wan22 Remix (Enhanced Motions) — baked motion, 3090-only (not on RunPod)
 
     @classmethod
     def _missing_(cls, value):


### PR DESCRIPTION
Adds `REMIX = 'remix'` for the Wan22 Remix (Enhanced Motions) mode (documentation/consistency — mode is a free string end-to-end). Pairs with daemon #51 + console #197.