### PR TITLE
fix: delete_image leaves orphaned DB rows (dead references)

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
@@ -254,12 +254,16 @@ async def move_images(body: dict):
 
 
 @router.delete("/images", dependencies=[Depends(get_current_user)])
-async def delete_image(path: str = Query(...)):
-    """Delete a single image by S3 URI."""
+async def delete_image(path: str = Query(...), db: AsyncSession = Depends(get_db)):
+    """Delete a single image by S3 URI, plus its DB references (tags + favorites)
+    so it doesn't linger as a dead reference in Favorites/Untagged views."""
     bucket = settings.s3_images_bucket
     if not path.startswith(f"s3://{bucket}/"):
         raise HTTPException(status_code=400, detail="Path must be in the images bucket")
     await asyncio.to_thread(delete_object, path)
+    await db.execute(delete(ImageMeta).where(ImageMeta.path == path))
+    await db.execute(delete(Favorite).where(Favorite.item_type == "image", Favorite.item_ref == path))
+    await db.commit()
     return {"ok": True}
 
 


### PR DESCRIPTION
**Bug (David found it):** `DELETE /images` only deleted the S3 object — the `ImageMeta` row (tags) and any `Favorite` row (`item_ref=path`) were left behind, pointing at a now-gone object → **dead references** (worst in the DB-driven Favorites view; phantom 'tagged' paths elsewhere).

**Fix:** after `delete_object`, also `DELETE FROM image_meta WHERE path=…` and `DELETE FROM favorites WHERE item_type='image' AND item_ref=…`, then commit.

Note: the *Untagged* view lists live S3, so the dead refs there are likely S3 listing lag (clears on refresh) — but this fixes the persistent DB-orphan kind. A one-time cleanup of existing orphans can be run separately.