### PR TITLE
Final Cut: api layer (lineage, animate segment, route, claim gate)

### DIFF
--- a/alembic/versions/033_add_final_cut_columns.py
+++ b/alembic/versions/033_add_final_cut_columns.py
@@ -1,0 +1,45 @@
+"""Add Final Cut columns: jobs.kind + jobs.source_job_id, segments.animate_mode/preset
+
+Revision ID: 033
+Revises: 032
+Create Date: 2026-07-04
+
+Final Cut re-renders a job's finalized video through Wan Animate as a linked
+child job. A `final_cut` job carries `kind="final_cut"` and `source_job_id`
+pointing at its source (lineage, both directions). Its single segment uses
+`reprocess_type="animate"` and stores the Animate `animate_mode` (move/mix) and
+`animate_preset` (fast/highres). All columns are nullable / server-defaulted so
+existing rows backfill cleanly (kind -> 'generate').
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "033"
+down_revision = "032"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("kind", sa.String(length=20), nullable=False, server_default="generate"),
+    )
+    op.add_column("jobs", sa.Column("source_job_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_index("ix_jobs_source_job_id", "jobs", ["source_job_id"])
+    op.create_foreign_key(
+        "fk_jobs_source_job_id", "jobs", "jobs",
+        ["source_job_id"], ["id"], ondelete="SET NULL",
+    )
+    op.add_column("segments", sa.Column("animate_mode", sa.String(length=20), nullable=True))
+    op.add_column("segments", sa.Column("animate_preset", sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "animate_preset")
+    op.drop_column("segments", "animate_mode")
+    op.drop_constraint("fk_jobs_source_job_id", "jobs", type_="foreignkey")
+    op.drop_index("ix_jobs_source_job_id", table_name="jobs")
+    op.drop_column("jobs", "source_job_id")
+    op.drop_column("jobs", "kind")

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy import BigInteger, Boolean, DateTime, Float, ForeignKey, Index, Integer, JSON, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, backref, mapped_column, relationship
 
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 
@@ -42,6 +42,9 @@ class Job(Base):
     starting_image = mapped_column(Text, nullable=True)
     starting_image_hash = mapped_column(String(64), nullable=True, index=True)
     mode = mapped_column(String(20), nullable=False, default="identity", server_default="identity")
+    # Final Cut: a final_cut job re-renders source_job's finalized video through Wan Animate.
+    kind = mapped_column(String(20), nullable=False, default="generate", server_default="generate")
+    source_job_id = mapped_column(UUID(as_uuid=True), ForeignKey("jobs.id", ondelete="SET NULL"), nullable=True, index=True)
     priority = mapped_column(Integer, nullable=False, default=0)
     status = mapped_column(String(20), nullable=False, default=JobStatus.PENDING)
     tags = mapped_column(Text, nullable=True)
@@ -51,6 +54,8 @@ class Job(Base):
     user = relationship("User", back_populates="jobs")
     segments = relationship("Segment", back_populates="job", order_by="Segment.index", cascade="all, delete-orphan", passive_deletes=True)
     videos = relationship("Video", back_populates="job", cascade="all, delete-orphan", passive_deletes=True)
+    # Lineage: final_cuts = jobs derived from this one; source_job = the job a final_cut derives from.
+    final_cuts = relationship("Job", backref=backref("source_job", remote_side=[id]))
 
 
 class Segment(Base):
@@ -85,6 +90,9 @@ class Segment(Base):
     reference_frames = mapped_column(JSON, nullable=True)
     negative_prompt = mapped_column(Text, nullable=True)
     reprocess_type = mapped_column(String(20), nullable=True)
+    # Final Cut (reprocess_type="animate"): Wan Animate mode (move/mix) + preset (fast/highres).
+    animate_mode = mapped_column(String(20), nullable=True)
+    animate_preset = mapped_column(String(20), nullable=True)
     status = mapped_column(String(20), nullable=False, default=SegmentStatus.PENDING)
     worker_id = mapped_column(UUID(as_uuid=True), nullable=True)
     worker_name = mapped_column(String(255), nullable=True)

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -35,8 +35,9 @@ def _image_ext(filename: str | None) -> str:
 
 def _starting_image_key(user_id: UUID, image_hash: str, ext: str) -> str:
     return f"users/{user_id}/starting_images/{image_hash}{ext}"
-from app.schemas.jobs import JobCreate, JobDetailResponse, JobListResponse, JobReorderRequest, JobResponse, JobUpdate, StatsResponse, WorkerStatsItem
+from app.schemas.jobs import FinalCutCreate, FinalCutSummary, JobCreate, JobDetailResponse, JobListResponse, JobReorderRequest, JobResponse, JobUpdate, StatsResponse, WorkerStatsItem
 from app.schemas.segments import SegmentResponse
+from app.schemas.videos import VideoResponse
 from app.stitch import stitch_video
 
 import logging
@@ -379,6 +380,22 @@ async def get_job(
     else:
         seg_responses = [SegmentResponse.model_validate(s) for s in segments]
 
+    # Final Cut lineage: child jobs derived from this one, each with its finalized video.
+    fc_result = await db.execute(
+        select(Job)
+        .where(Job.source_job_id == job.id)
+        .options(selectinload(Job.videos))
+        .order_by(Job.created_at.asc())
+    )
+    final_cuts = []
+    for fc in fc_result.scalars().all():
+        fc_video = next((v for v in fc.videos if v.status == VideoStatus.COMPLETED and v.output_path), None)
+        final_cuts.append(FinalCutSummary(
+            id=fc.id, name=fc.name, kind=fc.kind, status=fc.status,
+            created_at=fc.created_at,
+            video=VideoResponse.model_validate(fc_video) if fc_video else None,
+        ))
+
     return JobDetailResponse(
         id=job.id,
         name=job.name,
@@ -388,6 +405,8 @@ async def get_job(
         seed=job.seed,
         starting_image=job.starting_image,
         mode=job.mode,
+        kind=job.kind,
+        source_job_id=job.source_job_id,
         priority=job.priority,
         status=job.status,
         tags=job.tags,
@@ -396,11 +415,96 @@ async def get_job(
         updated_at=job.updated_at,
         segments=seg_responses,
         videos=job.videos,
+        final_cuts=final_cuts,
         segment_count=len(segments),
         completed_segment_count=len(completed),
         total_run_time=total_run_time,
         total_video_time=total_video_time,
     )
+
+
+@router.post("/jobs/{job_id}/final-cut", response_model=JobResponse, status_code=status.HTTP_201_CREATED)
+async def create_final_cut(
+    job_id: UUID,
+    body: FinalCutCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Final Cut: re-render a job's finalized video through Wan Animate as a linked child job.
+
+    Driving video = the source job's finalized video (stored on the animate segment's output_path,
+    read by the daemon like a faceswap reprocess). Reference/character = an override or the source's
+    starting image. Enters the normal segment queue so nothing collides on the GPU.
+    """
+    result = await db.execute(
+        select(Job)
+        .where(Job.id == job_id, Job.user_id == user.id)
+        .options(selectinload(Job.videos), selectinload(Job.segments))
+    )
+    source = result.scalar_one_or_none()
+    if source is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    driving_video = next((v for v in source.videos if v.status == VideoStatus.COMPLETED and v.output_path), None)
+    if driving_video is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Source job has no finalized video to Final Cut")
+
+    reference = body.reference_image_uri or source.starting_image
+    if not reference:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No reference image — source job has no starting image; provide reference_image_uri",
+        )
+    if body.mode not in ("move", "mix"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="mode must be 'move' or 'mix'")
+    if body.preset not in ("fast", "highres"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="preset must be 'fast' or 'highres'")
+
+    resolved_loras = await _resolve_loras(db, body.loras)
+
+    # New jobs go to the bottom of the queue.
+    max_priority_result = await db.execute(
+        select(func.coalesce(func.max(Job.priority), -1)).where(Job.user_id == user.id)
+    )
+    next_priority = max_priority_result.scalar_one() + 1
+    fc_count = await db.execute(select(func.count()).select_from(Job).where(Job.source_job_id == source.id))
+    fc_num = fc_count.scalar_one() + 1
+
+    fc_job = Job(
+        user_id=user.id,
+        name=f"Final Cut {fc_num} — {source.name}"[:255],
+        width=source.width,
+        height=source.height,
+        fps=source.fps,
+        seed=source.seed,
+        mode=source.mode,
+        kind="final_cut",
+        source_job_id=source.id,
+        priority=next_priority,
+        starting_image=reference,
+        tags=source.tags,
+    )
+    db.add(fc_job)
+    await db.flush()
+
+    prompt = source.segments[0].prompt if source.segments else "natural realistic human motion, detailed face, cinematic lighting"
+    animate_segment = Segment(
+        job_id=fc_job.id,
+        index=0,
+        prompt=prompt,
+        duration_seconds=driving_video.duration_seconds or 5.0,
+        start_image=reference,                     # character reference for Animate
+        loras=resolved_loras,
+        output_path=driving_video.output_path,     # driving video (read by daemon like a reprocess input)
+        reprocess_type="animate",
+        animate_mode=body.mode,
+        animate_preset=body.preset,
+        auto_finalize=True,                        # single segment -> job finalizes -> Video on completion
+    )
+    db.add(animate_segment)
+    await db.commit()
+    await db.refresh(fc_job)
+    return fc_job
 
 
 @router.patch("/jobs/{job_id}", response_model=JobResponse)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -196,6 +196,7 @@ async def add_segment(
 async def claim_next_segment(
     worker_id: UUID = Query(...),
     worker_name: str = Query(None),
+    supports_animate: bool = Query(False, description="Worker has the Wan Animate stack (Final Cut)"),
     db: AsyncSession = Depends(get_db),
 ):
     # Reset stale segments: claimed/processing for > 30 minutes with no completion
@@ -214,11 +215,16 @@ async def claim_next_segment(
         stale.claimed_at = None
         stale.progress_log = None
 
-    result = await db.execute(
+    seg_query = (
         select(Segment)
         .join(Job, Segment.job_id == Job.id)
         .where(Segment.status == SegmentStatus.PENDING, Job.status.in_([JobStatus.PENDING, JobStatus.PROCESSING]))
-        .order_by(Job.priority.asc(), Segment.created_at.asc())
+    )
+    if not supports_animate:
+        # Only Animate-capable workers (Final Cut) may claim animate segments.
+        seg_query = seg_query.where(Segment.reprocess_type.is_distinct_from("animate"))
+    result = await db.execute(
+        seg_query.order_by(Job.priority.asc(), Segment.created_at.asc())
         .limit(1)
         .with_for_update(skip_locked=True)
     )

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -296,6 +296,8 @@ async def claim_next_segment(
         negative_prompt=negative_prompt,
         reprocess_type=segment.reprocess_type,
         output_path=segment.output_path,
+        animate_mode=segment.animate_mode,
+        animate_preset=segment.animate_preset,
         width=job.width,
         height=job.height,
         fps=job.fps,

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -34,6 +34,8 @@ class JobResponse(BaseModel):
     seed: int
     starting_image: Optional[str]
     mode: str = "identity"
+    kind: str = "generate"
+    source_job_id: Optional[UUID] = None
     priority: int
     status: str
     segment_count: int = 0
@@ -54,9 +56,28 @@ class JobListResponse(BaseModel):
     offset: int
 
 
+class FinalCutCreate(BaseModel):
+    mode: str = "mix"           # Wan Animate mode: "move" (regen scene) | "mix" (keep source scene)
+    preset: str = "fast"        # "fast" | "highres"
+    loras: Optional[list] = None  # optional character LoRA(s), same shape as segment loras ([{lora_id, low_weight}])
+    reference_image_uri: Optional[str] = None  # override reference; default = source job's starting_image
+
+
+class FinalCutSummary(BaseModel):
+    id: UUID
+    name: str
+    kind: str = "final_cut"
+    status: str
+    created_at: datetime
+    video: Optional[VideoResponse] = None
+
+    model_config = {"from_attributes": True}
+
+
 class JobDetailResponse(JobResponse):
     segments: list[SegmentResponse]
     videos: list[VideoResponse]
+    final_cuts: list[FinalCutSummary] = []
     segment_count: int
     completed_segment_count: int
     total_run_time: float

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -99,6 +99,8 @@ class SegmentClaimResponse(BaseModel):
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None
+    animate_mode: Optional[str] = None      # Final Cut: Wan Animate mode (move/mix)
+    animate_preset: Optional[str] = None    # Final Cut: preset (fast/highres)
     width: int
     height: int
     fps: int


### PR DESCRIPTION
Part of the Final Cut feature. Job.kind + source_job_id lineage (migration 033), POST /jobs/{id}/final-cut creating a linked final_cut job + one reprocess_type=animate segment, final_cuts on job detail, and a claim gate so only Animate-capable workers (the 3090) claim animate segments.