### PR TITLE
Draft/Driver generation mode (ultra-fast stage-1)

### DIFF
--- a/app/enums.py
+++ b/app/enums.py
@@ -43,6 +43,7 @@ class GenerationMode(StrEnum):
     EXPRESSION = "expression"  # Wan22 Base (Identity + Expression) — de-distill/offload, ~21m
     DASIWA = "dasiwa"          # DaSiWa (Fast) — distilled remix, ~13m, weaker identity
     REMIX = "remix"            # Wan22 Remix (Enhanced Motions) — baked motion, 3090-only (not on RunPod)
+    DRAFT = "draft"            # Draft/Driver — ultra-fast, motion-only; feed to Final Cut (Animate re-renders identity/face/scene)
 
     @classmethod
     def _missing_(cls, value):


### PR DESCRIPTION
New GenerationMode.DRAFT for the 2-stage pipeline: an ultra-fast, motion-only generation pass meant to feed Final Cut (Animate re-renders identity/face/scene). Pairs with the daemon preset (DaSiWa model, 6 steps) and console option (fps->16).