### PR TITLE
Final Cut: optional scene prompt

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -487,7 +487,7 @@ async def create_final_cut(
     db.add(fc_job)
     await db.flush()
 
-    prompt = source.segments[0].prompt if source.segments else "natural realistic human motion, detailed face, cinematic lighting"
+    prompt = body.prompt or (source.segments[0].prompt if source.segments else "natural realistic human motion, detailed face, cinematic lighting")
     animate_segment = Segment(
         job_id=fc_job.id,
         index=0,

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -61,6 +61,7 @@ class FinalCutCreate(BaseModel):
     preset: str = "fast"        # "fast" | "highres"
     loras: Optional[list] = None  # optional character LoRA(s), same shape as segment loras ([{lora_id, low_weight}])
     reference_image_uri: Optional[str] = None  # override reference; default = source job's starting_image
+    prompt: Optional[str] = None  # scene prompt (matters for move mode); default = source job's prompt
 
 
 class FinalCutSummary(BaseModel):


### PR DESCRIPTION
FinalCutCreate gains an optional prompt (matters for move mode — shapes the regenerated scene). Falls back to the source job's prompt when omitted.