### PR TITLE
Final Cut: Wan Animate → FaceFusion (API + migration)

### DIFF
--- a/alembic/versions/034_add_facefusion_columns.py
+++ b/alembic/versions/034_add_facefusion_columns.py
@@ -1,0 +1,33 @@
+"""Add FaceFusion Final Cut columns: segments.facefusion_face_index/distance
+
+Revision ID: 034
+Revises: 033
+Create Date: 2026-07-07
+
+Final Cut's stage-2 engine moves from Wan Animate to FaceFusion. A facefusion
+segment (reprocess_type="facefusion") stores which face to swap in a multi-person
+clip (facefusion_face_index, left-to-right) and an optional reference-face-distance
+override (facefusion_distance; NULL -> daemon auto: 1.0 single / 0.6 targeted).
+Both nullable / server-defaulted so existing rows backfill cleanly.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "034"
+down_revision = "033"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "segments",
+        sa.Column("facefusion_face_index", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column("segments", sa.Column("facefusion_distance", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "facefusion_distance")
+    op.drop_column("segments", "facefusion_face_index")

--- a/app/models.py
+++ b/app/models.py
@@ -93,6 +93,9 @@ class Segment(Base):
     # Final Cut (reprocess_type="animate"): Wan Animate mode (move/mix) + preset (fast/highres).
     animate_mode = mapped_column(String(20), nullable=True)
     animate_preset = mapped_column(String(20), nullable=True)
+    # Final Cut (reprocess_type="facefusion"): FaceFusion face-swap params.
+    facefusion_face_index = mapped_column(Integer, nullable=False, server_default="0")
+    facefusion_distance = mapped_column(Float, nullable=True)
     status = mapped_column(String(20), nullable=False, default=SegmentStatus.PENDING)
     worker_id = mapped_column(UUID(as_uuid=True), nullable=True)
     worker_name = mapped_column(String(255), nullable=True)

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -430,10 +430,10 @@ async def create_final_cut(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Final Cut: re-render a job's finalized video through Wan Animate as a linked child job.
+    """Final Cut: face-swap a character onto a job's finalized video via FaceFusion, as a linked child job.
 
-    Driving video = the source job's finalized video (stored on the animate segment's output_path,
-    read by the daemon like a faceswap reprocess). Reference/character = an override or the source's
+    Driving video = the source job's finalized video (stored on the facefusion segment's output_path,
+    read by the daemon like a faceswap reprocess). Reference face = an override or the source's
     starting image. Enters the normal segment queue so nothing collides on the GPU.
     """
     result = await db.execute(
@@ -455,12 +455,10 @@ async def create_final_cut(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No reference image — source job has no starting image; provide reference_image_uri",
         )
-    if body.mode not in ("move", "mix"):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="mode must be 'move' or 'mix'")
-    if body.preset not in ("fast", "highres"):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="preset must be 'fast' or 'highres'")
-
-    resolved_loras = await _resolve_loras(db, body.loras)
+    if body.face_index < 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="face_index must be >= 0")
+    if body.distance is not None and not (0.0 <= body.distance <= 1.5):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="distance must be between 0.0 and 1.5")
 
     # New jobs go to the bottom of the queue.
     max_priority_result = await db.execute(
@@ -487,21 +485,19 @@ async def create_final_cut(
     db.add(fc_job)
     await db.flush()
 
-    prompt = body.prompt or (source.segments[0].prompt if source.segments else "natural realistic human motion, detailed face, cinematic lighting")
-    animate_segment = Segment(
+    facefusion_segment = Segment(
         job_id=fc_job.id,
         index=0,
-        prompt=prompt,
+        prompt="",                                 # unused by FaceFusion (no generation step)
         duration_seconds=driving_video.duration_seconds or 5.0,
-        start_image=reference,                     # character reference for Animate
-        loras=resolved_loras,
+        start_image=reference,                     # the face to swap in
         output_path=driving_video.output_path,     # driving video (read by daemon like a reprocess input)
-        reprocess_type="animate",
-        animate_mode=body.mode,
-        animate_preset=body.preset,
+        reprocess_type="facefusion",
+        facefusion_face_index=body.face_index,
+        facefusion_distance=body.distance,
         auto_finalize=True,                        # single segment -> job finalizes -> Video on completion
     )
-    db.add(animate_segment)
+    db.add(facefusion_segment)
     await db.commit()
     await db.refresh(fc_job)
     return fc_job

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -196,7 +196,8 @@ async def add_segment(
 async def claim_next_segment(
     worker_id: UUID = Query(...),
     worker_name: str = Query(None),
-    supports_animate: bool = Query(False, description="Worker has the Wan Animate stack (Final Cut)"),
+    supports_animate: bool = Query(False, description="Worker has the Wan Animate stack (legacy Final Cut)"),
+    supports_facefusion: bool = Query(False, description="Worker has FaceFusion (Final Cut)"),
     db: AsyncSession = Depends(get_db),
 ):
     # Reset stale segments: claimed/processing for > 30 minutes with no completion
@@ -223,6 +224,9 @@ async def claim_next_segment(
     if not supports_animate:
         # Only Animate-capable workers (Final Cut) may claim animate segments.
         seg_query = seg_query.where(Segment.reprocess_type.is_distinct_from("animate"))
+    if not supports_facefusion:
+        # Only FaceFusion-capable workers (Final Cut) may claim facefusion segments.
+        seg_query = seg_query.where(Segment.reprocess_type.is_distinct_from("facefusion"))
     result = await db.execute(
         seg_query.order_by(Job.priority.asc(), Segment.created_at.asc())
         .limit(1)
@@ -304,6 +308,8 @@ async def claim_next_segment(
         output_path=segment.output_path,
         animate_mode=segment.animate_mode,
         animate_preset=segment.animate_preset,
+        facefusion_face_index=segment.facefusion_face_index,
+        facefusion_distance=segment.facefusion_distance,
         width=job.width,
         height=job.height,
         fps=job.fps,

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -57,11 +57,10 @@ class JobListResponse(BaseModel):
 
 
 class FinalCutCreate(BaseModel):
-    mode: str = "mix"           # Wan Animate mode: "move" (regen scene) | "mix" (keep source scene)
-    preset: str = "fast"        # "fast" | "highres"
-    loras: Optional[list] = None  # optional character LoRA(s), same shape as segment loras ([{lora_id, low_weight}])
-    reference_image_uri: Optional[str] = None  # override reference; default = source job's starting_image
-    prompt: Optional[str] = None  # scene prompt (matters for move mode); default = source job's prompt
+    # Final Cut now swaps a character's face onto the finalized video via FaceFusion.
+    reference_image_uri: Optional[str] = None  # face to swap in; default = source job's starting_image
+    face_index: int = 0          # which face to swap in a multi-person clip (0=first, left-to-right)
+    distance: Optional[float] = None  # FaceFusion reference-face-distance; None -> daemon auto
 
 
 class FinalCutSummary(BaseModel):

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -99,8 +99,10 @@ class SegmentClaimResponse(BaseModel):
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None
-    animate_mode: Optional[str] = None      # Final Cut: Wan Animate mode (move/mix)
-    animate_preset: Optional[str] = None    # Final Cut: preset (fast/highres)
+    animate_mode: Optional[str] = None      # Final Cut (legacy Animate): mode (move/mix)
+    animate_preset: Optional[str] = None    # Final Cut (legacy Animate): preset (fast/highres)
+    facefusion_face_index: int = 0          # Final Cut (FaceFusion): which face to swap, left-to-right
+    facefusion_distance: Optional[float] = None  # FaceFusion reference-face-distance; None -> auto
     width: int
     height: int
     fps: int


### PR DESCRIPTION
Final Cut API: Wan Animate → FaceFusion. **Part of a 3-PR feature** (daemon + console companions).

- **Migration 034** (chains on 033): `segments.facefusion_face_index` (int, default 0) + `facefusion_distance` (float, null). Backfills cleanly.
- `FinalCutCreate`: `{reference_image_uri, face_index, distance}` replace mode/preset/loras/prompt.
- `create_final_cut` builds a `reprocess_type='facefusion'` segment (start_image = face to swap in, output_path = driving video); validates face_index/distance.
- `/segments/next`: `supports_facefusion` query param + claim gate (facefusion segments only to FaceFusion-capable workers, mirroring the animate gate); claim response carries the new fields.
- Legacy animate path intact.

Requires `alembic upgrade head` on deploy. Not yet deployed.
