### PR TITLE
feat: sampler defaults in app settings (steps/high-noise/flow-shift)

### DIFF
--- a/app/routes/app_settings.py
+++ b/app/routes/app_settings.py
@@ -17,6 +17,9 @@ _DEFAULTS = {
     "cfg_low": "1",
     "lightx2v_strength_high": "2.0",
     "lightx2v_strength_low": "1.0",
+    "steps_total": "4",
+    "high_noise_steps": "2",
+    "flow_shift": "5",
     "negative_prompt": "",
 }
 
@@ -33,6 +36,9 @@ def _to_response(settings: dict[str, str]) -> AppSettingsResponse:
         cfg_low=float(settings["cfg_low"]),
         lightx2v_strength_high=float(settings["lightx2v_strength_high"]),
         lightx2v_strength_low=float(settings["lightx2v_strength_low"]),
+        steps_total=int(settings["steps_total"]),
+        high_noise_steps=int(settings["high_noise_steps"]),
+        flow_shift=float(settings["flow_shift"]),
         negative_prompt=settings["negative_prompt"],
     )
 

--- a/app/schemas/app_settings.py
+++ b/app/schemas/app_settings.py
@@ -8,6 +8,9 @@ class AppSettingsResponse(BaseModel):
     cfg_low: float
     lightx2v_strength_high: float
     lightx2v_strength_low: float
+    steps_total: int
+    high_noise_steps: int
+    flow_shift: float
     negative_prompt: str
 
 
@@ -16,4 +19,7 @@ class AppSettingsUpdate(BaseModel):
     cfg_low: Optional[float] = None
     lightx2v_strength_high: Optional[float] = None
     lightx2v_strength_low: Optional[float] = None
+    steps_total: Optional[int] = None
+    high_noise_steps: Optional[int] = None
+    flow_shift: Optional[float] = None
     negative_prompt: Optional[str] = None

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -15,6 +15,9 @@ class TestAppSettingsSchemas:
             cfg_low=1.0,
             lightx2v_strength_high=2.0,
             lightx2v_strength_low=1.0,
+            steps_total=4,
+            high_noise_steps=2,
+            flow_shift=5.0,
             negative_prompt="bad quality, blurry",
         )
         assert resp.negative_prompt == "bad quality, blurry"
@@ -71,6 +74,9 @@ class TestToResponse:
             "cfg_low": "1.0",
             "lightx2v_strength_high": "2.0",
             "lightx2v_strength_low": "1.0",
+            "steps_total": "4",
+            "high_noise_steps": "2",
+            "flow_shift": "5",
             "negative_prompt": "ugly, blurry",
         }
         resp = _to_response(settings)
@@ -85,6 +91,9 @@ class TestToResponse:
             "cfg_low": "1",
             "lightx2v_strength_high": "2.0",
             "lightx2v_strength_low": "1.0",
+            "steps_total": "4",
+            "high_noise_steps": "2",
+            "flow_shift": "5",
             "negative_prompt": "",
         }
         resp = _to_response(settings)


### PR DESCRIPTION
Adds steps_total, high_noise_steps, flow_shift to the key-value app settings (no migration). Backs the console Settings-page defaults for the new-job sampler params.