### PR TITLE
feat(jobs): config_starred flag + starred filter

### DIFF
--- a/alembic/versions/037_add_job_config_starred.py
+++ b/alembic/versions/037_add_job_config_starred.py
@@ -1,0 +1,28 @@
+"""Add jobs.config_starred
+
+Revision ID: 037
+Revises: 036
+Create Date: 2026-07-09
+
+Per-job bookmark flag: the user marks a job whose runtime config produced a good result
+as a "successful config" so it can be found later (Job Queue starred filter). Non-null,
+defaults false for existing rows.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "037"
+down_revision = "036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("config_starred", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "config_starred")

--- a/app/models.py
+++ b/app/models.py
@@ -49,6 +49,7 @@ class Job(Base):
     high_noise_steps = mapped_column(Integer, nullable=True)
     flow_shift = mapped_column(Float, nullable=True)
     priority = mapped_column(Integer, nullable=False, default=0)
+    config_starred = mapped_column(Boolean, nullable=False, default=False)
     status = mapped_column(String(20), nullable=False, default=JobStatus.PENDING)
     tags = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -191,10 +191,13 @@ async def list_jobs(
     sort: str = Query("created_at_desc"),
     name: str | None = Query(None, min_length=1, max_length=255, description="Filter jobs by name (case-insensitive partial match)"),
     search: str | None = Query(None, min_length=1, max_length=255, alias="q", description="Search jobs by name or tags (case-insensitive partial match)"),
+    starred: bool | None = Query(None, description="Only jobs flagged as successful configs"),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     base = select(Job).where(Job.user_id == user.id)
+    if starred:
+        base = base.where(Job.config_starred.is_(True))
     if name:
         safe = name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         base = base.where(Job.name.ilike(f"%{safe}%", escape="\\"))
@@ -210,7 +213,9 @@ async def list_jobs(
     if status_filter:
         statuses = [s.strip() for s in status_filter.split(",") if s.strip()]
         base = base.where(Job.status.in_(statuses))
-    else:
+    elif not starred:
+        # Starred = "successful configs" and those are usually finalized jobs, so the
+        # star filter must see all statuses; only hide finalized/archived otherwise.
         base = base.where(Job.status.notin_([JobStatus.FINALIZED, JobStatus.FINALIZING, JobStatus.ARCHIVED]))
 
     total_result = await db.execute(select(func.count()).select_from(base.subquery()))
@@ -441,6 +446,9 @@ async def update_job(
 
     if body.tags is not None:
         job.tags = body.tags
+
+    if body.config_starred is not None:
+        job.config_starred = body.config_starred
 
     if body.status is not None:
         allowed = JOB_VALID_TRANSITIONS.get(job.status, set())

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -47,6 +47,7 @@ class JobResponse(BaseModel):
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
     priority: int
+    config_starred: bool = False
     status: str
     segment_count: int = 0
     completed_segment_count: int = 0
@@ -79,6 +80,7 @@ class JobUpdate(BaseModel):
     name: Optional[str] = None
     status: Optional[str] = None
     tags: Optional[str] = Field(None, max_length=500, description="Comma-separated tags")
+    config_starred: Optional[bool] = Field(None, description="Flag this job's config as a successful one")
 
 
 class WorkerStatsItem(BaseModel):


### PR DESCRIPTION
Backs the 'Successful Configs' feature. Users flag a job whose config worked; the dedicated console page lists them.

- `jobs.config_starred` boolean, migration **037** (server_default false)
- `JobResponse.config_starred`, settable via `PATCH /jobs/{id}` (`JobUpdate.config_starred`)
- `GET /jobs?starred=true` filter — **bypasses** the default finalized/archived exclusion so finalized winners still appear

34 job tests pass. **Requires `alembic upgrade head` on deploy.**