### PR TITLE
feat(jobs): include LoRA summary (with weights) in job list

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -258,6 +258,53 @@ async def list_jobs(
         for row in faceswap_result.all():
             faceswap_map[row[0]] = bool(row[1])
 
+    # Aggregate distinct LoRAs (with weights) per job from its segment configs, resolving names.
+    loras_map: dict[UUID, list[dict]] = {}
+    if job_ids:
+        seg_loras_result = await db.execute(
+            select(Segment.job_id, Segment.loras)
+            .where(Segment.job_id.in_(job_ids), Segment.loras.isnot(None))
+        )
+        raw_buckets: dict[UUID, dict] = {}
+        referenced_ids: set[UUID] = set()
+        for seg_job_id, seg_loras in seg_loras_result.all():
+            if not seg_loras:
+                continue
+            bucket = raw_buckets.setdefault(seg_job_id, {})
+            for lora in seg_loras:
+                key = (
+                    lora.get("lora_id"),
+                    lora.get("high_file"),
+                    lora.get("low_file"),
+                    lora.get("high_weight"),
+                    lora.get("low_weight"),
+                )
+                bucket[key] = lora
+                lid = lora.get("lora_id")
+                if lid:
+                    try:
+                        referenced_ids.add(UUID(str(lid)))
+                    except (ValueError, TypeError):
+                        pass
+        name_map: dict[str, str] = {}
+        if referenced_ids:
+            name_result = await db.execute(
+                select(Lora.id, Lora.name).where(Lora.id.in_(referenced_ids))
+            )
+            name_map = {str(r[0]): r[1] for r in name_result.all()}
+        for seg_job_id, bucket in raw_buckets.items():
+            loras_map[seg_job_id] = [
+                {
+                    "lora_id": lora.get("lora_id"),
+                    "name": name_map.get(str(lora.get("lora_id"))),
+                    "high_file": lora.get("high_file"),
+                    "low_file": lora.get("low_file"),
+                    "high_weight": lora.get("high_weight"),
+                    "low_weight": lora.get("low_weight"),
+                }
+                for lora in bucket.values()
+            ]
+
     # Fetch active segment info for estimation
     active_statuses = {SegmentStatus.PENDING, SegmentStatus.CLAIMED, SegmentStatus.PROCESSING}
     active_jobs = [j for j in items if j.status in (JobStatus.PENDING, JobStatus.PROCESSING)]
@@ -308,11 +355,13 @@ async def list_jobs(
                 high_noise_steps=j.high_noise_steps,
                 flow_shift=j.flow_shift,
                 priority=j.priority,
+                config_starred=j.config_starred,
                 status=j.status,
                 segment_count=seg_total,
                 completed_segment_count=seg_completed,
                 estimated_run_time=est_map.get(j.id),
                 faceswap_enabled=faceswap_map.get(j.id, False),
+                loras=loras_map.get(j.id, []),
                 tags=j.tags,
                 created_at=j.created_at,
                 updated_at=j.updated_at,
@@ -412,6 +461,7 @@ async def get_job(
         high_noise_steps=job.high_noise_steps,
         flow_shift=job.flow_shift,
         priority=job.priority,
+        config_starred=job.config_starred,
         status=job.status,
         tags=job.tags,
         estimated_run_time=job_est,

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -31,6 +31,15 @@ class JobCreate(BaseModel):
     tags: Optional[str] = Field(None, max_length=500)
 
 
+class JobLoraSummary(BaseModel):
+    lora_id: Optional[str] = None
+    name: Optional[str] = None
+    high_file: Optional[str] = None
+    low_file: Optional[str] = None
+    high_weight: Optional[float] = None
+    low_weight: Optional[float] = None
+
+
 class JobResponse(BaseModel):
     id: UUID
     name: str
@@ -53,6 +62,7 @@ class JobResponse(BaseModel):
     completed_segment_count: int = 0
     estimated_run_time: Optional[float] = None
     faceswap_enabled: bool = False
+    loras: list[JobLoraSummary] = []
     tags: Optional[str] = None
     created_at: datetime
     updated_at: datetime


### PR DESCRIPTION
Follow-up to #104. The Successful Configs page needs LoRAs + weights, but those live in per-segment JSON.

- `JobResponse.loras`: distinct LoRAs aggregated across a job's segments (lora_id, name, high/low file, high/low weight), names resolved from the loras table
- **Bug fix:** `list_jobs` and `get_job` build `JobResponse`/`JobDetailResponse` explicitly and never set `config_starred` — so the flag always read false outside the DB filter. Now set in both.

34 job tests pass.