### PR TITLE
feat(vace): continuation_mode flag + claim resolution (PR 1, default off)

### DIFF
--- a/alembic/versions/038_add_job_continuation_mode.py
+++ b/alembic/versions/038_add_job_continuation_mode.py
@@ -1,0 +1,25 @@
+"""Add jobs.continuation_mode
+
+Revision ID: 038
+Revises: 037
+Create Date: 2026-07-11
+
+Per-job override for segment continuation strategy ("traditional" | "vace").
+NULL falls back to the global continuation_mode app setting. Part of the VACE
+continuation integration (default off).
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "038"
+down_revision = "037"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("continuation_mode", sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "continuation_mode")

--- a/app/models.py
+++ b/app/models.py
@@ -50,6 +50,8 @@ class Job(Base):
     flow_shift = mapped_column(Float, nullable=True)
     priority = mapped_column(Integer, nullable=False, default=0)
     config_starred = mapped_column(Boolean, nullable=False, default=False)
+    # Per-job continuation-mode override ("traditional"|"vace"); NULL -> global app setting.
+    continuation_mode = mapped_column(String(20), nullable=True)
     status = mapped_column(String(20), nullable=False, default=JobStatus.PENDING)
     tags = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))

--- a/app/routes/app_settings.py
+++ b/app/routes/app_settings.py
@@ -21,6 +21,8 @@ _DEFAULTS = {
     "high_noise_steps": "2",
     "flow_shift": "5",
     "negative_prompt": "",
+    "continuation_mode": "traditional",
+    "vace_overlap_frames": "12",
 }
 
 
@@ -40,6 +42,8 @@ def _to_response(settings: dict[str, str]) -> AppSettingsResponse:
         high_noise_steps=int(settings["high_noise_steps"]),
         flow_shift=float(settings["flow_shift"]),
         negative_prompt=settings["negative_prompt"],
+        continuation_mode=settings.get("continuation_mode", "traditional"),
+        vace_overlap_frames=int(settings.get("vace_overlap_frames", "12")),
     )
 
 

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -269,6 +269,18 @@ async def claim_next_segment(
         neg_setting = await db.get(AppSetting, "negative_prompt")
         negative_prompt = neg_setting.value if neg_setting else None
 
+    # Resolve continuation mode API-side (VACE vs traditional). seg0 is always i2v;
+    # VACE requires index>0 + the previous segment's video. The daemon falls back to
+    # traditional if it isn't VACE-capable, so flipping this is safe.
+    mode_setting = await db.get(AppSetting, "continuation_mode")
+    global_mode = mode_setting.value if mode_setting else "traditional"
+    overlap_setting = await db.get(AppSetting, "vace_overlap_frames")
+    vace_overlap = int(overlap_setting.value) if overlap_setting else 12
+    effective_mode = job.continuation_mode or global_mode
+    prev_output_path = previous_segment.output_path if previous_segment else None
+    use_vace = effective_mode == "vace" and segment.index > 0 and prev_output_path is not None
+    continuation_mode = "vace" if use_vace else "traditional"
+
     await db.commit()
     await db.refresh(segment)
 
@@ -306,6 +318,9 @@ async def claim_next_segment(
         height=job.height,
         fps=job.fps,
         seed=job.seed,
+        continuation_mode=continuation_mode,
+        previous_output_path=prev_output_path if use_vace else None,
+        vace_overlap_frames=vace_overlap,
     )
 
 

--- a/app/schemas/app_settings.py
+++ b/app/schemas/app_settings.py
@@ -12,6 +12,10 @@ class AppSettingsResponse(BaseModel):
     high_noise_steps: int
     flow_shift: float
     negative_prompt: str
+    # Segment continuation strategy: "traditional" (last-frame i2v handoff, current)
+    # or "vace" (video-conditioned continuation). vace_overlap_frames = kept tail length.
+    continuation_mode: str = "traditional"
+    vace_overlap_frames: int = 12
 
 
 class AppSettingsUpdate(BaseModel):
@@ -23,3 +27,5 @@ class AppSettingsUpdate(BaseModel):
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
     negative_prompt: Optional[str] = None
+    continuation_mode: Optional[str] = None
+    vace_overlap_frames: Optional[int] = None

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -109,6 +109,11 @@ class SegmentClaimResponse(BaseModel):
     height: int
     fps: int
     seed: int
+    # Continuation strategy for THIS segment, resolved API-side. "vace" only for
+    # index>0 when enabled + the previous segment's video is available; else "traditional".
+    continuation_mode: str = "traditional"
+    previous_output_path: Optional[str] = None  # prev segment video (VACE control source)
+    vace_overlap_frames: int = 12
 
     model_config = {"from_attributes": True}
 


### PR DESCRIPTION
**PR 1 of 3** for VACE continuation integration — additive and **dormant** (nothing generates VACE until the daemon path lands).

- `continuation_mode` (traditional|vace) + `vace_overlap_frames` app settings — the single backend toggle
- `Job.continuation_mode` nullable per-job override (migration **038**)
- Segment claim resolves effective mode API-side (`job override ?? global setting`, seg0 always i2v, only when prev video exists) and returns `continuation_mode`, `previous_output_path`, `vace_overlap_frames`

Safe by construction: default traditional, resolved per-segment, daemon falls back if not VACE-capable. Requires `alembic upgrade head`. 89 tests pass.