### PR TITLE
fix: trim VACE overlap in stitch instead of daemon (removes seam hitch)

### DIFF
--- a/alembic/versions/039_add_segment_vace_overlap_seconds.py
+++ b/alembic/versions/039_add_segment_vace_overlap_seconds.py
@@ -1,0 +1,26 @@
+"""Add segments.vace_overlap_seconds
+
+Revision ID: 039
+Revises: 038
+Create Date: 2026-07-12
+
+Length (seconds) of the reconstructed lead-in a VACE-continuation segment carries.
+Stitch trims this off the previous segment's tail so the reconstruction replaces it
+seamlessly. NULL for traditional (non-VACE) segments. Part of the VACE seam fix
+(moving the overlap trim out of the daemon and into stitch).
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "039"
+down_revision = "038"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("vace_overlap_seconds", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "vace_overlap_seconds")

--- a/app/models.py
+++ b/app/models.py
@@ -91,6 +91,10 @@ class Segment(Base):
     trim_end_frames = mapped_column(Integer, nullable=False, default=0)
     motion_keywords = mapped_column(JSON, nullable=True)
     motion_magnitude = mapped_column(Float, nullable=True)
+    # Length (seconds) of the reconstructed lead-in a VACE-continuation segment carries.
+    # Stitch trims this off the previous segment's tail so the reconstruction replaces it
+    # seamlessly. NULL for traditional (non-VACE) segments.
+    vace_overlap_seconds = mapped_column(Float, nullable=True)
     reference_frames = mapped_column(JSON, nullable=True)
     negative_prompt = mapped_column(Text, nullable=True)
     reprocess_type = mapped_column(String(20), nullable=True)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -351,6 +351,8 @@ async def update_segment(
         segment.motion_keywords = body.motion_keywords
     if body.motion_magnitude is not None:
         segment.motion_magnitude = body.motion_magnitude
+    if body.vace_overlap_seconds is not None:
+        segment.vace_overlap_seconds = body.vace_overlap_seconds
 
     await db.flush()
 

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -151,3 +151,4 @@ class SegmentStatusUpdate(BaseModel):
     progress_log: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
+    vace_overlap_seconds: Optional[float] = None

--- a/app/stitch.py
+++ b/app/stitch.py
@@ -198,10 +198,22 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                     await asyncio.to_thread(download_file, seg.output_path, str(local_path))
                     local_files.append(local_name)
 
-                # Trim pass: apply trim to segments with non-zero trim values
+                # Trim pass: apply trim to segments with non-zero trim values.
                 durations = [seg.duration_seconds for seg in segments]
+                # VACE overlap: a continuation segment carries a reconstructed lead-in
+                # (vace_overlap_seconds) that re-creates the previous segment's tail. Trim
+                # that tail off the *previous* segment so the reconstruction replaces it —
+                # consecutive frames across the seam, rather than jumping to the first
+                # generated frame (which drifts slightly and reads as a hitch).
+                extra_end_trim = [0] * len(segments)
                 for i, seg in enumerate(segments):
-                    if seg.trim_start_frames > 0 or seg.trim_end_frames > 0:
+                    overlap = seg.vace_overlap_seconds
+                    if overlap and i > 0:
+                        extra_end_trim[i - 1] += round(overlap * job.fps)
+                        durations[i] += overlap  # actual output = intended + reconstructed lead-in
+                for i, seg in enumerate(segments):
+                    end_trim = seg.trim_end_frames + extra_end_trim[i]
+                    if seg.trim_start_frames > 0 or end_trim > 0:
                         trimmed_name = f"seg_{seg.index:03d}_trimmed.mp4"
                         new_dur = await asyncio.to_thread(
                             _apply_trim,
@@ -209,7 +221,7 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                             str(tmppath / trimmed_name),
                             job.fps,
                             seg.trim_start_frames,
-                            seg.trim_end_frames,
+                            end_trim,
                         )
                         local_files[i] = trimmed_name
                         durations[i] = new_dur


### PR DESCRIPTION
Pairs with wanly-gpu-daemon #69.

**Problem:** the VACE seam had a ~5x frame-diff spike (measured 11-18 vs ~2-3 within-segment) — a boundary hitch, masked by big motion but obvious in low-motion scenes. Cause: the daemon trimmed VACE's reconstructed lead-in and started the segment at the first *generated* frame, which follows the reconstruction (drifted from the previous segment's actual tail), not the tail itself.

**Fix:** the daemon now keeps the full reconstruction+generation and reports `vace_overlap_seconds`. Stitch trims that off the *previous* segment's tail so the reconstruction replaces it (consecutive frames = seamless).

- `segments.vace_overlap_seconds` column + migration 039
- `SegmentStatusUpdate` + PATCH `/segments/{id}` accept & store it
- stitch trim pass: extra end-trim on the previous segment per VACE overlap; duration bookkeeping adjusted
- 89 tests pass