### PR TITLE
feat: AR hologram API (Tier-0) — Make Hologram trigger + upload

### DIFF
--- a/alembic/versions/040_add_segment_hologram.py
+++ b/alembic/versions/040_add_segment_hologram.py
@@ -1,0 +1,35 @@
+"""Add segments hologram columns
+
+Revision ID: 040
+Revises: 039
+Create Date: 2026-07-12
+
+AR hologram (Tier-0) support. A finalized job's index-0 segment is reused as the
+queue carrier for a `reprocess_type="ar_hologram"` job: two resolved params
+(key color, subject height) drive the daemon matte + manifest, and three output
+paths hold the packed color+alpha mp4, the hologram.json manifest, and a
+transparent poster PNG. All nullable — traditional segments are unaffected.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "040"
+down_revision = "039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("hologram_key_color", sa.String(length=20), nullable=True))
+    op.add_column("segments", sa.Column("hologram_subject_height_m", sa.Float(), nullable=True))
+    op.add_column("segments", sa.Column("hologram_video_path", sa.Text(), nullable=True))
+    op.add_column("segments", sa.Column("hologram_manifest_path", sa.Text(), nullable=True))
+    op.add_column("segments", sa.Column("hologram_poster_path", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "hologram_poster_path")
+    op.drop_column("segments", "hologram_manifest_path")
+    op.drop_column("segments", "hologram_video_path")
+    op.drop_column("segments", "hologram_subject_height_m")
+    op.drop_column("segments", "hologram_key_color")

--- a/app/models.py
+++ b/app/models.py
@@ -95,6 +95,14 @@ class Segment(Base):
     # Stitch trims this off the previous segment's tail so the reconstruction replaces it
     # seamlessly. NULL for traditional (non-VACE) segments.
     vace_overlap_seconds = mapped_column(Float, nullable=True)
+    # AR hologram (Tier-0). When a finalized job's index-0 segment is reused as the carrier
+    # for reprocess_type="ar_hologram": the two params drive the daemon matte + manifest, the
+    # three paths hold the packed color+alpha mp4, the hologram.json manifest, and the poster.
+    hologram_key_color = mapped_column(String(20), nullable=True)
+    hologram_subject_height_m = mapped_column(Float, nullable=True)
+    hologram_video_path = mapped_column(Text, nullable=True)
+    hologram_manifest_path = mapped_column(Text, nullable=True)
+    hologram_poster_path = mapped_column(Text, nullable=True)
     reference_frames = mapped_column(JSON, nullable=True)
     negative_prompt = mapped_column(Text, nullable=True)
     reprocess_type = mapped_column(String(20), nullable=True)

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -133,3 +133,58 @@ async def upload_segment_output(
     await db.commit()
     await db.refresh(segment)
     return segment
+
+
+@router.post(
+    "/segments/{segment_id}/hologram_upload",
+    response_model=SegmentResponse,
+    dependencies=[Depends(verify_api_key)],
+)
+async def upload_hologram_output(
+    segment_id: UUID,
+    video: UploadFile = File(...),
+    manifest: UploadFile = File(...),
+    poster: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+):
+    """Upload AR hologram artifacts (packed color+alpha mp4 + manifest + poster).
+
+    Called by the daemon after an ar_hologram carrier segment completes. Stores the three
+    artifacts on the segment's hologram_* columns, preserves the carrier's own
+    output/last_frame, and does NOT re-stitch — the job just returns to FINALIZED.
+    """
+    segment = await db.get(Segment, segment_id)
+    if segment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Segment not found")
+
+    video_data = await video.read()
+    manifest_data = await manifest.read()
+    poster_data = await poster.read()
+
+    video_key = f"{segment.job_id}/{segment.index}_hologram.mp4"
+    manifest_key = f"{segment.job_id}/{segment.index}_hologram.json"
+    poster_key = f"{segment.job_id}/{segment.index}_hologram_poster.png"
+
+    video_uri, manifest_uri, poster_uri = await asyncio.gather(
+        asyncio.to_thread(upload_bytes, video_data, video_key, settings.s3_jobs_bucket),
+        asyncio.to_thread(upload_bytes, manifest_data, manifest_key, settings.s3_jobs_bucket),
+        asyncio.to_thread(upload_bytes, poster_data, poster_key, settings.s3_jobs_bucket),
+    )
+
+    segment.hologram_video_path = video_uri
+    segment.hologram_manifest_path = manifest_uri
+    segment.hologram_poster_path = poster_uri
+    segment.status = SegmentStatus.COMPLETED
+    segment.reprocess_type = None
+
+    from datetime import datetime, timezone
+
+    segment.completed_at = datetime.now(timezone.utc)
+
+    # Holograms only run on already-finalized jobs; restore that status, no re-stitch.
+    job = await db.get(Job, segment.job_id)
+    job.status = JobStatus.FINALIZED
+
+    await db.commit()
+    await db.refresh(segment)
+    return segment

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -733,6 +733,28 @@ async def make_hologram(
     return carrier
 
 
+@router.get("/segments/{segment_id}/hologram")
+async def get_hologram(
+    segment_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return a segment's hologram artifact S3 paths (for the WebXR AR player)."""
+    result = await db.execute(
+        select(Segment)
+        .join(Job, Segment.job_id == Job.id)
+        .where(Segment.id == segment_id, Job.user_id == user.id)
+    )
+    segment = result.scalar_one_or_none()
+    if segment is None or not segment.hologram_video_path:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Hologram not found")
+    return {
+        "video_path": segment.hologram_video_path,
+        "manifest_path": segment.hologram_manifest_path,
+        "poster_path": segment.hologram_poster_path,
+    }
+
+
 @router.post("/segments/{segment_id}/cancel", response_model=SegmentResponse)
 async def cancel_segment(
     segment_id: UUID,

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -24,6 +24,7 @@ from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
     FramePreview,
     FramePreviewResponse,
+    HologramRequest,
     SegmentClaimResponse,
     SegmentCreate,
     SegmentReprocessRequest,
@@ -281,6 +282,19 @@ async def claim_next_segment(
     use_vace = effective_mode == "vace" and segment.index > 0 and prev_output_path is not None
     continuation_mode = "vace" if use_vace else "traditional"
 
+    # AR hologram carrier: the source is the job's finalized stitched video, not this
+    # segment's own output. The daemon mattes/packs it into a color+alpha hologram.
+    hologram_source_path = None
+    if segment.reprocess_type == "ar_hologram":
+        holo_video = (
+            await db.execute(
+                select(Video)
+                .where(Video.job_id == job.id, Video.status == VideoStatus.COMPLETED)
+                .order_by(Video.created_at.desc())
+            )
+        ).scalars().first()
+        hologram_source_path = holo_video.output_path if holo_video else None
+
     await db.commit()
     await db.refresh(segment)
 
@@ -321,6 +335,9 @@ async def claim_next_segment(
         continuation_mode=continuation_mode,
         previous_output_path=prev_output_path if use_vace else None,
         vace_overlap_frames=vace_overlap,
+        hologram_source_path=hologram_source_path,
+        hologram_key_color=segment.hologram_key_color,
+        hologram_subject_height_m=segment.hologram_subject_height_m,
     )
 
 
@@ -642,6 +659,78 @@ async def reprocess_segment(
     await db.commit()
     await db.refresh(segment)
     return segment
+
+
+@router.post("/jobs/{job_id}/hologram", response_model=SegmentResponse)
+async def make_hologram(
+    job_id: UUID,
+    body: HologramRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create an AR hologram from a finalized job's stitched video.
+
+    Reuses the reprocess queue: the job's lowest-index segment becomes the carrier
+    (reprocess_type="ar_hologram"); the daemon mattes the job's final video into a packed
+    color+alpha hologram + manifest + poster. The carrier's own output is preserved.
+    """
+    job = await db.get(Job, job_id)
+    if job is None or job.user_id != user.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    if job.status != JobStatus.FINALIZED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Only finalized jobs can be turned into holograms (current: '{job.status}')",
+        )
+
+    holo_video = (
+        await db.execute(
+            select(Video)
+            .where(Video.job_id == job.id, Video.status == VideoStatus.COMPLETED)
+            .order_by(Video.created_at.desc())
+        )
+    ).scalars().first()
+    if holo_video is None or not holo_video.output_path:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Job has no finalized video to source the hologram from",
+        )
+
+    carrier = (
+        await db.execute(
+            select(Segment).where(Segment.job_id == job.id).order_by(Segment.index.asc())
+        )
+    ).scalars().first()
+    if carrier is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Job has no segments")
+
+    # Resolve params: request override -> AppSetting global -> hardcoded default.
+    key_setting = await db.get(AppSetting, "hologram_key_color")
+    key_color = body.key_color or (key_setting.value if key_setting else None) or "0x00b140"
+    height_setting = await db.get(AppSetting, "hologram_subject_height_m")
+    subject_height = (
+        body.subject_height_m
+        if body.subject_height_m is not None
+        else (float(height_setting.value) if height_setting else 1.70)
+    )
+
+    carrier.hologram_key_color = key_color
+    carrier.hologram_subject_height_m = subject_height
+    # Reuse the carrier as the ar_hologram queue item (preserve its own output/last_frame).
+    carrier.reprocess_type = "ar_hologram"
+    carrier.status = SegmentStatus.PENDING
+    carrier.worker_id = None
+    carrier.worker_name = None
+    carrier.claimed_at = None
+    carrier.completed_at = None
+    carrier.error_message = None
+    carrier.progress_log = None
+
+    job.status = JobStatus.PENDING
+
+    await db.commit()
+    await db.refresh(carrier)
+    return carrier
 
 
 @router.post("/segments/{segment_id}/cancel", response_model=SegmentResponse)

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -51,6 +51,9 @@ class SegmentResponse(BaseModel):
     worker_name: Optional[str]
     output_path: Optional[str]
     last_frame_path: Optional[str]
+    hologram_video_path: Optional[str] = None
+    hologram_manifest_path: Optional[str] = None
+    hologram_poster_path: Optional[str] = None
     created_at: datetime
     claimed_at: Optional[datetime]
     completed_at: Optional[datetime]
@@ -114,6 +117,11 @@ class SegmentClaimResponse(BaseModel):
     continuation_mode: str = "traditional"
     previous_output_path: Optional[str] = None  # prev segment video (VACE control source)
     vace_overlap_frames: int = 12
+    # AR hologram (reprocess_type="ar_hologram"): the source is the job's finalized stitched
+    # video (not this carrier segment's own output); params drive the daemon matte + manifest.
+    hologram_source_path: Optional[str] = None
+    hologram_key_color: Optional[str] = None
+    hologram_subject_height_m: Optional[float] = None
 
     model_config = {"from_attributes": True}
 
@@ -141,6 +149,13 @@ class SegmentReprocessRequest(BaseModel):
     faceswap_image: Optional[str] = None
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
+
+
+class HologramRequest(BaseModel):
+    """Per-request overrides for a 'Make Hologram' action. Unset -> AppSetting -> hardcoded default."""
+
+    subject_height_m: Optional[float] = None
+    key_color: Optional[str] = None
 
 
 class SegmentStatusUpdate(BaseModel):


### PR DESCRIPTION
First slice of the personal AR-hologram feature (plan: place a finalized clip's subject in the room on Quest 3). API only; daemon + console PRs follow.

Reuses the `reprocess_type` queue rather than adding a new engine/model:
- **Trigger** `POST /jobs/{id}/hologram` — mirrors `reprocess_segment`; marks the job's lowest-index segment `reprocess_type="ar_hologram"` (carrier), stores resolved params, re-queues the job. Source is derived at claim time from the job's finalized `Video` (handles multi-segment clips).
- **Claim** returns `hologram_source_path` + `hologram_key_color` + `hologram_subject_height_m`.
- **Upload** `POST /segments/{id}/hologram_upload` — stores packed mp4 + manifest + poster on 5 new nullable columns; preserves the carrier's own output; **no re-stitch** (job returns to FINALIZED).
- **migration 040**; params resolve request → AppSetting → default.

89 tests pass. Single-user tool, so no multi-tenant/coverage scaffolding.