### PR TITLE
feat: expose reprocess_type in SegmentResponse

### DIFF
--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -47,6 +47,7 @@ class SegmentResponse(BaseModel):
     motion_magnitude: Optional[float] = None
     reference_frames: Optional[list[str]] = None
     status: str
+    reprocess_type: Optional[str] = None
     worker_id: Optional[UUID]
     worker_name: Optional[str]
     output_path: Optional[str]


### PR DESCRIPTION
Adds `reprocess_type` to `SegmentResponse` so the console can show a reload-safe "Building hologram…" state on the finalized card while an `ar_hologram` carrier segment is in flight (and the finalized job briefly flips to processing). One-line schema field; no behavior change.