### PR TITLE
feat: user-managed video-settings presets + per-segment settings

### DIFF
--- a/alembic/versions/041_add_video_settings_presets.py
+++ b/alembic/versions/041_add_video_settings_presets.py
@@ -1,0 +1,77 @@
+"""Add video_settings_presets + per-job/segment video_preset_id
+
+Revision ID: 041
+Revises: 040
+Create Date: 2026-07-12
+
+User-managed named bundles of the 7 sampler params (lightx2v h/l, cfg h/l, steps_total,
+high_noise_steps, flow_shift), live-linked from Job (default) and Segment (override). Seeds
+the three previously-hardcoded console presets so nothing is lost.
+"""
+import uuid
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "041"
+down_revision = "040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "video_settings_presets",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False, unique=True),
+        sa.Column("lightx2v_strength_high", sa.Float(), nullable=True),
+        sa.Column("lightx2v_strength_low", sa.Float(), nullable=True),
+        sa.Column("cfg_high", sa.Float(), nullable=True),
+        sa.Column("cfg_low", sa.Float(), nullable=True),
+        sa.Column("steps_total", sa.Integer(), nullable=True),
+        sa.Column("high_noise_steps", sa.Integer(), nullable=True),
+        sa.Column("flow_shift", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("jobs", sa.Column("video_preset_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(
+        "fk_jobs_video_preset", "jobs", "video_settings_presets",
+        ["video_preset_id"], ["id"], ondelete="SET NULL",
+    )
+    op.add_column("segments", sa.Column("video_preset_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(
+        "fk_segments_video_preset", "segments", "video_settings_presets",
+        ["video_preset_id"], ["id"], ondelete="SET NULL",
+    )
+
+    now = datetime.now(timezone.utc)
+    presets = sa.table(
+        "video_settings_presets",
+        sa.column("id"), sa.column("name"),
+        sa.column("lightx2v_strength_high"), sa.column("lightx2v_strength_low"),
+        sa.column("cfg_high"), sa.column("cfg_low"),
+        sa.column("steps_total"), sa.column("high_noise_steps"), sa.column("flow_shift"),
+        sa.column("created_at"), sa.column("updated_at"),
+    )
+    op.bulk_insert(presets, [
+        {"id": uuid.uuid4(), "name": "Lightning", "lightx2v_strength_high": 1, "lightx2v_strength_low": 1,
+         "cfg_high": 1, "cfg_low": 1, "steps_total": 4, "high_noise_steps": 2, "flow_shift": 5,
+         "created_at": now, "updated_at": now},
+        {"id": uuid.uuid4(), "name": "Prompt-Aware", "lightx2v_strength_high": 0, "lightx2v_strength_low": 1,
+         "cfg_high": 2.75, "cfg_low": 1, "steps_total": 12, "high_noise_steps": 8, "flow_shift": 5,
+         "created_at": now, "updated_at": now},
+        {"id": uuid.uuid4(), "name": "High Motion", "lightx2v_strength_high": 0, "lightx2v_strength_low": 1,
+         "cfg_high": 3.5, "cfg_low": 1, "steps_total": 12, "high_noise_steps": 8, "flow_shift": 5,
+         "created_at": now, "updated_at": now},
+    ])
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_segments_video_preset", "segments", type_="foreignkey")
+    op.drop_column("segments", "video_preset_id")
+    op.drop_constraint("fk_jobs_video_preset", "jobs", type_="foreignkey")
+    op.drop_column("jobs", "video_preset_id")
+    op.drop_table("video_settings_presets")

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from slowapi.errors import RateLimitExceeded
 from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
 from app.limiter import limiter
-from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, prompt_presets, segments, tags, videos, wildcards, workers
+from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, prompt_presets, segments, tags, video_presets, videos, wildcards, workers
 
 logger = logging.getLogger(__name__)
 
@@ -64,4 +64,5 @@ app.include_router(tags.router)
 app.include_router(videos.router)
 app.include_router(wildcards.router)
 app.include_router(prompt_presets.router)
+app.include_router(video_presets.router)
 app.include_router(workers.router)

--- a/app/models.py
+++ b/app/models.py
@@ -48,6 +48,11 @@ class Job(Base):
     steps_total = mapped_column(Integer, nullable=True)
     high_noise_steps = mapped_column(Integer, nullable=True)
     flow_shift = mapped_column(Float, nullable=True)
+    # Optional link to a named video-settings preset (job default). Live: the 7 sampler values
+    # are read from the preset at claim time. NULL -> use this job's raw params above.
+    video_preset_id = mapped_column(
+        UUID(as_uuid=True), ForeignKey("video_settings_presets.id", ondelete="SET NULL"), nullable=True
+    )
     priority = mapped_column(Integer, nullable=False, default=0)
     config_starred = mapped_column(Boolean, nullable=False, default=False)
     # Per-job continuation-mode override ("traditional"|"vace"); NULL -> global app setting.
@@ -106,6 +111,10 @@ class Segment(Base):
     reference_frames = mapped_column(JSON, nullable=True)
     negative_prompt = mapped_column(Text, nullable=True)
     reprocess_type = mapped_column(String(20), nullable=True)
+    # Per-segment video-settings override (live link). Takes precedence over the job's preset.
+    video_preset_id = mapped_column(
+        UUID(as_uuid=True), ForeignKey("video_settings_presets.id", ondelete="SET NULL"), nullable=True
+    )
     status = mapped_column(String(20), nullable=False, default=SegmentStatus.PENDING)
     worker_id = mapped_column(UUID(as_uuid=True), nullable=True)
     worker_name = mapped_column(String(255), nullable=True)
@@ -198,6 +207,24 @@ class PromptPreset(Base):
     name = mapped_column(String(255), unique=True, nullable=False)
     prompt = mapped_column(Text, nullable=False)
     loras = mapped_column(JSON, nullable=True)
+    created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+
+class VideoSettingsPreset(Base):
+    """A named bundle of the 7 sampler params, selectable per-job and per-segment (live link)."""
+
+    __tablename__ = "video_settings_presets"
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = mapped_column(String(255), unique=True, nullable=False)
+    lightx2v_strength_high = mapped_column(Float, nullable=True)
+    lightx2v_strength_low = mapped_column(Float, nullable=True)
+    cfg_high = mapped_column(Float, nullable=True)
+    cfg_low = mapped_column(Float, nullable=True)
+    steps_total = mapped_column(Integer, nullable=True)
+    high_noise_steps = mapped_column(Integer, nullable=True)
+    flow_shift = mapped_column(Float, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -104,6 +104,7 @@ async def create_job(
         steps_total=body.steps_total,
         high_noise_steps=body.high_noise_steps,
         flow_shift=body.flow_shift,
+        video_preset_id=body.video_preset_id,
         priority=next_priority,
         tags=body.tags,
     )
@@ -176,6 +177,7 @@ async def create_job(
         faceswap_faces_index=seg.faceswap_faces_index,
         negative_prompt=seg.negative_prompt,
         auto_finalize=seg.auto_finalize,
+        video_preset_id=seg.video_preset_id,
     )
     db.add(segment)
     await db.commit()
@@ -499,6 +501,9 @@ async def update_job(
 
     if body.config_starred is not None:
         job.config_starred = body.config_starred
+
+    if body.video_preset_id is not None:
+        job.video_preset_id = body.video_preset_id
 
     if body.status is not None:
         allowed = JOB_VALID_TRANSITIONS.get(job.status, set())

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -19,7 +19,7 @@ from app.auth import get_current_user, verify_api_key, verify_api_key_or_bearer
 from app.database import get_db
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.helpers import upload_faceswap_image
-from app.models import AppSetting, Job, Lora, Segment, User, Video, Wildcard
+from app.models import AppSetting, Job, Lora, Segment, User, Video, VideoSettingsPreset, Wildcard
 from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
     FramePreview,
@@ -31,6 +31,7 @@ from app.schemas.segments import (
     SegmentResponse,
     SegmentStatusUpdate,
     SegmentTrimUpdate,
+    SegmentVideoPresetUpdate,
     WorkerSegmentResponse,
 )
 from app.stitch import stitch_video
@@ -188,6 +189,7 @@ async def add_segment(
         faceswap_faces_index=body.faceswap_faces_index,
         negative_prompt=negative_prompt,
         auto_finalize=body.auto_finalize,
+        video_preset_id=body.video_preset_id,
     )
     db.add(segment)
 
@@ -317,6 +319,15 @@ async def claim_next_segment(
     )
     continuation_mode = "vace" if use_vace else "traditional"
 
+    # Resolve video (sampler) settings: segment's preset -> job's preset -> job's raw params.
+    # Live-linked, so editing a preset changes future claims that reference it.
+    vp_id = segment.video_preset_id or job.video_preset_id
+    vsettings = job
+    if vp_id is not None:
+        preset = await db.get(VideoSettingsPreset, vp_id)
+        if preset is not None:
+            vsettings = preset
+
     # AR hologram carrier: the source is the job's finalized stitched video, not this
     # segment's own output. The daemon mattes/packs it into a color+alpha hologram.
     hologram_source_path = None
@@ -353,13 +364,13 @@ async def claim_next_segment(
         previous_motion_keywords=previous_motion_keywords,
         previous_motion_magnitude=previous_motion_magnitude,
         reference_frames=reference_frames if reference_frames else None,
-        lightx2v_strength_high=job.lightx2v_strength_high,
-        lightx2v_strength_low=job.lightx2v_strength_low,
-        cfg_high=job.cfg_high,
-        cfg_low=job.cfg_low,
-        steps_total=job.steps_total,
-        high_noise_steps=job.high_noise_steps,
-        flow_shift=job.flow_shift,
+        lightx2v_strength_high=vsettings.lightx2v_strength_high,
+        lightx2v_strength_low=vsettings.lightx2v_strength_low,
+        cfg_high=vsettings.cfg_high,
+        cfg_low=vsettings.cfg_low,
+        steps_total=vsettings.steps_total,
+        high_noise_steps=vsettings.high_noise_steps,
+        flow_shift=vsettings.flow_shift,
         negative_prompt=negative_prompt,
         reprocess_type=segment.reprocess_type,
         output_path=segment.output_path,
@@ -488,6 +499,28 @@ async def update_segment_trim(
 
     segment.trim_start_frames = body.trim_start_frames
     segment.trim_end_frames = body.trim_end_frames
+    await db.commit()
+    await db.refresh(segment)
+    return segment
+
+
+@router.patch("/segments/{segment_id}/video-preset", response_model=SegmentResponse)
+async def update_segment_video_preset(
+    segment_id: UUID,
+    body: SegmentVideoPresetUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Set/clear a segment's video-settings preset override (applies to the next claim)."""
+    result = await db.execute(
+        select(Segment)
+        .join(Job, Segment.job_id == Job.id)
+        .where(Segment.id == segment_id, Job.user_id == user.id)
+    )
+    segment = result.scalar_one_or_none()
+    if segment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Segment not found")
+    segment.video_preset_id = body.video_preset_id
     await db.commit()
     await db.refresh(segment)
     return segment

--- a/app/routes/video_presets.py
+++ b/app/routes/video_presets.py
@@ -1,0 +1,84 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import User, VideoSettingsPreset
+from app.schemas.video_presets import VideoPresetCreate, VideoPresetResponse, VideoPresetUpdate
+
+router = APIRouter()
+
+_PARAMS = (
+    "lightx2v_strength_high",
+    "lightx2v_strength_low",
+    "cfg_high",
+    "cfg_low",
+    "steps_total",
+    "high_noise_steps",
+    "flow_shift",
+)
+
+
+@router.get("/video-presets", response_model=list[VideoPresetResponse])
+async def list_video_presets(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(VideoSettingsPreset).order_by(VideoSettingsPreset.name))
+    return result.scalars().all()
+
+
+@router.post("/video-presets", response_model=VideoPresetResponse, status_code=status.HTTP_201_CREATED)
+async def create_video_preset(
+    body: VideoPresetCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    existing = await db.execute(select(VideoSettingsPreset).where(VideoSettingsPreset.name == body.name))
+    if existing.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Preset '{body.name}' already exists",
+        )
+    preset = VideoSettingsPreset(name=body.name, **{p: getattr(body, p) for p in _PARAMS})
+    db.add(preset)
+    await db.commit()
+    await db.refresh(preset)
+    return preset
+
+
+@router.patch("/video-presets/{preset_id}", response_model=VideoPresetResponse)
+async def update_video_preset(
+    preset_id: UUID,
+    body: VideoPresetUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    preset = await db.get(VideoSettingsPreset, preset_id)
+    if preset is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Preset not found")
+    if body.name is not None:
+        preset.name = body.name
+    for p in _PARAMS:
+        v = getattr(body, p)
+        if v is not None:
+            setattr(preset, p, v)
+    await db.commit()
+    await db.refresh(preset)
+    return preset
+
+
+@router.delete("/video-presets/{preset_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_video_preset(
+    preset_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    preset = await db.get(VideoSettingsPreset, preset_id)
+    if preset is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Preset not found")
+    await db.delete(preset)
+    await db.commit()

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -25,6 +25,7 @@ class JobCreate(BaseModel):
     steps_total: Optional[int] = None
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
+    video_preset_id: Optional[UUID] = None
     starting_image_uri: Optional[str] = None
     starting_image_hash: Optional[str] = None
     first_segment: SegmentCreate
@@ -91,6 +92,7 @@ class JobUpdate(BaseModel):
     status: Optional[str] = None
     tags: Optional[str] = Field(None, max_length=500, description="Comma-separated tags")
     config_starred: Optional[bool] = Field(None, description="Flag this job's config as a successful one")
+    video_preset_id: Optional[UUID] = Field(None, description="Job default video-settings preset")
 
 
 class WorkerStatsItem(BaseModel):

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -20,6 +20,7 @@ class SegmentCreate(BaseModel):
     negative_prompt: Optional[str] = None
     auto_finalize: bool = False
     transition: Optional[str] = None
+    video_preset_id: Optional[UUID] = None
 
 
 class SegmentResponse(BaseModel):
@@ -48,6 +49,7 @@ class SegmentResponse(BaseModel):
     reference_frames: Optional[list[str]] = None
     status: str
     reprocess_type: Optional[str] = None
+    video_preset_id: Optional[UUID] = None
     worker_id: Optional[UUID]
     worker_name: Optional[str]
     output_path: Optional[str]
@@ -130,6 +132,10 @@ class SegmentClaimResponse(BaseModel):
 class SegmentTrimUpdate(BaseModel):
     trim_start_frames: int = Field(ge=0)
     trim_end_frames: int = Field(ge=0)
+
+
+class SegmentVideoPresetUpdate(BaseModel):
+    video_preset_id: Optional[UUID] = None
 
 
 class FramePreview(BaseModel):

--- a/app/schemas/video_presets.py
+++ b/app/schemas/video_presets.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class VideoPresetCreate(BaseModel):
+    name: str
+    lightx2v_strength_high: Optional[float] = None
+    lightx2v_strength_low: Optional[float] = None
+    cfg_high: Optional[float] = None
+    cfg_low: Optional[float] = None
+    steps_total: Optional[int] = None
+    high_noise_steps: Optional[int] = None
+    flow_shift: Optional[float] = None
+
+
+class VideoPresetUpdate(BaseModel):
+    name: Optional[str] = None
+    lightx2v_strength_high: Optional[float] = None
+    lightx2v_strength_low: Optional[float] = None
+    cfg_high: Optional[float] = None
+    cfg_low: Optional[float] = None
+    steps_total: Optional[int] = None
+    high_noise_steps: Optional[int] = None
+    flow_shift: Optional[float] = None
+
+
+class VideoPresetResponse(BaseModel):
+    id: UUID
+    name: str
+    lightx2v_strength_high: Optional[float] = None
+    lightx2v_strength_low: Optional[float] = None
+    cfg_high: Optional[float] = None
+    cfg_low: Optional[float] = None
+    steps_total: Optional[int] = None
+    high_noise_steps: Optional[int] = None
+    flow_shift: Optional[float] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}


### PR DESCRIPTION
**Feature 1 — configurable presets (no more hardcoding):** `video_settings_presets` table (name + 7 sampler params) + CRUD mirroring `PromptPreset`. Migration 041 seeds the three hardcoded console presets so nothing's lost.

**Feature 2 — per-segment:** `Job.video_preset_id` (default) + `Segment.video_preset_id` (override), live-linked FKs (`SET NULL` on delete). Claim resolves `segment.preset → job.preset → job's raw params → daemon default` and sends the resolved 7 values — **daemon unchanged** (`SegmentClaim` already takes per-segment params).

- `JobCreate`/`JobUpdate`/`SegmentCreate` accept `video_preset_id`; new `PATCH /segments/{id}/video-preset`; `SegmentResponse` exposes it.
- 89 tests pass. (Console PR: presets library + dropdowns.)