### PR TITLE
feat: video presets carry 1:N LoRAs (complete recipe)

### DIFF
--- a/alembic/versions/042_add_video_preset_loras.py
+++ b/alembic/versions/042_add_video_preset_loras.py
@@ -1,0 +1,24 @@
+"""Add loras to video_settings_presets
+
+Revision ID: 042
+Revises: 041
+Create Date: 2026-07-12
+
+A video preset becomes a complete recipe: 1:N LoRAs (each {lora_id, high_weight, low_weight})
+alongside the sampler params. Resolved live at claim time when linked.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "042"
+down_revision = "041"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("video_settings_presets", sa.Column("loras", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("video_settings_presets", "loras")

--- a/app/models.py
+++ b/app/models.py
@@ -225,6 +225,9 @@ class VideoSettingsPreset(Base):
     steps_total = mapped_column(Integer, nullable=True)
     high_noise_steps = mapped_column(Integer, nullable=True)
     flow_shift = mapped_column(Float, nullable=True)
+    # 1:N LoRAs that constitute this recipe — each {lora_id, high_weight, low_weight} (expert
+    # placement). Resolved live at claim time when a job/segment links this preset.
+    loras = mapped_column(JSON, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -323,10 +323,15 @@ async def claim_next_segment(
     # Live-linked, so editing a preset changes future claims that reference it.
     vp_id = segment.video_preset_id or job.video_preset_id
     vsettings = job
+    effective_loras = segment.loras
     if vp_id is not None:
         preset = await db.get(VideoSettingsPreset, vp_id)
         if preset is not None:
             vsettings = preset
+            # A full-recipe preset owns its LoRAs (resolved live); a sampler-only preset
+            # leaves the segment's own LoRAs untouched.
+            if preset.loras:
+                effective_loras = await _resolve_loras(db, preset.loras)
 
     # AR hologram carrier: the source is the job's finalized stitched video, not this
     # segment's own output. The daemon mattes/packs it into a color+alpha hologram.
@@ -352,7 +357,7 @@ async def claim_next_segment(
         duration_seconds=segment.duration_seconds,
         speed=segment.speed,
         start_image=resolved_start_image,
-        loras=segment.loras,
+        loras=effective_loras,
         faceswap_enabled=segment.faceswap_enabled,
         faceswap_method=segment.faceswap_method,
         faceswap_source_type=segment.faceswap_source_type,

--- a/app/routes/video_presets.py
+++ b/app/routes/video_presets.py
@@ -44,6 +44,8 @@ async def create_video_preset(
             detail=f"Preset '{body.name}' already exists",
         )
     preset = VideoSettingsPreset(name=body.name, **{p: getattr(body, p) for p in _PARAMS})
+    if body.loras is not None:
+        preset.loras = [slot.model_dump() for slot in body.loras]
     db.add(preset)
     await db.commit()
     await db.refresh(preset)
@@ -66,6 +68,8 @@ async def update_video_preset(
         v = getattr(body, p)
         if v is not None:
             setattr(preset, p, v)
+    if body.loras is not None:
+        preset.loras = [slot.model_dump() for slot in body.loras]
     await db.commit()
     await db.refresh(preset)
     return preset

--- a/app/schemas/video_presets.py
+++ b/app/schemas/video_presets.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from app.schemas.prompt_presets import LoraSlot
+
 
 class VideoPresetCreate(BaseModel):
     name: str
@@ -14,6 +16,7 @@ class VideoPresetCreate(BaseModel):
     steps_total: Optional[int] = None
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
+    loras: Optional[list[LoraSlot]] = None
 
 
 class VideoPresetUpdate(BaseModel):
@@ -25,6 +28,7 @@ class VideoPresetUpdate(BaseModel):
     steps_total: Optional[int] = None
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
+    loras: Optional[list[LoraSlot]] = None
 
 
 class VideoPresetResponse(BaseModel):
@@ -37,6 +41,7 @@ class VideoPresetResponse(BaseModel):
     steps_total: Optional[int] = None
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
+    loras: Optional[list[LoraSlot]] = None
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
Turns a video preset into a full named recipe (e.g. "Kelly-Walking" = char LoRA @ low + motion LoRA @ high + tuned sampler split), not just sampler knobs.

- Preset gains `loras` (list of `{lora_id, high_weight, low_weight}`, same shape as PromptPreset).
- **Claim:** a linked preset that HAS loras → those LoRAs (resolved **live** via `_resolve_loras`) replace the segment's own; a sampler-only preset leaves segment LoRAs untouched.
- migration 042 + model + schema + CRUD. 89 tests pass. (Console PR: LoRA picker in the preset dialog.)

Note: this supersedes tag1/tag2 → LoRA auto-selection when a preset is picked (David is fine letting that go on the preset path).