### PR TITLE
feat: sampler_name + scheduler on video presets

### DIFF
--- a/alembic/versions/043_add_video_preset_sampler.py
+++ b/alembic/versions/043_add_video_preset_sampler.py
@@ -1,0 +1,26 @@
+"""Add sampler_name + scheduler to video_settings_presets
+
+Revision ID: 043
+Revises: 042
+Create Date: 2026-07-12
+
+Optional sampler algorithm + scheduler per preset (NULL -> daemon default euler/simple).
+Makes the preset a truly complete recipe.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "043"
+down_revision = "042"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("video_settings_presets", sa.Column("sampler_name", sa.String(length=40), nullable=True))
+    op.add_column("video_settings_presets", sa.Column("scheduler", sa.String(length=40), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("video_settings_presets", "scheduler")
+    op.drop_column("video_settings_presets", "sampler_name")

--- a/app/models.py
+++ b/app/models.py
@@ -225,6 +225,10 @@ class VideoSettingsPreset(Base):
     steps_total = mapped_column(Integer, nullable=True)
     high_noise_steps = mapped_column(Integer, nullable=True)
     flow_shift = mapped_column(Float, nullable=True)
+    # Sampler algorithm + scheduler (NULL -> daemon default euler/simple). Only the scheduler
+    # applies on the VACE path (its sampler node has no sampler_name).
+    sampler_name = mapped_column(String(40), nullable=True)
+    scheduler = mapped_column(String(40), nullable=True)
     # 1:N LoRAs that constitute this recipe — each {lora_id, high_weight, low_weight} (expert
     # placement). Resolved live at claim time when a job/segment links this preset.
     loras = mapped_column(JSON, nullable=True)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -332,6 +332,9 @@ async def claim_next_segment(
             # leaves the segment's own LoRAs untouched.
             if preset.loras:
                 effective_loras = await _resolve_loras(db, preset.loras)
+    # Sampler/scheduler only come from a preset (empty -> daemon default euler/simple).
+    sampler_name = getattr(vsettings, "sampler_name", None) or None
+    scheduler = getattr(vsettings, "scheduler", None) or None
 
     # AR hologram carrier: the source is the job's finalized stitched video, not this
     # segment's own output. The daemon mattes/packs it into a color+alpha hologram.
@@ -376,6 +379,8 @@ async def claim_next_segment(
         steps_total=vsettings.steps_total,
         high_noise_steps=vsettings.high_noise_steps,
         flow_shift=vsettings.flow_shift,
+        sampler_name=sampler_name,
+        scheduler=scheduler,
         negative_prompt=negative_prompt,
         reprocess_type=segment.reprocess_type,
         output_path=segment.output_path,

--- a/app/routes/video_presets.py
+++ b/app/routes/video_presets.py
@@ -43,7 +43,12 @@ async def create_video_preset(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Preset '{body.name}' already exists",
         )
-    preset = VideoSettingsPreset(name=body.name, **{p: getattr(body, p) for p in _PARAMS})
+    preset = VideoSettingsPreset(
+        name=body.name,
+        sampler_name=body.sampler_name,
+        scheduler=body.scheduler,
+        **{p: getattr(body, p) for p in _PARAMS},
+    )
     if body.loras is not None:
         preset.loras = [slot.model_dump() for slot in body.loras]
     db.add(preset)
@@ -68,6 +73,10 @@ async def update_video_preset(
         v = getattr(body, p)
         if v is not None:
             setattr(preset, p, v)
+    if body.sampler_name is not None:
+        preset.sampler_name = body.sampler_name
+    if body.scheduler is not None:
+        preset.scheduler = body.scheduler
     if body.loras is not None:
         preset.loras = [slot.model_dump() for slot in body.loras]
     await db.commit()

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -108,6 +108,8 @@ class SegmentClaimResponse(BaseModel):
     steps_total: Optional[int] = None
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
+    sampler_name: Optional[str] = None
+    scheduler: Optional[str] = None
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None

--- a/app/schemas/video_presets.py
+++ b/app/schemas/video_presets.py
@@ -16,6 +16,8 @@ class VideoPresetCreate(BaseModel):
     steps_total: Optional[int] = None
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
+    sampler_name: Optional[str] = None
+    scheduler: Optional[str] = None
     loras: Optional[list[LoraSlot]] = None
 
 
@@ -28,6 +30,8 @@ class VideoPresetUpdate(BaseModel):
     steps_total: Optional[int] = None
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
+    sampler_name: Optional[str] = None
+    scheduler: Optional[str] = None
     loras: Optional[list[LoraSlot]] = None
 
 
@@ -41,6 +45,8 @@ class VideoPresetResponse(BaseModel):
     steps_total: Optional[int] = None
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
+    sampler_name: Optional[str] = None
+    scheduler: Optional[str] = None
     loras: Optional[list[LoraSlot]] = None
     created_at: datetime
     updated_at: datetime


### PR DESCRIPTION
Preset gains optional `sampler_name` + `scheduler` (migration 043). Claim returns them (from the linked preset; empty → daemon default euler/simple). Makes the preset a truly complete recipe. Pairs with wanly-gpu-daemon. 89 tests pass.