### PR TITLE
feat(ar): hologram_flavor plumbing (2d_matte | 2.5d_depth)

### DIFF
--- a/alembic/versions/045_add_segment_hologram_flavor.py
+++ b/alembic/versions/045_add_segment_hologram_flavor.py
@@ -1,0 +1,23 @@
+"""Add hologram_flavor to segments
+
+Revision ID: 045
+Revises: 044
+Create Date: 2026-07-13
+
+AR hologram gains a flavor: "2d_matte" (Tier-0 flat) or "2.5d_depth" (Tier-1 depth-displaced).
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "045"
+down_revision = "044"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("hologram_flavor", sa.String(length=16), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "hologram_flavor")

--- a/app/models.py
+++ b/app/models.py
@@ -105,6 +105,9 @@ class Segment(Base):
     # three paths hold the packed color+alpha mp4, the hologram.json manifest, and the poster.
     hologram_key_color = mapped_column(String(20), nullable=True)
     hologram_subject_height_m = mapped_column(Float, nullable=True)
+    # "2d_matte" (flat, Tier-0) or "2.5d_depth" (depth-displaced mesh, Tier-1). One flavor per
+    # video at a time — re-making overwrites the single carrier's artifacts.
+    hologram_flavor = mapped_column(String(16), nullable=True)
     hologram_video_path = mapped_column(Text, nullable=True)
     hologram_manifest_path = mapped_column(Text, nullable=True)
     hologram_poster_path = mapped_column(Text, nullable=True)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -394,6 +394,7 @@ async def claim_next_segment(
         hologram_source_path=hologram_source_path,
         hologram_key_color=segment.hologram_key_color,
         hologram_subject_height_m=segment.hologram_subject_height_m,
+        hologram_flavor=segment.hologram_flavor,
     )
 
 
@@ -784,6 +785,10 @@ async def make_hologram(
         if body.subject_height_m is not None
         else (float(height_setting.value) if height_setting else 1.70)
     )
+    flavor_setting = await db.get(AppSetting, "hologram_flavor")
+    flavor = body.flavor or (flavor_setting.value if flavor_setting else None) or "2d_matte"
+    if flavor not in ("2d_matte", "2.5d_depth"):
+        flavor = "2d_matte"
 
     # Dedicated hologram carrier at a sentinel index — a separate queue item, so the real
     # video segments and the job's FINALIZED status are left completely untouched. Reused
@@ -818,6 +823,7 @@ async def make_hologram(
     carrier.reprocess_type = "ar_hologram"
     carrier.hologram_key_color = key_color
     carrier.hologram_subject_height_m = subject_height
+    carrier.hologram_flavor = flavor
 
     await db.commit()
     await db.refresh(carrier)
@@ -840,6 +846,7 @@ async def get_hologram(
     if segment is None or not segment.hologram_video_path:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Hologram not found")
     return {
+        "flavor": segment.hologram_flavor or "2d_matte",
         "video_path": segment.hologram_video_path,
         "manifest_path": segment.hologram_manifest_path,
         "poster_path": segment.hologram_poster_path,

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -54,6 +54,7 @@ class SegmentResponse(BaseModel):
     worker_name: Optional[str]
     output_path: Optional[str]
     last_frame_path: Optional[str]
+    hologram_flavor: Optional[str] = None
     hologram_video_path: Optional[str] = None
     hologram_manifest_path: Optional[str] = None
     hologram_poster_path: Optional[str] = None
@@ -127,6 +128,7 @@ class SegmentClaimResponse(BaseModel):
     hologram_source_path: Optional[str] = None
     hologram_key_color: Optional[str] = None
     hologram_subject_height_m: Optional[float] = None
+    hologram_flavor: Optional[str] = None
 
     model_config = {"from_attributes": True}
 
@@ -165,6 +167,7 @@ class HologramRequest(BaseModel):
 
     subject_height_m: Optional[float] = None
     key_color: Optional[str] = None
+    flavor: Optional[str] = None  # "2d_matte" (default) or "2.5d_depth"
 
 
 class SegmentStatusUpdate(BaseModel):


### PR DESCRIPTION
First of 3 PRs for **AR Tier-1 (2.5D depth)**. Adds the `flavor` contract the daemon + console build against.

- `segments.hologram_flavor` column (migration 045)
- `HologramRequest.flavor`; resolved request → AppSetting `hologram_flavor` → `2d_matte`
- stored on the carrier segment; passed to the daemon via `SegmentClaimResponse.hologram_flavor`; returned by GET /hologram (+ on SegmentResponse)
- one flavor per video is enforced for free by the single-carrier overwrite

No behavior change yet — `2d_matte` is the default and the daemon ignores the field until the next PR. Syntax-checked.