### PR TITLE
feat(vace): job identity reference + continuation toggle

### DIFF
--- a/alembic/versions/046_add_job_identity_reference.py
+++ b/alembic/versions/046_add_job_identity_reference.py
@@ -1,0 +1,24 @@
+"""Add identity_reference_image to jobs
+
+Revision ID: 046
+Revises: 045
+Create Date: 2026-07-13
+
+Canonical VACE identity reference (a face crop from seg0) fed to every downstream segment's
+VACE ref_images so identity re-anchors at each continuation instead of drifting.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "046"
+down_revision = "045"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("identity_reference_image", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "identity_reference_image")

--- a/app/models.py
+++ b/app/models.py
@@ -57,6 +57,9 @@ class Job(Base):
     config_starred = mapped_column(Boolean, nullable=False, default=False)
     # Per-job continuation-mode override ("traditional"|"vace"); NULL -> global app setting.
     continuation_mode = mapped_column(String(20), nullable=True)
+    # Canonical identity reference for VACE continuation: a face crop from seg0, set by the daemon
+    # after seg0 completes and fed to every downstream segment's VACE ref_images (anchors identity).
+    identity_reference_image = mapped_column(Text, nullable=True)
     status = mapped_column(String(20), nullable=False, default=JobStatus.PENDING)
     tags = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))

--- a/app/routes/files.py
+++ b/app/routes/files.py
@@ -204,3 +204,25 @@ async def upload_hologram_output(
     await db.commit()
     await db.refresh(segment)
     return segment
+
+
+@router.post(
+    "/jobs/{job_id}/identity_reference",
+    dependencies=[Depends(verify_api_key)],
+)
+async def upload_identity_reference(
+    job_id: UUID,
+    image: UploadFile = File(...),
+    db: AsyncSession = Depends(get_db),
+):
+    """Set a job's canonical VACE identity reference — a face crop from seg0 the daemon uploads
+    after seg0 completes. Fed to every downstream segment's VACE ref_images to anchor identity."""
+    job = await db.get(Job, job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    data = await image.read()
+    key = f"{job_id}/identity_reference.png"
+    uri = await asyncio.to_thread(upload_bytes, data, key, settings.s3_jobs_bucket)
+    job.identity_reference_image = uri
+    await db.commit()
+    return {"identity_reference_image": uri}

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -105,6 +105,7 @@ async def create_job(
         high_noise_steps=body.high_noise_steps,
         flow_shift=body.flow_shift,
         video_preset_id=body.video_preset_id,
+        continuation_mode=body.continuation_mode,
         priority=next_priority,
         tags=body.tags,
     )

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -367,7 +367,7 @@ async def claim_next_segment(
         faceswap_image=segment.faceswap_image,
         faceswap_faces_order=segment.faceswap_faces_order,
         faceswap_faces_index=segment.faceswap_faces_index,
-        initial_reference_image=job.starting_image,
+        initial_reference_image=job.identity_reference_image or job.starting_image,
         motion_keywords=segment.motion_keywords,
         previous_motion_keywords=previous_motion_keywords,
         previous_motion_magnitude=previous_motion_magnitude,

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -26,6 +26,7 @@ class JobCreate(BaseModel):
     high_noise_steps: Optional[int] = None
     flow_shift: Optional[float] = None
     video_preset_id: Optional[UUID] = None
+    continuation_mode: Optional[str] = None  # "traditional" | "vace" (NULL -> global default)
     starting_image_uri: Optional[str] = None
     starting_image_hash: Optional[str] = None
     first_segment: SegmentCreate
@@ -65,6 +66,8 @@ class JobResponse(BaseModel):
     faceswap_enabled: bool = False
     loras: list[JobLoraSummary] = []
     tags: Optional[str] = None
+    continuation_mode: Optional[str] = None
+    identity_reference_image: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
First of 3 PRs for **VACE continuation with a canonical face-crop identity reference**.

- `jobs.identity_reference_image` column (migration 046) — the seg0 face crop
- `JobCreate.continuation_mode` (per-job VACE toggle); exposed on JobResponse alongside the identity reference
- continuation claims now resolve `initial_reference_image = job.identity_reference_image or job.starting_image`, so every downstream VACE segment's `ref_images` gets the persistent seg0 face
- `POST /jobs/{id}/identity_reference` for the daemon to upload the crop after seg0 completes

Verified all Fun-VACE models are present on the 3090. Daemon (seg0 face crop) + console (toggle) follow. Syntax-checked.