### PR TITLE
fix: JobResponse missing video_preset_id field (Custom bug)

### DIFF
--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -66,6 +66,7 @@ class JobResponse(BaseModel):
     faceswap_enabled: bool = False
     loras: list[JobLoraSummary] = []
     tags: Optional[str] = None
+    video_preset_id: Optional[UUID] = None
     continuation_mode: Optional[str] = None
     identity_reference_image: Optional[str] = None
     created_at: datetime


### PR DESCRIPTION
**The actual root cause.** `JobResponse`/`JobDetailResponse` never declared `video_preset_id` (only `JobCreate`/`JobUpdate` did), so Pydantic silently dropped the `video_preset_id=job.video_preset_id` I'd been passing to the hand-built response. The console always received `undefined` → every inherited seg0 showed "Custom." `continuation_mode` worked only because I'd added *that* to `JobResponse`. Adds `video_preset_id` to `JobResponse`. Verified: ORM has the value, API response was dropping it.