### PR TITLE
Resolve seed_faceswap on segment claim

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -325,6 +325,20 @@ async def claim_next_segment(
     )
     continuation_mode = "vace" if use_vace else "traditional"
 
+    # Seed re-anchor: faceswap this segment's last frame to the canonical identity before it
+    # seeds the next segment. Only when the global setting is on AND a later segment exists
+    # (so single-segment / final segments never pay the extra faceswap round-trip).
+    sf_setting = await db.get(AppSetting, "seed_faceswap")
+    seed_faceswap_on = bool(sf_setting) and sf_setting.value.strip().lower() in ("1", "true", "on", "yes")
+    seed_faceswap = False
+    if seed_faceswap_on:
+        successor_id = await db.scalar(
+            select(Segment.id)
+            .where(Segment.job_id == job.id, Segment.index > segment.index)
+            .limit(1)
+        )
+        seed_faceswap = successor_id is not None
+
     # Resolve video (sampler) settings: segment's preset -> job's preset -> job's raw params.
     # Live-linked, so editing a preset changes future claims that reference it.
     vp_id = segment.video_preset_id or job.video_preset_id
@@ -390,6 +404,7 @@ async def claim_next_segment(
         negative_prompt=negative_prompt,
         reprocess_type=segment.reprocess_type,
         output_path=segment.output_path,
+        seed_faceswap=seed_faceswap,
         width=job.width,
         height=job.height,
         fps=job.fps,

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -123,6 +123,9 @@ class SegmentClaimResponse(BaseModel):
     continuation_mode: str = "traditional"
     previous_output_path: Optional[str] = None  # prev segment video (VACE control source)
     vace_overlap_frames: int = 12
+    # Seed re-anchor: faceswap this segment's last frame to the canonical identity before it
+    # seeds the next segment (resolved API-side: setting on AND a successor segment exists).
+    seed_faceswap: bool = False
     # AR hologram (reprocess_type="ar_hologram"): the source is the job's finalized stitched
     # video (not this carrier segment's own output); params drive the daemon matte + manifest.
     hologram_source_path: Optional[str] = None


### PR DESCRIPTION
Adds `seed_faceswap` to `SegmentClaimResponse`, computed True only when the `seed_faceswap` AppSetting is on AND a successor segment exists (so single-segment/final segments don't pay the extra faceswap round-trip).

Pairs with the wanly-gpu-daemon seed re-anchor PR (#79) which does the actual swap + graceful fallback + logging. No migration (setting is a lazy AppSetting, gate is computed at claim time).