### PR TITLE
Expose seed_faceswap in app settings API

### DIFF
--- a/app/routes/app_settings.py
+++ b/app/routes/app_settings.py
@@ -23,6 +23,7 @@ _DEFAULTS = {
     "negative_prompt": "",
     "continuation_mode": "traditional",
     "vace_overlap_frames": "12",
+    "seed_faceswap": "false",
 }
 
 
@@ -44,6 +45,7 @@ def _to_response(settings: dict[str, str]) -> AppSettingsResponse:
         negative_prompt=settings["negative_prompt"],
         continuation_mode=settings.get("continuation_mode", "traditional"),
         vace_overlap_frames=int(settings.get("vace_overlap_frames", "12")),
+        seed_faceswap=settings.get("seed_faceswap", "false").strip().lower() in ("1", "true", "on", "yes"),
     )
 
 

--- a/app/schemas/app_settings.py
+++ b/app/schemas/app_settings.py
@@ -16,6 +16,9 @@ class AppSettingsResponse(BaseModel):
     # or "vace" (video-conditioned continuation). vace_overlap_frames = kept tail length.
     continuation_mode: str = "traditional"
     vace_overlap_frames: int = 12
+    # Seed re-anchor: faceswap each continuation segment's last frame to the canonical
+    # identity before it seeds the next segment (only fires when a successor exists).
+    seed_faceswap: bool = False
 
 
 class AppSettingsUpdate(BaseModel):
@@ -29,3 +32,4 @@ class AppSettingsUpdate(BaseModel):
     negative_prompt: Optional[str] = None
     continuation_mode: Optional[str] = None
     vace_overlap_frames: Optional[int] = None
+    seed_faceswap: Optional[bool] = None


### PR DESCRIPTION
Adds the `seed_faceswap` boolean to the settings GET/PUT (lazy default off) so the console Settings page can toggle the seed re-anchor faceswap (daemon #79 / api #125). No migration — lazy AppSetting.