### PR TITLE
Add notes field to video presets

### DIFF
--- a/alembic/versions/048_add_preset_notes.py
+++ b/alembic/versions/048_add_preset_notes.py
@@ -1,0 +1,23 @@
+"""Add notes to video_settings_presets
+
+Revision ID: 048
+Revises: 047
+Create Date: 2026-07-15
+
+Free-form notes on a video preset (what it's for, gotchas). Not used by generation.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "048"
+down_revision = "047"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("video_settings_presets", sa.Column("notes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("video_settings_presets", "notes")

--- a/app/models.py
+++ b/app/models.py
@@ -234,6 +234,8 @@ class VideoSettingsPreset(Base):
     # Default prompt for this recipe. A snapshot default that fills the prompt field at job
     # creation (overridable at submit) — NOT live-linked like loras/sampler params.
     prompt = mapped_column(Text, nullable=True)
+    # Free-form notes about this recipe (what it's for, gotchas). Not used by generation.
+    notes = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/routes/video_presets.py
+++ b/app/routes/video_presets.py
@@ -48,6 +48,7 @@ async def create_video_preset(
         sampler_name=body.sampler_name,
         scheduler=body.scheduler,
         prompt=body.prompt,
+        notes=body.notes,
         **{p: getattr(body, p) for p in _PARAMS},
     )
     if body.loras is not None:
@@ -82,6 +83,8 @@ async def update_video_preset(
         preset.loras = [slot.model_dump() for slot in body.loras]
     if body.prompt is not None:
         preset.prompt = body.prompt
+    if body.notes is not None:
+        preset.notes = body.notes
     await db.commit()
     await db.refresh(preset)
     return preset

--- a/app/schemas/video_presets.py
+++ b/app/schemas/video_presets.py
@@ -24,6 +24,7 @@ class VideoPresetCreate(BaseModel):
     scheduler: Optional[str] = None
     loras: Optional[list[LoraSlot]] = None
     prompt: Optional[str] = None
+    notes: Optional[str] = None
 
 
 class VideoPresetUpdate(BaseModel):
@@ -39,6 +40,7 @@ class VideoPresetUpdate(BaseModel):
     scheduler: Optional[str] = None
     loras: Optional[list[LoraSlot]] = None
     prompt: Optional[str] = None
+    notes: Optional[str] = None
 
 
 class VideoPresetResponse(BaseModel):
@@ -55,6 +57,7 @@ class VideoPresetResponse(BaseModel):
     scheduler: Optional[str] = None
     loras: Optional[list[LoraSlot]] = None
     prompt: Optional[str] = None
+    notes: Optional[str] = None
     created_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
A single free-form notes field on video presets (what the recipe's for, gotchas). Migration 048; create/update/response wired. Not used by generation. 89 tests pass.