### PR TITLE
Hologram believability: per-remake depth scale + player cache-buster

### DIFF
--- a/alembic/versions/049_add_segment_hologram_depth_scale.py
+++ b/alembic/versions/049_add_segment_hologram_depth_scale.py
@@ -1,0 +1,24 @@
+"""Add hologram_depth_scale_m to segments
+
+Revision ID: 049
+Revises: 048
+Create Date: 2026-07-27
+
+Per-remake relief depth (meters) for the 2.5d_depth hologram flavor. Was a daemon-wide
+config constant (0.12) — now a console dialog knob threaded through the carrier segment.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "049"
+down_revision = "048"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("hologram_depth_scale_m", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "hologram_depth_scale_m")

--- a/app/models.py
+++ b/app/models.py
@@ -111,6 +111,10 @@ class Segment(Base):
     # "2d_matte" (flat, Tier-0) or "2.5d_depth" (depth-displaced mesh, Tier-1). One flavor per
     # video at a time — re-making overwrites the single carrier's artifacts.
     hologram_flavor = mapped_column(String(16), nullable=True)
+    # Relief depth in meters for the 2.5d_depth flavor (how far the nearest pixels are pushed
+    # toward the viewer). Per-remake knob from the console dialog; daemon falls back to its
+    # config default when null.
+    hologram_depth_scale_m = mapped_column(Float, nullable=True)
     hologram_video_path = mapped_column(Text, nullable=True)
     hologram_manifest_path = mapped_column(Text, nullable=True)
     hologram_poster_path = mapped_column(Text, nullable=True)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -441,6 +441,7 @@ async def claim_next_segment(
         hologram_key_color=segment.hologram_key_color,
         hologram_subject_height_m=segment.hologram_subject_height_m,
         hologram_flavor=segment.hologram_flavor,
+        hologram_depth_scale_m=segment.hologram_depth_scale_m,
         smashcut_clip_paths=smashcut_clip_paths,
         smashcut_transition=segment.smashcut_transition,
     )
@@ -837,6 +838,9 @@ async def make_hologram(
     flavor = body.flavor or (flavor_setting.value if flavor_setting else None) or "2d_matte"
     if flavor not in ("2d_matte", "2.5d_depth"):
         flavor = "2d_matte"
+    depth_scale = body.depth_scale_m
+    if depth_scale is not None:
+        depth_scale = max(0.03, min(0.60, float(depth_scale)))
 
     # Dedicated hologram carrier at a sentinel index — a separate queue item, so the real
     # video segments and the job's FINALIZED status are left completely untouched. Reused
@@ -872,6 +876,7 @@ async def make_hologram(
     carrier.hologram_key_color = key_color
     carrier.hologram_subject_height_m = subject_height
     carrier.hologram_flavor = flavor
+    carrier.hologram_depth_scale_m = depth_scale
 
     await db.commit()
     await db.refresh(carrier)
@@ -1031,6 +1036,9 @@ async def get_hologram(
         "video_path": segment.hologram_video_path,
         "manifest_path": segment.hologram_manifest_path,
         "poster_path": segment.hologram_poster_path,
+        # Cache-buster for the player: hologram artifacts live at fixed S3 keys and the /files
+        # redirect is cached for hours, so a remake would otherwise replay the previous flavor.
+        "version": segment.completed_at.isoformat() if segment.completed_at else None,
     }
 
 

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -55,6 +55,7 @@ class SegmentResponse(BaseModel):
     output_path: Optional[str]
     last_frame_path: Optional[str]
     hologram_flavor: Optional[str] = None
+    hologram_depth_scale_m: Optional[float] = None
     hologram_video_path: Optional[str] = None
     hologram_manifest_path: Optional[str] = None
     hologram_poster_path: Optional[str] = None
@@ -132,6 +133,7 @@ class SegmentClaimResponse(BaseModel):
     hologram_key_color: Optional[str] = None
     hologram_subject_height_m: Optional[float] = None
     hologram_flavor: Optional[str] = None
+    hologram_depth_scale_m: Optional[float] = None
     # Foundry smashcut (reprocess_type="smashcut_concat"): ordered source clip paths + transition.
     smashcut_clip_paths: Optional[list[str]] = None
     smashcut_transition: Optional[str] = None
@@ -199,6 +201,7 @@ class HologramRequest(BaseModel):
     subject_height_m: Optional[float] = None
     key_color: Optional[str] = None
     flavor: Optional[str] = None  # "2d_matte" (default) or "2.5d_depth"
+    depth_scale_m: Optional[float] = None  # 2.5d relief depth in meters (clamped 0.03..0.60)
 
 
 class SegmentStatusUpdate(BaseModel):


### PR DESCRIPTION
Part of the AR hologram believability pass (audit 2026-07-27; sibling PRs in wanly-console + wanly-gpu-daemon).

- `segments.hologram_depth_scale_m` (migration 049): relief depth in meters for the `2.5d_depth` flavor, threaded HologramRequest → carrier → SegmentClaimResponse. Replaces the daemon-wide 0.12 config constant that made the relief near-invisible.
- `HologramRequest.depth_scale_m`, clamped 0.03–0.60.
- `GET /segments/{id}/hologram` now returns `version` (carrier `completed_at`): hologram artifacts live at fixed S3 keys behind a 5h-cached `/files` redirect, so without a cache-buster a remake replays the previous flavor's video + manifest — the root cause of "2D and 2.5D look identical".