### PR TITLE
fix(lynx): map starting_image to lynx_subject_image on job creation

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -169,6 +169,14 @@ async def create_job(
     elif body.starting_image_uri:
         job.starting_image = body.starting_image_uri
 
+    # Lynx conditions identity on a subject image. The console reuses the starting-image
+    # upload path for it (same crop/hash-dedup machinery), so mirror the resolved URI
+    # across unless the caller set lynx_subject_image explicitly. Despite sharing the
+    # upload slot it is NOT a first frame — Lynx is a T2V base, and the subject never
+    # appears as frame 0.
+    if job.generation_engine == "lynx" and not job.lynx_subject_image:
+        job.lynx_subject_image = job.starting_image
+
     # Upload faceswap image to S3 if provided
     faceswap_uri = None
     if faceswap_image is not None:

--- a/tests/test_lynx_engine.py
+++ b/tests/test_lynx_engine.py
@@ -169,6 +169,34 @@ class TestHandBuiltResponses:
         pytest.fail("no SegmentClaimResponse construction found in app/routes/segments.py")
 
 
+class TestSubjectImageMirroring:
+    """The console reuses the starting-image upload slot for the Lynx subject, so
+    create_job mirrors the resolved URI across."""
+
+    @staticmethod
+    def _mirror_source():
+        tree = ast.parse((ROOT / "app" / "routes" / "jobs.py").read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.If):
+                src = ast.unparse(node)
+                if "lynx_subject_image" in src and "generation_engine" in src:
+                    return src
+        return None
+
+    def test_mirror_exists(self):
+        assert self._mirror_source() is not None, (
+            "create_job must map starting_image -> lynx_subject_image for Lynx jobs, "
+            "or a console-submitted Lynx job reaches the daemon with no subject."
+        )
+
+    def test_mirror_only_applies_to_lynx(self):
+        assert "'lynx'" in self._mirror_source()
+
+    def test_mirror_does_not_clobber_an_explicit_value(self):
+        # guarded by `not job.lynx_subject_image`
+        assert "not job.lynx_subject_image" in self._mirror_source()
+
+
 class TestMigration:
     """Migration 050 must match the model, or a deployed API 500s on a column that
     exists in Python and not in Postgres."""


### PR DESCRIPTION
Without this, a Lynx job reaches the daemon with no subject image and fails validation:

```
Lynx validation error: Lynx segment has no lynx_subject_image
```

That is what the first A/B submission hit. The change was written alongside the console PR but never committed — my miss.

`create_job` now mirrors the resolved starting-image URI into `lynx_subject_image` for Lynx jobs, so the console reuses the existing upload path (crop, hash-dedup) rather than needing a second upload route. Guarded by `not job.lynx_subject_image` so an explicit value is never clobbered.

Despite sharing the upload slot, the image is **not** a first frame — Lynx is a T2V base and the subject never appears as frame 0.

Tests assert the mirror exists, is Lynx-only, and does not clobber an explicit value.