### PR TITLE
fix(workers): a re-register must not cancel a pending drain

### DIFF
--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -13,6 +13,22 @@ from app.schemas.workers import WorkerDrain, WorkerHeartbeat, WorkerRegister, Wo
 router = APIRouter()
 
 
+def reregistered_drain_state(
+    current_status: str | None, current_drain_after: int | None
+) -> tuple[str, int | None]:
+    """Status + drain countdown for a worker that is re-registering.
+
+    A re-register must NOT cancel a pending drain. The daemon re-registers on every
+    start, and a RunPod container respawns automatically when the daemon exits — so
+    resetting here silently erased operator drain requests roughly 30s after they took
+    effect, and the worker went straight back to claiming work. Cancelling a drain is
+    an explicit action: DELETE /workers/{id}/drain.
+    """
+    if current_status == "draining":
+        return "draining", None
+    return "online-idle", current_drain_after
+
+
 @router.post("/workers", response_model=WorkerResponse, status_code=201, dependencies=[Depends(verify_api_key)])
 async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_db)):
     # Upsert: if friendly_name already exists, reclaim that row
@@ -24,8 +40,9 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
         worker.hostname = body.hostname
         worker.ip_address = body.ip_address
         worker.comfyui_running = body.comfyui_running
-        worker.status = "online-idle"
-        worker.drain_after_jobs = None
+        worker.status, worker.drain_after_jobs = reregistered_drain_state(
+            worker.status, worker.drain_after_jobs
+        )
         worker.last_heartbeat = datetime.now(timezone.utc)
     else:
         worker = Worker(

--- a/tests/test_worker_drain.py
+++ b/tests/test_worker_drain.py
@@ -1,0 +1,47 @@
+"""Tests for drain state surviving a worker re-registration.
+
+The regression these guard: a drain was silently cancelled ~30s after it took effect.
+The daemon honours the drain, finishes its segment and exits; the RunPod container then
+respawns automatically, the daemon re-registers under the same friendly_name, and
+register_worker reset status to "online-idle" and drain_after_jobs to None. The worker
+resumed claiming work, so the drain looked like it had been ignored entirely.
+
+Pure logic — no HTTP, no database, matching the house style.
+"""
+
+import pytest
+
+from app.routes.workers import reregistered_drain_state
+
+
+class TestDrainSurvivesReregistration:
+    def test_draining_status_is_preserved(self):
+        """The bug: this used to come back ("online-idle", None)."""
+        assert reregistered_drain_state("draining", None) == ("draining", None)
+
+    def test_pending_countdown_is_preserved(self):
+        """drain-after-N is an operator request too, and must survive a restart."""
+        assert reregistered_drain_state("online-busy", 3) == ("online-idle", 3)
+
+    @pytest.mark.parametrize("status", ["online-idle", "online-busy", "offline", None])
+    def test_non_draining_worker_comes_back_idle(self, status):
+        assert reregistered_drain_state(status, None) == ("online-idle", None)
+
+    def test_draining_clears_the_countdown(self):
+        """Once status is draining the countdown is spent; keeping it would let a later
+        cancel_drain leave a stale countdown that re-drains the worker unexpectedly."""
+        assert reregistered_drain_state("draining", 2) == ("draining", None)
+
+    def test_countdown_is_not_decremented_here(self):
+        """Only update_status decrements. A restart must not consume a job's worth."""
+        _, remaining = reregistered_drain_state("online-busy", 5)
+        assert remaining == 5
+
+
+class TestCancelIsTheOnlyEscape:
+    def test_a_drained_worker_stays_drained_across_restarts(self):
+        """Restart loop: each cycle must keep returning 'draining', never drift to idle."""
+        status, after = "draining", None
+        for _ in range(5):
+            status, after = reregistered_drain_state(status, after)
+        assert (status, after) == ("draining", None)


### PR DESCRIPTION
## The bug

Requesting a drain appeared to do nothing — the worker kept claiming jobs.

`register_worker` reset both drain fields with no guard:

```python
worker.status = "online-idle"
worker.drain_after_jobs = None
```

The daemon honours the drain correctly: heartbeat sees `status='draining'`, finishes the current segment, deregisters, and calls `_stop_runpod_pod()`. But if that stop is a no-op (missing `RUNPOD_API_KEY`), the container respawns, the daemon re-registers under the same `friendly_name`, and the drain is erased. Net effect: drained, then un-drained ~30 seconds later.

`update_status:152` already protects this case. `register` didn't.

## Fix

`reregistered_drain_state()` — pure function, so it is testable without HTTP or a database (house style):

- `draining` → stays `draining`
- pending `drain_after_jobs` countdown → preserved, and **not** decremented (a restart must not consume a job's worth)
- anything else → `online-idle`

Cancelling stays explicit via `DELETE /workers/{id}/drain`.

## Testing

217 passed (208 baseline + 9 new). I verified the new tests actually catch the old behaviour rather than passing vacuously — reverting the fix fails 5 of the 9.

Companion daemon PR makes the silent `_stop_runpod_pod` failure loud, which is what hid this.