### PR TITLE
feat(smashcut): per-clip playback speed

### DIFF
--- a/alembic/versions/051_add_smashcut_clip_speeds.py
+++ b/alembic/versions/051_add_smashcut_clip_speeds.py
@@ -1,0 +1,29 @@
+"""Add per-clip playback speed to smashcut carriers
+
+Revision ID: 051
+Revises: 050
+Create Date: 2026-07-31
+
+Smashcut clips can now be retimed individually (slow-motion through fast-forward). The
+speeds ride in a list parallel to the existing smashcut_clip_paths rather than reshaping
+that column into objects, so a daemon running older code still reads the paths it expects
+and simply builds the montage at 1x instead of failing on an unrecognised shape.
+
+Nullable with no backfill: NULL means "no retiming", which is exactly what every existing
+smashcut carrier did.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "051"
+down_revision = "050"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("smashcut_clip_speeds", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "smashcut_clip_speeds")

--- a/app/models.py
+++ b/app/models.py
@@ -158,6 +158,10 @@ class Segment(Base):
     # output_paths to concatenate + the transition style ("seamless" | "black").
     smashcut_clip_paths = mapped_column(JSON, nullable=True)
     smashcut_transition = mapped_column(String(20), nullable=True)
+    # Per-clip playback speed, aligned 1:1 with smashcut_clip_paths. NULL means "no retiming"
+    # (the common case) and keeps the daemon on its fast stream-copy concat path. Distinct
+    # from Segment.speed above, which is a generation-time motion-density knob.
+    smashcut_clip_speeds = mapped_column(JSON, nullable=True)
     # Per-segment video-settings override (live link). Takes precedence over the job's preset.
     video_preset_id = mapped_column(
         UUID(as_uuid=True), ForeignKey("video_settings_presets.id", ondelete="SET NULL"), nullable=True

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -392,7 +392,9 @@ async def claim_next_segment(
     await db.commit()
     await db.refresh(segment)
 
-    smashcut_clip_paths = segment.smashcut_clip_paths if segment.reprocess_type == "smashcut_concat" else None
+    is_smashcut = segment.reprocess_type == "smashcut_concat"
+    smashcut_clip_paths = segment.smashcut_clip_paths if is_smashcut else None
+    smashcut_clip_speeds = segment.smashcut_clip_speeds if is_smashcut else None
 
     return SegmentClaimResponse(
         id=segment.id,
@@ -444,6 +446,7 @@ async def claim_next_segment(
         hologram_depth_scale_m=segment.hologram_depth_scale_m,
         smashcut_clip_paths=smashcut_clip_paths,
         smashcut_transition=segment.smashcut_transition,
+        smashcut_clip_speeds=smashcut_clip_speeds,
         # Lynx tunables live on the job (they describe the whole generation, not one
         # segment) and are passed through verbatim: None means "daemon settings default".
         generation_engine=job.generation_engine,
@@ -977,6 +980,36 @@ async def list_segment_clips(
     ]
 
 
+SMASHCUT_SPEED_MIN = 0.25
+SMASHCUT_SPEED_MAX = 4.0
+
+
+def normalize_clip_speeds(clip_count: int, speeds: list[float] | None) -> list[float] | None:
+    """Validate per-clip smashcut playback speeds, aligned 1:1 with the ordered clips.
+
+    Collapses to None when nothing is actually retimed, which keeps the daemon on its fast
+    stream-copy concat path — the field is a request for extra work, so an all-1.0 list must
+    not read as one. Bounds match Segment.speed's, though the two are unrelated: that one is
+    generation-time motion density, this one is playback rate on a finished clip.
+    """
+    if speeds is None:
+        return None
+    if len(speeds) != clip_count:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Expected {clip_count} clip speeds to match the picked clips, got {len(speeds)}",
+        )
+    for s in speeds:
+        if not SMASHCUT_SPEED_MIN <= s <= SMASHCUT_SPEED_MAX:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Clip speed {s}x is outside {SMASHCUT_SPEED_MIN}x-{SMASHCUT_SPEED_MAX}x",
+            )
+    if all(s == 1.0 for s in speeds):
+        return None
+    return [float(s) for s in speeds]
+
+
 @router.post("/smashcut", response_model=SegmentResponse)
 async def create_smashcut(
     body: SmashcutRequest,
@@ -993,6 +1026,7 @@ async def create_smashcut(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Pick at least 2 clips")
     if body.transition not in ("seamless", "black"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid transition")
+    clip_speeds = normalize_clip_speeds(len(body.segment_ids), body.clip_speeds)
 
     # Resolve the picked segments (must be the user's, completed, with output). Preserve order.
     rows = (
@@ -1039,6 +1073,7 @@ async def create_smashcut(
         reprocess_type="smashcut_concat",
         smashcut_clip_paths=clip_paths,
         smashcut_transition=body.transition,
+        smashcut_clip_speeds=clip_speeds,
     )
     db.add(carrier)
     await db.commit()

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -139,6 +139,7 @@ class SegmentClaimResponse(BaseModel):
     # Foundry smashcut (reprocess_type="smashcut_concat"): ordered source clip paths + transition.
     smashcut_clip_paths: Optional[list[str]] = None
     smashcut_transition: Optional[str] = None
+    smashcut_clip_speeds: Optional[list[float]] = None
     # === Lynx identity-preserving engine (resolved from the job) ===
     # generation_engine="lynx" routes the daemon to build_lynx_workflow. Each lynx_*
     # value is a per-job override; None means "use the daemon's settings default".
@@ -166,6 +167,9 @@ class SmashcutRequest(BaseModel):
     name: str
     segment_ids: list[UUID]  # ordered
     transition: str = "seamless"  # "seamless" (butt-splice) | "black" (dip-to-black)
+    # Per-clip playback speed, aligned 1:1 with segment_ids. Omit (or send all 1.0) for no
+    # retiming. <1 is slow-motion, >1 is fast-forward.
+    clip_speeds: Optional[list[float]] = None
 
 
 class SegmentClipResponse(BaseModel):

--- a/tests/test_smashcut_speed.py
+++ b/tests/test_smashcut_speed.py
@@ -1,0 +1,69 @@
+"""Tests for per-clip smashcut playback-speed validation.
+
+Two behaviours matter beyond plain range-checking:
+
+  * An all-1.0 list must collapse to None. The daemon keys its fast stream-copy concat on
+    "no speeds requested"; a list of 1.0s would silently force a full re-encode that changes
+    nothing, so the cheap path has to survive a UI that always sends its defaults.
+
+  * Length must match the picked clips. The speeds ride in a list parallel to the clip paths,
+    so a mismatch is not a cosmetic error — it would misalign every clip after the gap and
+    retime the wrong ones.
+
+Pure logic — no HTTP, no database, matching the house style.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.routes.segments import SMASHCUT_SPEED_MAX, SMASHCUT_SPEED_MIN, normalize_clip_speeds
+
+
+class TestNoRetimingCollapsesToNone:
+    def test_omitted_speeds_stay_none(self):
+        assert normalize_clip_speeds(3, None) is None
+
+    def test_all_ones_collapse_to_none(self):
+        """The console sends a full list every build; defaults must not cost a re-encode."""
+        assert normalize_clip_speeds(3, [1.0, 1.0, 1.0]) is None
+
+    def test_one_non_default_keeps_the_whole_list(self):
+        assert normalize_clip_speeds(3, [1.0, 2.0, 1.0]) == [1.0, 2.0, 1.0]
+
+
+class TestAlignmentWithClips:
+    @pytest.mark.parametrize("count,speeds", [
+        (3, [1.0, 2.0]),          # too few — every later clip would shift
+        (2, [1.0, 2.0, 1.0]),     # too many
+        (2, []),                  # empty is not "unspecified"; None is
+    ])
+    def test_length_mismatch_is_rejected(self, count, speeds):
+        with pytest.raises(HTTPException) as e:
+            normalize_clip_speeds(count, speeds)
+        assert e.value.status_code == 400
+
+    def test_order_is_preserved(self):
+        """Position is the only thing binding a speed to its clip."""
+        assert normalize_clip_speeds(4, [2.0, 0.5, 1.0, 4.0]) == [2.0, 0.5, 1.0, 4.0]
+
+
+class TestBounds:
+    @pytest.mark.parametrize("bad", [0.0, 0.1, 4.1, 100.0, -1.0])
+    def test_out_of_range_is_rejected(self, bad):
+        with pytest.raises(HTTPException) as e:
+            normalize_clip_speeds(1, [bad])
+        assert e.value.status_code == 400
+
+    @pytest.mark.parametrize("edge", [SMASHCUT_SPEED_MIN, SMASHCUT_SPEED_MAX])
+    def test_the_bounds_themselves_are_allowed(self, edge):
+        assert normalize_clip_speeds(1, [edge]) == [edge]
+
+    def test_slow_motion_is_supported(self):
+        """Below 1.0 is the whole point of the lower bound — not just a guard."""
+        assert normalize_clip_speeds(2, [0.5, 0.25]) == [0.5, 0.25]
+
+    def test_ints_are_coerced_to_float(self):
+        """JSON sends 2, not 2.0; the daemon divides by this value."""
+        result = normalize_clip_speeds(1, [2])
+        assert result == [2.0]
+        assert isinstance(result[0], float)


### PR DESCRIPTION
Each clip in a smashcut can now be retimed independently — **0.25x slow-motion through 4x fast-forward**.

Pairs with wanly-gpu-daemon and wanly-console PRs of the same name.

### Data model
Speeds ride in `smashcut_clip_speeds`, a list **parallel** to `smashcut_clip_paths`, rather than reshaping that column into `[{path, speed}]` objects. That way a daemon still running older code reads the paths it expects and builds at 1x, instead of failing on a shape it doesn't recognise — which matters because the daemon `git pull`s at boot and can lag the API by a restart.

Migration `051` adds the column nullable with **no backfill**: NULL means "no retiming", which is exactly what every existing carrier did.

### `normalize_clip_speeds`
Collapses an all-1.0 list to NULL. The console sends a full list on every build, and the daemon keys its fast stream-copy concat on "no speeds requested" — without the collapse, untouched defaults would silently force a full re-encode that changes nothing.

Length mismatches are a 400, not a truncation: the lists are positional, so a gap would retime the wrong clips.

### Naming
`Segment.speed` already exists with the same 0.25–4.0 bounds and means something **different** — generation-time motion density. This one is playback rate on a finished clip. Named `smashcut_clip_speeds` / `clip_speeds` throughout so the two never get confused, and both are commented to say so.

### Verification
- 233 tests pass (217 baseline + 16 new in `tests/test_smashcut_speed.py`, pure-logic house style).
- Migration verified offline: `alembic upgrade 050:051 --sql` emits `ALTER TABLE segments ADD COLUMN smashcut_clip_speeds JSON;`.
- Confirmed the field is present on `SegmentClaimResponse` — this repo hand-builds that response, and fields missing from the schema get silently dropped.