### PR TITLE
feat(stats): window the run-time average and add total queue time

### DIFF
--- a/app/estimation.py
+++ b/app/estimation.py
@@ -81,6 +81,26 @@ async def get_estimation_rates(
     }
 
 
+def sum_estimated_queue_time(rates: dict, segments) -> float:
+    """Total estimated seconds for a set of queued segments.
+
+    Each row is (width, height, fps, duration_seconds, worker_name).
+
+    A segment the estimator cannot price — no completed run at that config and no global
+    rate to fall back on — contributes nothing rather than a guess. That makes the total
+    read low on a cold database instead of confidently wrong, which is the safer failure
+    for a number used to decide whether there is time to queue more work.
+    """
+    total = 0.0
+    for width, height, fps, duration_seconds, worker_name in segments:
+        if not duration_seconds:
+            continue
+        est = estimate_segment_time(rates, width, height, fps, duration_seconds, worker_name)
+        if est:
+            total += est
+    return round(total, 1)
+
+
 def estimate_segment_time(
     rates: dict,
     width: int,

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -4,7 +4,7 @@ import json
 import os
 import random
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
@@ -18,7 +18,7 @@ from app.auth import get_current_user
 from app.config import settings
 from app.database import get_db
 from app.enums import JOB_VALID_TRANSITIONS, JobStatus, SegmentStatus, VideoStatus
-from app.estimation import estimate_segment_time, get_estimation_rates
+from app.estimation import estimate_segment_time, get_estimation_rates, sum_estimated_queue_time
 from app.helpers import upload_faceswap_image
 from app.models import Job, Lora, Segment, User, Video
 from app.routes.segments import _resolve_loras, _resolve_wildcards
@@ -739,6 +739,18 @@ async def delete_job(
     await db.commit()
 
 
+STATS_WINDOW_HOURS = 24
+# What counts as "still queued". Mirrors the job-queue view so the dashboard total and the
+# per-job estimates there are derived from the same set of work. Awaiting jobs are excluded:
+# they are blocked on a prompt, so their segments are not waiting on a worker.
+QUEUE_JOB_STATUSES = (JobStatus.PENDING, JobStatus.PROCESSING)
+QUEUE_SEGMENT_STATUSES = (
+    SegmentStatus.PENDING,
+    SegmentStatus.CLAIMED,
+    SegmentStatus.PROCESSING,
+)
+
+
 @router.get("/stats", response_model=StatsResponse)
 async def get_stats(
     user: User = Depends(get_current_user),
@@ -765,24 +777,49 @@ async def get_stats(
     ).all()
     segments_by_status = {row[0]: row[1] for row in seg_rows}
 
-    # Avg run time and totals for completed segments
-    agg = (
+    # Avg run time over a rolling window, not all of history. A lifetime average barely
+    # moves once there are thousands of segments behind it, so it stops reflecting how the
+    # current models, settings and workers are actually performing.
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=STATS_WINDOW_HOURS)
+    avg_run_time = (
         await db.execute(
             select(
                 func.avg(
                     func.extract("epoch", Segment.completed_at)
                     - func.extract("epoch", Segment.claimed_at)
-                ),
-                func.count(),
-                func.coalesce(func.sum(Segment.duration_seconds), 0),
+                )
             )
             .join(Job, Segment.job_id == Job.id)
-            .where(Job.user_id == user.id, Segment.status == SegmentStatus.COMPLETED)
+            .where(
+                Job.user_id == user.id,
+                Segment.status == SegmentStatus.COMPLETED,
+                Segment.claimed_at.isnot(None),
+                Segment.completed_at >= cutoff,
+            )
         )
-    ).one()
-    avg_run_time = round(agg[0], 1) if agg[0] is not None else None
-    total_completed = agg[1]
-    total_video_time = float(agg[2])
+    ).scalar_one_or_none()
+    avg_run_time = round(avg_run_time, 1) if avg_run_time is not None else None
+
+    # Work still outstanding, priced with the same estimator the job queue uses so the two
+    # views agree. Segments the estimator cannot price (no comparable completed run yet)
+    # contribute nothing, so this reads low rather than guessing.
+    queue_rows = (
+        await db.execute(
+            select(
+                Job.width, Job.height, Job.fps, Segment.duration_seconds, Segment.worker_name
+            )
+            .join(Job, Segment.job_id == Job.id)
+            .where(
+                Job.user_id == user.id,
+                Job.status.in_(QUEUE_JOB_STATUSES),
+                Segment.status.in_(QUEUE_SEGMENT_STATUSES),
+            )
+        )
+    ).all()
+    total_queue_time = 0.0
+    if queue_rows:  # skip three estimator queries when the queue is empty
+        rates = await get_estimation_rates(db, user.id)
+        total_queue_time = sum_estimated_queue_time(rates, queue_rows)
 
     # Worker stats
     worker_rows = (
@@ -818,8 +855,7 @@ async def get_stats(
     return StatsResponse(
         jobs_by_status=jobs_by_status,
         segments_by_status=segments_by_status,
-        avg_segment_run_time=avg_run_time,
-        total_segments_completed=total_completed,
-        total_video_time=total_video_time,
+        avg_segment_run_time_24h=avg_run_time,
+        total_queue_time=total_queue_time,
         worker_stats=worker_stats,
     )

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -147,7 +147,10 @@ class WorkerStatsItem(BaseModel):
 class StatsResponse(BaseModel):
     jobs_by_status: dict[str, int]
     segments_by_status: dict[str, int]
-    avg_segment_run_time: Optional[float]
-    total_segments_completed: int
-    total_video_time: float
+    # Windowed rather than lifetime: a rolling average over every segment ever run stops
+    # moving, so it says nothing about how the rig is performing now.
+    avg_segment_run_time_24h: Optional[float]
+    # Estimated seconds of work still queued: every active segment of every active job,
+    # priced with the same estimator the job queue uses.
+    total_queue_time: float
     worker_stats: list[WorkerStatsItem]

--- a/tests/test_queue_time.py
+++ b/tests/test_queue_time.py
@@ -1,0 +1,77 @@
+"""Tests for the dashboard's Total Queue Time sum.
+
+The number answers "is there room to queue more work", so the failure that matters is a
+confident overestimate. An unpriceable segment therefore contributes nothing rather than a
+fallback guess, and the total reads low on a cold database instead of wrong.
+
+Pure logic — no HTTP, no database, matching the house style.
+"""
+
+import pytest
+
+from app.estimation import sum_estimated_queue_time
+
+# (width, height, fps, duration_seconds, worker_name)
+ROW = (720, 1056, 30, 4.0, "3090.zero")
+
+
+def rates(*, config=None, worker=None, global_rate=None):
+    return {
+        "rates": config or {},
+        "worker_rates": worker or {},
+        "global_rate": global_rate,
+    }
+
+
+class TestSumming:
+    def test_empty_queue_is_zero(self):
+        assert sum_estimated_queue_time(rates(global_rate=2.0), []) == 0.0
+
+    def test_sums_across_segments(self):
+        r = rates(global_rate=2.0)
+        assert sum_estimated_queue_time(r, [ROW, ROW, ROW]) == pytest.approx(24.0)
+
+    def test_mixed_configs_each_use_their_own_rate(self):
+        """A 720p and a 1080p segment must not be priced with the same rate."""
+        r = rates(config={(720, 1056, 30): 2.0, (1056, 720, 30): 5.0})
+        total = sum_estimated_queue_time(r, [
+            (720, 1056, 30, 4.0, None),
+            (1056, 720, 30, 4.0, None),
+        ])
+        assert total == pytest.approx(8.0 + 20.0)
+
+
+class TestUnpriceableSegments:
+    def test_no_rate_at_all_contributes_nothing(self):
+        """Cold database: better to read 0 than to invent a duration."""
+        assert sum_estimated_queue_time(rates(), [ROW, ROW]) == 0.0
+
+    def test_priceable_segments_still_count_when_others_cannot_be_priced(self):
+        """One unknown config must not zero out the whole total."""
+        r = rates(config={(720, 1056, 30): 2.0})
+        total = sum_estimated_queue_time(r, [ROW, (9999, 9999, 30, 4.0, None)])
+        assert total == pytest.approx(8.0)
+
+    @pytest.mark.parametrize("duration", [0, 0.0, None])
+    def test_segments_with_no_duration_are_skipped(self, duration):
+        """duration_seconds is nullable; rate * None would raise rather than degrade."""
+        r = rates(global_rate=2.0)
+        assert sum_estimated_queue_time(r, [(720, 1056, 30, duration, None)]) == 0.0
+
+
+class TestRateSelection:
+    def test_worker_rate_wins_over_config_rate(self):
+        """A known worker's measured pace is the best predictor available."""
+        r = rates(
+            config={(720, 1056, 30): 10.0},
+            worker={(720, 1056, 30, "3090.zero"): 2.0},
+        )
+        assert sum_estimated_queue_time(r, [ROW]) == pytest.approx(8.0)
+
+    def test_falls_back_to_global_when_config_is_unseen(self):
+        assert sum_estimated_queue_time(rates(global_rate=3.0), [ROW]) == pytest.approx(12.0)
+
+    def test_unclaimed_segments_use_the_config_rate(self):
+        """Pending segments have no worker_name yet — the common case for a deep queue."""
+        r = rates(config={(720, 1056, 30): 2.0})
+        assert sum_estimated_queue_time(r, [(720, 1056, 30, 4.0, None)]) == pytest.approx(8.0)


### PR DESCRIPTION
Backs the dashboard card changes. Pairs with wanly-console#265.

### `avg_segment_run_time` → `avg_segment_run_time_24h`
Not just a relabel — the computation changes, and the old number was materially wrong. Measured against production:

| | value | from |
|---|---|---|
| last 24h | **1228.2s** (20m 28s) | 63 segments |
| lifetime (current behaviour) | 450.3s (7m 30s) | 3,015 segments |

Three thousand historical segments were drowning out current performance, so the card under-reported by **2.7x**. A lifetime average stops moving and stops meaning anything.

### New: `total_queue_time`
Estimated seconds of work still outstanding, summed with the **same estimator the job queue already uses** (`app/estimation.py`) so the two views can't disagree. Production reads 3.11h across 7 queued segments, 0 unpriceable.

Segments the estimator can't price contribute **nothing** rather than a fallback guess. This number answers "is there room to queue more work", so reading low on a cold database is the safer failure than reading confidently wrong.

Scoped to active segments (`pending`/`claimed`/`processing`) of active jobs (`pending`/`processing`), mirroring the job-queue view. Awaiting jobs are excluded — they're blocked on a prompt, not on a worker.

The estimator's three rate queries are skipped entirely when the queue is empty.

### Removed
`total_segments_completed` and `total_video_time` — the dashboard was their only consumer. Checked: `Videos.tsx` and `JobDetail.tsx` have their own `total_video_time` on *different* objects; those are untouched.

### Known pre-existing bug, not fixed here
`jobs.py` builds its per-job estimate with `est_map[seg_job_id] = est` inside a loop over segments, so a job with several active segments reports only its **last** segment's estimate instead of the sum. That means the queue page's per-job numbers understate multi-segment jobs, and won't add up to this new total. Flagging rather than fixing — it's outside this change and worth its own PR.

### Verification
244 tests pass (233 baseline + 11 new in `tests/test_queue_time.py`, pure-logic house style). Numbers above are real, queried through SSM against the production database using the deployed container's own estimator.