### PR TITLE
fix(seed-faceswap): per-segment flag so the seed re-anchor can actually fire

### DIFF
--- a/alembic/versions/050_add_segment_seed_faceswap.py
+++ b/alembic/versions/050_add_segment_seed_faceswap.py
@@ -1,0 +1,35 @@
+"""Add seed_faceswap to segments
+
+Revision ID: 050
+Revises: 049
+Create Date: 2026-08-02
+
+Seed re-anchor moves from a global app setting to a per-segment flag.
+
+The global version could never fire: it gated on "a later segment exists at claim time",
+but jobs are created with segment 0 only and continuations are appended afterwards, so
+the successor never existed when segment 0 was claimed. Per-segment removes the gate
+entirely — the flag is set by the author, and the face comes from the segment's own
+faceswap selection instead of a hardcoded per-LoRA map.
+
+The old app_settings row is deleted here; nothing reads it after this revision.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "050"
+down_revision = "049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "segments",
+        sa.Column("seed_faceswap", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.execute("DELETE FROM app_settings WHERE key = 'seed_faceswap'")
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "seed_faceswap")

--- a/app/models.py
+++ b/app/models.py
@@ -120,6 +120,10 @@ class Segment(Base):
     faceswap_image = mapped_column(Text, nullable=True)
     faceswap_faces_order = mapped_column(Text, nullable=True)
     faceswap_faces_index = mapped_column(Text, nullable=True)
+    # Seed re-anchor: faceswap this segment's last frame to the segment's faceswap face
+    # before it seeds the next segment. Author-set per segment (no successor gate: the
+    # successor does not exist yet when this segment is claimed).
+    seed_faceswap = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     auto_finalize = mapped_column(Boolean, nullable=False, default=False)
     transition = mapped_column(String(20), nullable=True, default=None)
     trim_start_frames = mapped_column(Integer, nullable=False, default=0)

--- a/app/routes/app_settings.py
+++ b/app/routes/app_settings.py
@@ -23,7 +23,6 @@ _DEFAULTS = {
     "negative_prompt": "",
     "continuation_mode": "traditional",
     "vace_overlap_frames": "12",
-    "seed_faceswap": "false",
 }
 
 
@@ -45,7 +44,6 @@ def _to_response(settings: dict[str, str]) -> AppSettingsResponse:
         negative_prompt=settings["negative_prompt"],
         continuation_mode=settings.get("continuation_mode", "traditional"),
         vace_overlap_frames=int(settings.get("vace_overlap_frames", "12")),
-        seed_faceswap=settings.get("seed_faceswap", "false").strip().lower() in ("1", "true", "on", "yes"),
     )
 
 

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -200,6 +200,7 @@ async def create_job(
         faceswap_image=faceswap_uri if faceswap_uri else seg.faceswap_image,
         faceswap_faces_order=seg.faceswap_faces_order,
         faceswap_faces_index=seg.faceswap_faces_index,
+        seed_faceswap=seg.seed_faceswap,
         negative_prompt=seg.negative_prompt,
         auto_finalize=seg.auto_finalize,
         video_preset_id=seg.video_preset_id,

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -198,6 +198,7 @@ async def add_segment(
         faceswap_image=body.faceswap_image,
         faceswap_faces_order=body.faceswap_faces_order,
         faceswap_faces_index=body.faceswap_faces_index,
+        seed_faceswap=body.seed_faceswap,
         negative_prompt=negative_prompt,
         auto_finalize=body.auto_finalize,
         video_preset_id=body.video_preset_id,
@@ -345,19 +346,15 @@ async def claim_next_segment(
     )
     continuation_mode = "vace" if use_vace else "traditional"
 
-    # Seed re-anchor: faceswap this segment's last frame to the canonical identity before it
-    # seeds the next segment. Only when the global setting is on AND a later segment exists
-    # (so single-segment / final segments never pay the extra faceswap round-trip).
-    sf_setting = await db.get(AppSetting, "seed_faceswap")
-    seed_faceswap_on = bool(sf_setting) and sf_setting.value.strip().lower() in ("1", "true", "on", "yes")
-    seed_faceswap = False
-    if seed_faceswap_on:
-        successor_id = await db.scalar(
-            select(Segment.id)
-            .where(Segment.job_id == job.id, Segment.index > segment.index)
-            .limit(1)
-        )
-        seed_faceswap = successor_id is not None
+    # Seed re-anchor: faceswap this segment's last frame to its own faceswap face before the
+    # frame seeds the next segment. Author-set per segment.
+    #
+    # This used to be a global app setting gated on "a later segment already exists". That
+    # gate could never pass: a job is created with segment 0 only and continuations are
+    # appended after it runs, so at claim time there is never a successor. The feature was
+    # dead in every job. No gate now — if the author asked for it, it fires. The cost when
+    # the segment turns out to be last is one wasted still-image faceswap (seconds).
+    seed_faceswap = bool(segment.seed_faceswap)
 
     # Resolve video (sampler) settings: segment's preset -> job's preset -> job's raw params.
     # Live-linked, so editing a preset changes future claims that reference it.

--- a/app/schemas/app_settings.py
+++ b/app/schemas/app_settings.py
@@ -18,7 +18,6 @@ class AppSettingsResponse(BaseModel):
     vace_overlap_frames: int = 12
     # Seed re-anchor: faceswap each continuation segment's last frame to the canonical
     # identity before it seeds the next segment (only fires when a successor exists).
-    seed_faceswap: bool = False
 
 
 class AppSettingsUpdate(BaseModel):
@@ -32,4 +31,3 @@ class AppSettingsUpdate(BaseModel):
     negative_prompt: Optional[str] = None
     continuation_mode: Optional[str] = None
     vace_overlap_frames: Optional[int] = None
-    seed_faceswap: Optional[bool] = None

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -17,6 +17,9 @@ class SegmentCreate(BaseModel):
     faceswap_image: Optional[str] = None
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
+    # Re-anchor this segment's last frame to the faceswap face before it seeds the next
+    # segment. Uses faceswap_image, so it only has an effect when faceswap is configured.
+    seed_faceswap: bool = False
     negative_prompt: Optional[str] = None
     auto_finalize: bool = False
     transition: Optional[str] = None
@@ -39,6 +42,7 @@ class SegmentResponse(BaseModel):
     faceswap_image: Optional[str]
     faceswap_faces_order: Optional[str]
     faceswap_faces_index: Optional[str]
+    seed_faceswap: bool = False
     negative_prompt: Optional[str] = None
     auto_finalize: bool
     transition: Optional[str]

--- a/tests/test_seed_faceswap.py
+++ b/tests/test_seed_faceswap.py
@@ -1,0 +1,128 @@
+"""Tests for the per-segment seed re-anchor flag.
+
+Context: seed_faceswap started as a GLOBAL app setting gated on "a later segment already
+exists at claim time". That gate can never pass — a job is created with segment 0 only and
+continuations are appended after it runs, so at claim time there is never a successor. The
+feature was dead in every job it ever ran against (26 multi-segment jobs, 0 activations),
+and it had no tests, which is why it stayed dead.
+
+These tests pin the three things that made it broken:
+  1. no successor gate on the claim
+  2. the flag lives on the segment and survives create -> persist -> claim
+  3. the global app setting is gone, so it cannot be resurrected as a second source of truth
+
+Unit-level (no live DB), matching the rest of this suite. The AST checks follow the
+hand-built-response guard in test_lynx_engine.py: a field can exist on the schema and the
+model and still be silently dropped by a field-by-field construction.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.models import Segment
+from app.schemas.app_settings import AppSettingsResponse, AppSettingsUpdate
+from app.schemas.segments import SegmentClaimResponse, SegmentCreate, SegmentResponse
+
+ROOT = Path(__file__).resolve().parents[1]
+SEGMENTS_ROUTE = ROOT / "app" / "routes" / "segments.py"
+JOBS_ROUTE = ROOT / "app" / "routes" / "jobs.py"
+
+
+class TestSchemaContract:
+    def test_segment_create_defaults_off(self):
+        assert SegmentCreate(prompt="x").seed_faceswap is False
+
+    def test_segment_create_accepts_the_flag(self):
+        assert SegmentCreate(prompt="x", seed_faceswap=True).seed_faceswap is True
+
+    def test_claim_response_carries_the_flag(self):
+        """The daemon reads this field; if it is missing the re-anchor silently never runs."""
+        assert "seed_faceswap" in SegmentClaimResponse.model_fields
+
+    def test_segment_response_carries_the_flag(self):
+        """Console needs it back to render the checkbox state on an existing segment."""
+        assert "seed_faceswap" in SegmentResponse.model_fields
+
+    def test_model_has_the_column(self):
+        assert hasattr(Segment, "seed_faceswap")
+
+
+class TestGlobalSettingIsGone:
+    """One source of truth. A lingering global would silently fight the per-segment value."""
+
+    def test_not_on_the_settings_response(self):
+        assert "seed_faceswap" not in AppSettingsResponse.model_fields
+
+    def test_not_on_the_settings_update(self):
+        assert "seed_faceswap" not in AppSettingsUpdate.model_fields
+
+    def test_not_in_the_settings_defaults(self):
+        src = (ROOT / "app" / "routes" / "app_settings.py").read_text()
+        assert "seed_faceswap" not in src
+
+
+class TestNoSuccessorGate:
+    """THE regression. The claim must not condition the flag on a later segment existing."""
+
+    def _claim_fn(self) -> ast.AST:
+        tree = ast.parse(SEGMENTS_ROUTE.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "get_next_segment":
+                return node
+        # name may differ; fall back to the function containing the claim response
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) \
+                            and sub.func.id == "SegmentClaimResponse":
+                        return node
+        pytest.fail("could not locate the claim route function")
+
+    def test_claim_does_not_query_for_a_successor(self):
+        src = ast.unparse(self._claim_fn())
+        assert "successor" not in src, (
+            "the claim route still gates seed_faceswap on a successor segment; that gate "
+            "can never pass because continuations are appended after segment 0 runs"
+        )
+
+    def test_claim_does_not_read_the_global_app_setting(self):
+        src = ast.unparse(self._claim_fn())
+        assert 'AppSetting, "seed_faceswap"' not in src
+        assert "seed_faceswap_on" not in src
+
+    def test_claim_resolves_the_flag_from_the_segment(self):
+        src = ast.unparse(self._claim_fn())
+        assert "segment.seed_faceswap" in src
+
+
+class TestPersistence:
+    """A field can exist everywhere and still be dropped by a field-by-field construction."""
+
+    def _kwargs_for(self, path: Path, callee: str) -> list[set[str]]:
+        tree = ast.parse(path.read_text())
+        out = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) \
+                    and node.func.id == callee:
+                out.append({kw.arg for kw in node.keywords if kw.arg})
+        return out
+
+    def test_add_segment_persists_the_flag(self):
+        calls = self._kwargs_for(SEGMENTS_ROUTE, "Segment")
+        assert calls, "no Segment(...) construction in app/routes/segments.py"
+        assert any("seed_faceswap" in kw for kw in calls), (
+            "POST /jobs/{id}/segments drops seed_faceswap, so continuation segments "
+            "could never enable the re-anchor"
+        )
+
+    def test_job_creation_persists_the_flag_on_segment_zero(self):
+        calls = self._kwargs_for(JOBS_ROUTE, "Segment")
+        assert calls, "no Segment(...) construction in app/routes/jobs.py"
+        assert all("seed_faceswap" in kw for kw in calls)
+
+    def test_claim_response_passes_the_flag(self):
+        calls = self._kwargs_for(SEGMENTS_ROUTE, "SegmentClaimResponse")
+        assert len(calls) == 1, "expected exactly one claim construction site"
+        assert "seed_faceswap" in calls[0]


### PR DESCRIPTION
## The bug

The seed re-anchor has never run. The claim route gated it on *"a later segment already exists"*:

```python
successor_id = await db.scalar(
    select(Segment.id).where(Segment.job_id == job.id, Segment.index > segment.index).limit(1)
)
seed_faceswap = successor_id is not None
```

A job is created with **segment 0 only**; continuations are appended afterwards via `POST /jobs/{id}/segments`, which requires the job to already be `awaiting`/`failed`. So at the moment segment 0 is claimed there is never a successor, and the flag always resolved `False`.

**Measured:** since the 07-31 deploy, 26 jobs reached a Segment 1 and 5 reached a Segment 2. `[seed]` log lines: **0**. The executor reaches the call site (`[7/7] Extracting last frame` × 58) — the flag simply arrives `False`.

It shipped with zero test coverage, which is why the dead gate went unnoticed.

## Changes

- **Drop the successor gate.** The flag is author-set per segment; if it's requested, it fires. Worst case on a final segment is one wasted still-image faceswap (seconds against ~1700 s generation).
- **Move `seed_faceswap` from the global app setting onto the segment** (migration `050`, drops the dead `app_settings` row).
- Persist it on **both** creation paths — job `first_segment` and `add_segment`.
- **Remove the global app setting** so there's one source of truth.

## Tests

14 new, all passing (258 total, no regressions):

- schema contract — create/response/claim all carry the field
- **no-successor-gate regression** — asserts the claim route no longer references a successor query or the global setting
- AST guards that every hand-built construction passes the field, following the existing `test_lynx_engine.py` pattern

Pairs with wanly-gpu-daemon and wanly-console PRs on the same branch name.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct