### PR TITLE
fix(seed-faceswap): allow seed re-anchor without a whole-video faceswap

### DIFF
--- a/tests/test_seed_faceswap.py
+++ b/tests/test_seed_faceswap.py
@@ -48,6 +48,25 @@ class TestSchemaContract:
     def test_model_has_the_column(self):
         assert hasattr(Segment, "seed_faceswap")
 
+    def test_seed_only_is_valid_without_whole_video_faceswap(self):
+        """The re-anchor touches ONE frame; requiring the whole clip to be swapped as well
+        would be a different (and much more expensive) feature. The daemon resolves the face
+        from faceswap_image even when faceswap_enabled is False."""
+        seg = SegmentCreate(
+            prompt="x",
+            seed_faceswap=True,
+            faceswap_enabled=False,
+            faceswap_image="s3://wanly-loras/faces/kelly.png",
+        )
+        assert seg.seed_faceswap is True
+        assert seg.faceswap_enabled is False
+        assert seg.faceswap_image == "s3://wanly-loras/faces/kelly.png"
+
+    def test_whole_video_swap_without_seed_reanchor_is_valid(self):
+        """The other direction: swapping the clip does not imply re-anchoring the seed."""
+        seg = SegmentCreate(prompt="x", faceswap_enabled=True, seed_faceswap=False)
+        assert seg.faceswap_enabled is True and seg.seed_faceswap is False
+
 
 class TestGlobalSettingIsGone:
     """One source of truth. A lingering global would silently fight the per-segment value."""


### PR DESCRIPTION
## Problem

The version merged in #136 only exposed the re-anchor **when full faceswap was enabled** — which is the one configuration where it does nothing.

With a full-sequence swap, `_add_faceswap` feeds from node 87 (VAEDecode), so the swapped frames go into VideoCombine. The output video is already swapped, and `_extract_last_frame(video_data)` pulls from that video. The seed frame is therefore **already swapped**, and re-anchoring would swap an already-swapped face a second time — redundant, and a double-swap degrades quality.

The useful case is the opposite one: **no whole-video swap**, just a cheap identity re-anchor on the single frame that seeds the next segment.

## Change

Contract tests pinning both directions so the two can't be re-coupled:

- `seed_faceswap=True` + `faceswap_enabled=False` + a `faceswap_image` is valid
- `faceswap_enabled=True` + `seed_faceswap=False` is valid

No API logic change was needed — the claim already resolves `bool(segment.seed_faceswap)` independently. The coupling was entirely in the console.

Pairs with the wanly-console PR on the same branch.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct