### PR TITLE
fix(migrations): renumber seed_faceswap migration to 052 — 050 was already taken

### DIFF
--- a/alembic/versions/052_add_segment_seed_faceswap.py
+++ b/alembic/versions/052_add_segment_seed_faceswap.py
@@ -1,7 +1,7 @@
 """Add seed_faceswap to segments
 
-Revision ID: 050
-Revises: 049
+Revision ID: 052
+Revises: 051
 Create Date: 2026-08-02
 
 Seed re-anchor moves from a global app setting to a per-segment flag.
@@ -17,8 +17,8 @@ The old app_settings row is deleted here; nothing reads it after this revision.
 import sqlalchemy as sa
 from alembic import op
 
-revision = "050"
-down_revision = "049"
+revision = "052"
+down_revision = "051"
 branch_labels = None
 depends_on = None
 

--- a/tests/test_seed_faceswap.py
+++ b/tests/test_seed_faceswap.py
@@ -145,3 +145,32 @@ class TestPersistence:
         calls = self._kwargs_for(SEGMENTS_ROUTE, "SegmentClaimResponse")
         assert len(calls) == 1, "expected exactly one claim construction site"
         assert "seed_faceswap" in calls[0]
+
+
+class TestMigrationChain:
+    """A duplicate revision id gives alembic two heads and `upgrade head` fails, which
+    silently blocks every deploy. Both API deploys on 2026-08-02 died this way: this
+    migration was numbered 050, which 050_add_lynx_engine.py already used."""
+
+    def _chain(self):
+        import re, glob, os
+        nodes = {}
+        for f in sorted(glob.glob(str(ROOT / "alembic" / "versions" / "*.py"))):
+            src = open(f).read()
+            rev = re.search(r'^revision(?::[^=]+)? *= *["\'](.+?)["\']', src, re.M)
+            down = re.search(r'^down_revision(?::[^=]+)? *= *(?:["\'](.+?)["\']|None)', src, re.M)
+            if rev:
+                nodes.setdefault(rev.group(1), []).append(
+                    (down.group(1) if down and down.lastindex else None, os.path.basename(f))
+                )
+        return nodes
+
+    def test_no_duplicate_revision_ids(self):
+        dupes = {k: [f for _, f in v] for k, v in self._chain().items() if len(v) > 1}
+        assert not dupes, f"duplicate alembic revision ids will break `upgrade head`: {dupes}"
+
+    def test_exactly_one_head(self):
+        nodes = self._chain()
+        downs = {d for v in nodes.values() for d, _ in v if d}
+        heads = sorted(set(nodes) - downs)
+        assert len(heads) == 1, f"alembic must have exactly one head, found {heads}"


### PR DESCRIPTION
## Why the last two deploys failed

Both API deploys on 2026-08-02 (#136 and #137) show `completed/failure`. The code merged but never reached the server:

```
UserWarning: Revision 050 is present more than once
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head'
failed to run commands: exit status 255
```

`050_add_lynx_engine.py` already used revision `050`. I numbered the seed_faceswap migration `050` as well, which gave alembic **two heads**, so `alembic upgrade head` aborted and the deploy step exited 1.

Net effect: `main` has the new code, the running API does not. The deployed schema still shows `seed_faceswap` on `AppSettingsResponse`/`AppSettingsUpdate` — i.e. the pre-#136 code.

## Fix

- Renumber to **052**, `down_revision = "051"` (the real head — `051_add_smashcut_clip_speeds.py`)
- Verified: no duplicate revision ids, exactly one head

## Guard

Two tests so this can't recur silently:

- `test_no_duplicate_revision_ids`
- `test_exactly_one_head`

Both parse the versions directory directly, so a bad revision number now fails **CI on the PR** instead of passing CI and then killing the deploy after merge. That's the real failure mode here: CI was green both times.

260 tests passing.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct