### PR TITLE
feat(identity): persist per-segment identity scores + job aggregate

### DIFF
--- a/alembic/versions/053_add_segment_identity_scores.py
+++ b/alembic/versions/053_add_segment_identity_scores.py
@@ -1,0 +1,48 @@
+"""Add per-segment identity scores
+
+Revision ID: 053
+Revises: 052
+Create Date: 2026-08-03
+
+Every segment is now scored for facial identity as it finishes generating, inline where
+motion_magnitude is already measured. Stored on the segment rather than in a separate table
+because it is a property of that generation, exactly like motion_magnitude.
+
+Two means, deliberately not collapsed into one:
+  identity_mean_cos      vs the START FRAME      - how far this generation drifted
+  identity_mean_cos_ref  vs the identity ref     - is it the character at all
+A low mean with a flat slope is a weak-identity problem (dataset/LoRA); a good mean with a
+steep slope is temporal drift. The fixes differ, so the distinction has to survive to the UI.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "053"
+down_revision = "052"
+branch_labels = None
+depends_on = None
+
+_COLUMNS = (
+    ("identity_mean_cos", sa.Float()),
+    ("identity_mean_cos_ref", sa.Float()),
+    ("identity_min_cos", sa.Float()),
+    ("identity_slope", sa.Float()),
+    ("identity_frames", sa.Integer()),
+    ("identity_no_face", sa.Integer()),
+    ("identity_face_px_p50", sa.Float()),
+    ("identity_yaw_max", sa.Float()),
+)
+
+
+def upgrade() -> None:
+    for name, type_ in _COLUMNS:
+        op.add_column("segments", sa.Column(name, type_, nullable=True))
+    # per-yaw bands, per-frame series, stride, multi-face count
+    op.add_column("segments", sa.Column("identity_metrics", postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "identity_metrics")
+    for name, _ in reversed(_COLUMNS):
+        op.drop_column("segments", name)

--- a/app/models.py
+++ b/app/models.py
@@ -130,6 +130,18 @@ class Segment(Base):
     trim_end_frames = mapped_column(Integer, nullable=False, default=0)
     motion_keywords = mapped_column(JSON, nullable=True)
     motion_magnitude = mapped_column(Float, nullable=True)
+    # Identity scoring, measured inline when the segment finishes generating. Two means:
+    # _mean_cos is vs the START FRAME (drift of this generation), _mean_cos_ref is vs the
+    # identity reference (is it the character). Slope separates weak identity from drift.
+    identity_mean_cos = mapped_column(Float, nullable=True)
+    identity_mean_cos_ref = mapped_column(Float, nullable=True)
+    identity_min_cos = mapped_column(Float, nullable=True)
+    identity_slope = mapped_column(Float, nullable=True)
+    identity_frames = mapped_column(Integer, nullable=True)
+    identity_no_face = mapped_column(Integer, nullable=True)
+    identity_face_px_p50 = mapped_column(Float, nullable=True)
+    identity_yaw_max = mapped_column(Float, nullable=True)
+    identity_metrics = mapped_column(JSONB, nullable=True)
     # Length (seconds) of the reconstructed lead-in a VACE-continuation segment carries.
     # Stitch trims this off the previous segment's tail so the reconstruction replaces it
     # seamlessly. NULL for traditional (non-VACE) segments.

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -35,7 +35,7 @@ def _image_ext(filename: str | None) -> str:
 
 def _starting_image_key(user_id: UUID, image_hash: str, ext: str) -> str:
     return f"users/{user_id}/starting_images/{image_hash}{ext}"
-from app.schemas.jobs import JobCreate, JobDetailResponse, JobListResponse, JobReorderRequest, JobResponse, JobUpdate, StatsResponse, WorkerStatsItem
+from app.schemas.jobs import IdentityAggregate, JobCreate, JobDetailResponse, JobListResponse, JobReorderRequest, JobResponse, JobUpdate, StatsResponse, WorkerStatsItem
 from app.schemas.segments import SegmentResponse
 from app.stitch import stitch_video
 
@@ -44,6 +44,43 @@ import logging
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+
+def _identity_aggregate(segments) -> IdentityAggregate | None:
+    """Roll per-segment identity scores up to the job.
+
+    Frame-weighted, so a short segment does not carry the same weight as a long one, and it
+    surfaces the worst-drifting segment index - "which segment went wrong" is what you act on,
+    and a blended mean hides exactly that.
+    """
+    scored = [s for s in segments if s.identity_frames]
+    if not scored:
+        return None
+
+    def weighted(attr: str):
+        pairs = [(getattr(s, attr), s.identity_frames) for s in scored
+                 if getattr(s, attr) is not None]
+        if not pairs:
+            return None
+        total = sum(n for _, n in pairs)
+        return sum(v * n for v, n in pairs) / total if total else None
+
+    worst = min(
+        (s for s in scored if s.identity_slope is not None),
+        key=lambda s: s.identity_slope,
+        default=None,
+    )
+    return IdentityAggregate(
+        mean_cos=weighted("identity_mean_cos"),
+        mean_cos_ref=weighted("identity_mean_cos_ref"),
+        slope=weighted("identity_slope"),
+        frames=sum(s.identity_frames or 0 for s in scored),
+        no_face=sum(s.identity_no_face or 0 for s in scored),
+        scored_segments=len(scored),
+        worst_segment_index=worst.index if worst else None,
+        worst_segment_slope=worst.identity_slope if worst else None,
+    )
 
 
 @router.get("/jobs/starting-image-exists")
@@ -491,6 +528,7 @@ async def get_job(
         seg_responses = [SegmentResponse.model_validate(s) for s in segments]
 
     return JobDetailResponse(
+        identity=_identity_aggregate(job.segments),
         id=job.id,
         name=job.name,
         width=job.width,
@@ -649,6 +687,7 @@ async def reopen_job(
         seg_responses = [SegmentResponse.model_validate(s) for s in segments]
 
     return JobDetailResponse(
+        identity=_identity_aggregate(job.segments),
         id=job.id, name=job.name, width=job.width, height=job.height,
         fps=job.fps, seed=job.seed, starting_image=job.starting_image,
         lightx2v_strength_high=job.lightx2v_strength_high,

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -491,6 +491,26 @@ async def update_segment(
         segment.motion_keywords = body.motion_keywords
     if body.motion_magnitude is not None:
         segment.motion_magnitude = body.motion_magnitude
+    # Identity scores measured by the daemon at generation time. Measurement only -
+    # never gates status, exactly like motion_magnitude and the Lynx QA scores.
+    if body.identity_mean_cos is not None:
+        segment.identity_mean_cos = body.identity_mean_cos
+    if body.identity_mean_cos_ref is not None:
+        segment.identity_mean_cos_ref = body.identity_mean_cos_ref
+    if body.identity_min_cos is not None:
+        segment.identity_min_cos = body.identity_min_cos
+    if body.identity_slope is not None:
+        segment.identity_slope = body.identity_slope
+    if body.identity_frames is not None:
+        segment.identity_frames = body.identity_frames
+    if body.identity_no_face is not None:
+        segment.identity_no_face = body.identity_no_face
+    if body.identity_face_px_p50 is not None:
+        segment.identity_face_px_p50 = body.identity_face_px_p50
+    if body.identity_yaw_max is not None:
+        segment.identity_yaw_max = body.identity_yaw_max
+    if body.identity_metrics is not None:
+        segment.identity_metrics = body.identity_metrics
     if body.vace_overlap_seconds is not None:
         segment.vace_overlap_seconds = body.vace_overlap_seconds
     if body.lynx_identity_scores is not None:

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -120,6 +120,23 @@ class JobListResponse(BaseModel):
     offset: int
 
 
+class IdentityAggregate(BaseModel):
+    """Job-level identity, derived from the per-segment scores rather than re-measuring.
+
+    Frame-weighted so a 20-frame segment does not count the same as a 200-frame one, and it
+    names the worst-drifting segment because "which segment went wrong" is the actionable
+    answer - a blended average hides it.
+    """
+    mean_cos: Optional[float] = None
+    mean_cos_ref: Optional[float] = None
+    slope: Optional[float] = None
+    frames: int = 0
+    no_face: int = 0
+    scored_segments: int = 0
+    worst_segment_index: Optional[int] = None
+    worst_segment_slope: Optional[float] = None
+
+
 class JobDetailResponse(JobResponse):
     segments: list[SegmentResponse]
     videos: list[VideoResponse]
@@ -127,6 +144,7 @@ class JobDetailResponse(JobResponse):
     completed_segment_count: int
     total_run_time: float
     total_video_time: float
+    identity: Optional[IdentityAggregate] = None
 
 
 class JobUpdate(BaseModel):

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -50,6 +50,15 @@ class SegmentResponse(BaseModel):
     trim_end_frames: int
     motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
+    identity_mean_cos: Optional[float] = None
+    identity_mean_cos_ref: Optional[float] = None
+    identity_min_cos: Optional[float] = None
+    identity_slope: Optional[float] = None
+    identity_frames: Optional[int] = None
+    identity_no_face: Optional[int] = None
+    identity_face_px_p50: Optional[float] = None
+    identity_yaw_max: Optional[float] = None
+    identity_metrics: Optional[dict[str, Any]] = None
     reference_frames: Optional[list[str]] = None
     status: str
     reprocess_type: Optional[str] = None
@@ -240,6 +249,15 @@ class SegmentStatusUpdate(BaseModel):
     progress_log: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
+    identity_mean_cos: Optional[float] = None
+    identity_mean_cos_ref: Optional[float] = None
+    identity_min_cos: Optional[float] = None
+    identity_slope: Optional[float] = None
+    identity_frames: Optional[int] = None
+    identity_no_face: Optional[int] = None
+    identity_face_px_p50: Optional[float] = None
+    identity_yaw_max: Optional[float] = None
+    identity_metrics: Optional[dict[str, Any]] = None
     vace_overlap_seconds: Optional[float] = None
     # Lynx identity QA measured by the daemon. Measurement only — no gating.
     lynx_identity_scores: Optional[dict[str, Any]] = None

--- a/tests/test_identity_scoring.py
+++ b/tests/test_identity_scoring.py
@@ -1,0 +1,163 @@
+"""Tests for per-segment identity scoring on the API side.
+
+The failure mode this guards is silence. Identity scores are measurement-only — they never
+gate a segment's status — so if a field is dropped between the daemon and the console,
+nothing errors. The numbers simply never appear, and the feature looks like it "doesn't work"
+without a single log line. That is exactly how the seed re-anchor stayed dead through 26 jobs.
+
+Unit-level (no live DB), matching the rest of this suite.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.models import Segment
+from app.schemas.jobs import IdentityAggregate, JobDetailResponse
+from app.schemas.segments import SegmentResponse, SegmentStatusUpdate
+
+ROOT = Path(__file__).resolve().parents[1]
+JOBS_ROUTE = ROOT / "app" / "routes" / "jobs.py"
+SEGMENTS_ROUTE = ROOT / "app" / "routes" / "segments.py"
+
+IDENTITY_FIELDS = [
+    "identity_mean_cos",
+    "identity_mean_cos_ref",
+    "identity_min_cos",
+    "identity_slope",
+    "identity_frames",
+    "identity_no_face",
+    "identity_face_px_p50",
+    "identity_yaw_max",
+    "identity_metrics",
+]
+
+
+class TestFieldsExistEndToEnd:
+    """daemon -> API -> DB -> console. A gap anywhere shows up as missing numbers, not an error."""
+
+    @pytest.mark.parametrize("field", IDENTITY_FIELDS)
+    def test_daemon_can_send_it(self, field):
+        assert field in SegmentStatusUpdate.model_fields
+
+    @pytest.mark.parametrize("field", IDENTITY_FIELDS)
+    def test_model_persists_it(self, field):
+        assert hasattr(Segment, field)
+
+    @pytest.mark.parametrize("field", IDENTITY_FIELDS)
+    def test_console_receives_it(self, field):
+        assert field in SegmentResponse.model_fields
+
+    def test_patch_handler_persists_every_field(self):
+        """SegmentStatusUpdate is applied field-by-field, so a field can exist on the schema
+        AND the model and still never be written."""
+        src = SEGMENTS_ROUTE.read_text()
+        for field in IDENTITY_FIELDS:
+            assert f"segment.{field} = body.{field}" in src, (
+                f"PATCH /segments/{{id}} never assigns {field}; the daemon would send it "
+                f"and the API would silently discard it"
+            )
+
+
+class TestTwoMeansStaySeparate:
+    """Collapsing 'drift from start' and 'is it the character' into one number destroys the
+    distinction the feature exists to expose. On the CTRL clip these were 0.811 and 0.489."""
+
+    def test_both_means_are_distinct_fields(self):
+        assert "identity_mean_cos" in SegmentResponse.model_fields
+        assert "identity_mean_cos_ref" in SegmentResponse.model_fields
+
+    def test_aggregate_keeps_both(self):
+        assert "mean_cos" in IdentityAggregate.model_fields
+        assert "mean_cos_ref" in IdentityAggregate.model_fields
+
+    def test_slope_is_reported_separately_from_the_mean(self):
+        """A low mean + flat slope is a dataset problem; a good mean + steep slope is drift.
+        Different fixes, so the UI must be able to tell them apart."""
+        assert "identity_slope" in SegmentResponse.model_fields
+        assert "slope" in IdentityAggregate.model_fields
+
+
+class TestJobAggregate:
+
+    def test_aggregate_is_on_the_detail_response(self):
+        assert "identity" in JobDetailResponse.model_fields
+
+    def test_every_detail_construction_passes_the_aggregate(self):
+        """JobDetailResponse is hand-built field-by-field in the route handlers, so an
+        omitted field is dropped silently by Pydantic — the video_preset_id 'Custom' bug."""
+        tree = ast.parse(JOBS_ROUTE.read_text())
+        calls = [
+            {kw.arg for kw in n.keywords if kw.arg}
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            and n.func.id == "JobDetailResponse"
+        ]
+        assert len(calls) == 2, f"expected 2 JobDetailResponse sites, found {len(calls)}"
+        for i, kwargs in enumerate(calls):
+            assert "identity" in kwargs, (
+                f"JobDetailResponse construction #{i} omits 'identity'; it would be dropped"
+            )
+
+    def test_aggregate_defaults_to_none_when_nothing_scored(self):
+        """Older jobs predate scoring. They must render, not 500."""
+        assert IdentityAggregate().mean_cos is None
+        assert IdentityAggregate().scored_segments == 0
+
+
+class TestAggregateMath:
+    """The helper is pure, so exercise it directly with stand-in segments."""
+
+    @staticmethod
+    def _load_helper():
+        tree = ast.parse(JOBS_ROUTE.read_text())
+        fn = next(n for n in tree.body
+                  if isinstance(n, ast.FunctionDef) and n.name == "_identity_aggregate")
+        ns: dict = {"IdentityAggregate": IdentityAggregate}
+        exec(compile(ast.Module(body=[fn], type_ignores=[]), "<agg>", "exec"), ns)
+        return ns["_identity_aggregate"]
+
+    @staticmethod
+    def _seg(index, frames, mean=None, ref=None, slope=None, no_face=0):
+        class S:
+            pass
+        s = S()
+        s.index, s.identity_frames = index, frames
+        s.identity_mean_cos, s.identity_mean_cos_ref = mean, ref
+        s.identity_slope, s.identity_no_face = slope, no_face
+        return s
+
+    def test_no_scored_segments_returns_none(self):
+        agg = self._load_helper()
+        assert agg([self._seg(0, 0)]) is None
+        assert agg([]) is None
+
+    def test_mean_is_frame_weighted_not_a_flat_average(self):
+        """A 20-frame segment must not count the same as a 200-frame one."""
+        agg = self._load_helper()
+        r = agg([self._seg(0, 100, mean=0.9), self._seg(1, 900, mean=0.5)])
+        # flat average would be 0.70; frame-weighted is 0.54
+        assert r.mean_cos == pytest.approx(0.54, abs=1e-6)
+
+    def test_reports_the_worst_drifting_segment(self):
+        agg = self._load_helper()
+        r = agg([
+            self._seg(0, 50, mean=0.9, slope=-0.001),
+            self._seg(1, 50, mean=0.8, slope=-0.009),
+            self._seg(2, 50, mean=0.85, slope=-0.002),
+        ])
+        assert r.worst_segment_index == 1
+        assert r.worst_segment_slope == pytest.approx(-0.009)
+
+    def test_counts_frames_and_no_face_across_segments(self):
+        agg = self._load_helper()
+        r = agg([self._seg(0, 70, mean=0.8, no_face=3), self._seg(1, 30, mean=0.8, no_face=1)])
+        assert r.frames == 100 and r.no_face == 4 and r.scored_segments == 2
+
+    def test_partial_scores_do_not_break_the_aggregate(self):
+        """A segment can have a mean but no slope (too few frames to regress)."""
+        agg = self._load_helper()
+        r = agg([self._seg(0, 50, mean=0.8, slope=None), self._seg(1, 50, mean=0.6, slope=-0.01)])
+        assert r.mean_cos == pytest.approx(0.7, abs=1e-6)
+        assert r.slope == pytest.approx(-0.01)


### PR DESCRIPTION
API half of per-segment identity scoring. Pairs with wanly-gpu-daemon #94 and the console PR.

## Changes

**Migration `053`** — score columns on `segments`, stored there rather than in a separate table because they're a property of that generation, exactly like `motion_magnitude`. Verified a **single alembic head** before pushing (`052` → `053`); the duplicate-`050` incident silently blocked two deploys.

**Two means as separate columns, on purpose:**

| | |
|---|---|
| `identity_mean_cos` | vs the start frame — drift of this generation |
| `identity_mean_cos_ref` | vs the identity reference — is it the character |
| `identity_slope` | cosine per frame |

A low mean with a flat slope is a dataset/LoRA problem; a good mean with a steep slope is temporal drift. Different fixes, so the distinction has to survive to the UI.

**`JobDetailResponse.identity`** — frame-weighted aggregate from the segments (a 20-frame segment mustn't count the same as a 200-frame one), which also names the **worst-drifting segment index**. "Which segment went wrong" is what you act on; a blended mean hides it.

`SegmentResponse` is `from_attributes`, so the per-segment fields flow to the console automatically once they're on the model.

## Tests — 39 new, 301 total

The failure mode here is **silence**. Scores are measurement-only and never gate status, so a field dropped anywhere between daemon and console produces no error at all — the numbers simply never appear. That's exactly how the seed re-anchor stayed dead through 26 multi-segment jobs.

- every field present across `SegmentStatusUpdate` → `Segment` → `SegmentResponse`
- the PATCH handler **assigns** each one (a field can exist on schema *and* model and still never be written)
- AST guard that **both** hand-built `JobDetailResponse` sites pass `identity` — the video_preset_id "Custom" trap
- aggregate math: frame-weighting (asserts 0.54, not the flat-average 0.70), worst-segment selection, partial scores, and `None` for jobs that predate the feature so old jobs render rather than 500

**Deploy before the daemon** — the migration must run before segments start reporting scores.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct