### PR TITLE
fix(identity): surface the cumulative low point, not just the average

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -71,6 +71,13 @@ def _identity_aggregate(segments) -> IdentityAggregate | None:
         key=lambda s: s.identity_slope,
         default=None,
     )
+    # The cumulative low point matters more than the average: a mean over segments hides a
+    # late collapse, which is exactly what a multi-segment job drifts into.
+    lowest = min(
+        (s for s in scored if s.identity_mean_cos_ref is not None),
+        key=lambda s: s.identity_mean_cos_ref,
+        default=None,
+    )
     return IdentityAggregate(
         mean_cos=weighted("identity_mean_cos"),
         mean_cos_ref=weighted("identity_mean_cos_ref"),
@@ -80,6 +87,8 @@ def _identity_aggregate(segments) -> IdentityAggregate | None:
         scored_segments=len(scored),
         worst_segment_index=worst.index if worst else None,
         worst_segment_slope=worst.identity_slope if worst else None,
+        min_cos_ref=lowest.identity_mean_cos_ref if lowest else None,
+        min_cos_ref_segment_index=lowest.index if lowest else None,
     )
 
 

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -135,6 +135,13 @@ class IdentityAggregate(BaseModel):
     scored_segments: int = 0
     worst_segment_index: Optional[int] = None
     worst_segment_slope: Optional[float] = None
+    # Lowest per-segment cumulative score in the job, and where it happened. A job can
+    # average well while a late segment has lost the character entirely - each segment is
+    # measured against its OWN start frame, which for a continuation is the previous
+    # segment's already-drifted last frame. Observed: seg0 0.764, seg1 0.785 vs their own
+    # starts (both "healthy") while seg1 sat at 0.544 vs the job's original image.
+    min_cos_ref: Optional[float] = None
+    min_cos_ref_segment_index: Optional[int] = None
 
 
 class JobDetailResponse(JobResponse):

--- a/tests/test_identity_scoring.py
+++ b/tests/test_identity_scoring.py
@@ -161,3 +161,39 @@ class TestAggregateMath:
         r = agg([self._seg(0, 50, mean=0.8, slope=None), self._seg(1, 50, mean=0.6, slope=-0.01)])
         assert r.mean_cos == pytest.approx(0.7, abs=1e-6)
         assert r.slope == pytest.approx(-0.01)
+
+
+class TestCumulativeLowPointIsSurfaced:
+    """The bug this class exists for.
+
+    A real 2-segment job scored 0.764 and 0.785 "vs own start frame" — both green, both
+    read as healthy — while segment 1 sat at 0.544 against the job's original image and was
+    visibly a different person. Each segment is measured from its OWN first frame, and a
+    continuation's first frame is the previous segment's already-drifted last frame. So
+    per-segment scores can rise while cumulative identity collapses.
+
+    The aggregate must therefore expose the cumulative LOW POINT, not just an average.
+    """
+
+    def test_aggregate_exposes_the_cumulative_low_point(self):
+        assert "min_cos_ref" in IdentityAggregate.model_fields
+        assert "min_cos_ref_segment_index" in IdentityAggregate.model_fields
+
+    def test_low_point_is_found_even_when_the_average_looks_fine(self):
+        agg = TestAggregateMath._load_helper()
+        seg = TestAggregateMath._seg
+        r = agg([
+            seg(0, 177, mean=0.764, ref=0.764, slope=-0.0003),
+            seg(1, 177, mean=0.785, ref=0.544, slope=-0.0004),
+        ])
+        # the per-segment means both look healthy and even improve
+        assert r.mean_cos == pytest.approx(0.7745, abs=1e-3)
+        # but the cumulative low point tells the truth, and names the segment
+        assert r.min_cos_ref == pytest.approx(0.544)
+        assert r.min_cos_ref_segment_index == 1
+
+    def test_low_point_is_none_when_no_reference_was_scored(self):
+        agg = TestAggregateMath._load_helper()
+        seg = TestAggregateMath._seg
+        r = agg([seg(0, 50, mean=0.8, ref=None)])
+        assert r.min_cos_ref is None and r.min_cos_ref_segment_index is None


### PR DESCRIPTION
## The bug, from a real job

```
seg 0   0.764 vs own start   0.764 vs job reference
seg 1   0.785 vs own start   0.544 vs job reference   ← visibly a different person
```

Both segments displayed **green and healthy**, and segment 1's score was *higher* than segment 0's. Meanwhile identity had fallen from 0.764 to 0.544 against the job's original image.

**Why:** each segment is scored from its **own** first frame. A continuation's first frame is the previous segment's **already-drifted last frame**. So a segment can be internally stable — a good "vs start" score — while the character has been lost since the job began. Averaging across segments hides it a second time.

This is precisely the failure the feature was built to catch, and the aggregate reintroduced it by reporting a mean.

## Fix

`IdentityAggregate` gains:

- `min_cos_ref` — the lowest cumulative score across the job's segments
- `min_cos_ref_segment_index` — which segment it happened in

"Which segment lost her" is the actionable answer; a mean is not.

## Tests

Three new, using the **actual observed numbers** rather than invented ones:

- the average still reads 0.7745 (looks fine) while the low point correctly reports **0.544 at segment 1**
- `None` when no reference was scored
- the fields exist on the aggregate

**42 identity tests, 304 total, no regressions.**

Pairs with the console PR, which headlines the cumulative number instead of the per-segment one.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct