### PR TITLE
fix(identity): ground truth is segment 0's start frame, no override

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -409,6 +409,9 @@ async def claim_next_segment(
         faceswap_faces_order=segment.faceswap_faces_order,
         faceswap_faces_index=segment.faceswap_faces_index,
         initial_reference_image=job.identity_reference_image or job.starting_image,
+        # Ground truth for identity scoring is always segment 0's start frame. No override:
+        # "her" is defined by where the job began, not by a separate reference image.
+        identity_ground_truth=job.starting_image,
         motion_keywords=segment.motion_keywords,
         previous_motion_keywords=previous_motion_keywords,
         previous_motion_magnitude=previous_motion_magnitude,

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -115,6 +115,11 @@ class SegmentClaimResponse(BaseModel):
     faceswap_faces_order: Optional[str]
     faceswap_faces_index: Optional[str]
     initial_reference_image: Optional[str] = None
+    # Identity scoring ground truth: the JOB's starting image, i.e. segment 0's start frame.
+    # Deliberately NOT identity_reference_image - that field is the PainterLongVideo anchor
+    # and is overridable, which would silently swap what "her" means mid-measurement.
+    # Every segment scores against this same frame, so the numbers chain across the job.
+    identity_ground_truth: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
     previous_motion_keywords: Optional[list[str]] = None


### PR DESCRIPTION
## The problem

Scoring rode on `initial_reference_image`, which resolves to:

```python
job.identity_reference_image or job.starting_image
```

Two things wrong:

1. **Overridable.** Setting `identity_reference_image` would silently make an external image the ground truth instead of segment 0's start frame — changing what every number means, partway through a job, with no signal.
2. **Wrong field.** It exists for the PainterLongVideo identity anchor, not for measurement. Scoring was piggybacking on someone else's state.

## Fix

Explicit `identity_ground_truth` on the claim, always `job.starting_image`. **"Her" is where the job began** — no external reference, no override.

The scoring helper now reads exactly two segment fields:

```
segment.identity_ground_truth   seg0's start frame  ("her")
segment.start_image             this segment's own first frame (local drift only)
```

## Audit result

No hardcoded identity image exists anywhere in the daemon — the `_HARDCODE_IDENTITY_FACE` map was removed yesterday, and the remaining `.png` literals are file extensions and temp filenames.

## Guards

Four, so this cannot quietly return:

- the claim carries an explicit field
- the two fields are independently settable
- **source-level check** that the scoring helper never reads the overridable anchor — parsing the AST with comments and docstrings stripped, since the helper deliberately *names* the field in a comment explaining why it is not used
- no hardcoded identity face map exists

80 daemon tests / 308 API tests passing.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct