### PR TITLE
Add per-segment faceswap_model and faceswap_pixel_boost

### DIFF
--- a/alembic/versions/055_add_segment_faceswap_model.py
+++ b/alembic/versions/055_add_segment_faceswap_model.py
@@ -1,0 +1,44 @@
+"""Add per-segment face swapper model and pixel boost
+
+Revision ID: 055
+Revises: 054
+Create Date: 2026-08-05
+
+Both were hardcoded in the daemon (`inswapper_128` / `512x512`), which made the swap stage
+untunable — and the swap stage is now where the remaining headroom is. A controlled sweep
+showed nothing on the generation side moves identity: with NO LoRA at all the clip scores
+mean 0.695, the same as with a purpose-trained character LoRA. Identity has to be injected
+by the swap, so the swap needs knobs.
+
+Two specific reasons these are the knobs that matter:
+
+  face_swapper_model  inswapper_128 is 128px native. hyperswap_1c_256, simswap_256 and
+                      hififace_256 are 256 native, and simswap_unofficial_512 is 512 — so
+                      the crop is stretched half as far, or not at all. The ComfyUI node's
+                      own default is hyperswap_1c_256; we were overriding it with the
+                      older model.
+
+  pixel_boost         512x512 on a ~100px face is close to a no-op that costs ~16x compute:
+                      the crop is interpolated up from 100px and then pixel-unshuffled into
+                      16 strided sub-images carrying no extra real signal. Only worth it
+                      when the face genuinely has >128px of detail.
+
+NULL means "use the daemon default", matching every other per-segment override.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "055"
+down_revision = "054"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("faceswap_model", sa.String(64), nullable=True))
+    op.add_column("segments", sa.Column("faceswap_pixel_boost", sa.String(16), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "faceswap_pixel_boost")
+    op.drop_column("segments", "faceswap_model")

--- a/app/models.py
+++ b/app/models.py
@@ -120,6 +120,8 @@ class Segment(Base):
     faceswap_image = mapped_column(Text, nullable=True)
     faceswap_faces_order = mapped_column(Text, nullable=True)
     faceswap_faces_index = mapped_column(Text, nullable=True)
+    faceswap_model = mapped_column(String(64), nullable=True)
+    faceswap_pixel_boost = mapped_column(String(16), nullable=True)
     # Seed re-anchor: faceswap this segment's last frame to the segment's faceswap face
     # before it seeds the next segment. Author-set per segment (no successor gate: the
     # successor does not exist yet when this segment is claimed).

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -198,6 +198,8 @@ async def add_segment(
         faceswap_image=body.faceswap_image,
         faceswap_faces_order=body.faceswap_faces_order,
         faceswap_faces_index=body.faceswap_faces_index,
+        faceswap_model=body.faceswap_model,
+        faceswap_pixel_boost=body.faceswap_pixel_boost,
         seed_faceswap=body.seed_faceswap,
         negative_prompt=negative_prompt,
         auto_finalize=body.auto_finalize,
@@ -408,6 +410,8 @@ async def claim_next_segment(
         faceswap_image=segment.faceswap_image,
         faceswap_faces_order=segment.faceswap_faces_order,
         faceswap_faces_index=segment.faceswap_faces_index,
+        faceswap_model=segment.faceswap_model,
+        faceswap_pixel_boost=segment.faceswap_pixel_boost,
         initial_reference_image=job.identity_reference_image or job.starting_image,
         # Ground truth for identity scoring is always segment 0's start frame. No override:
         # "her" is defined by where the job began, not by a separate reference image.
@@ -828,6 +832,8 @@ async def reprocess_segment(
     segment.faceswap_image = effective_image
     segment.faceswap_faces_order = body.faceswap_faces_order
     segment.faceswap_faces_index = body.faceswap_faces_index
+    segment.faceswap_model = body.faceswap_model
+    segment.faceswap_pixel_boost = body.faceswap_pixel_boost
 
     # Reset segment for faceswap-only reprocessing (preserve existing output)
     segment.reprocess_type = "faceswap"

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -17,6 +17,8 @@ class SegmentCreate(BaseModel):
     faceswap_image: Optional[str] = None
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
+    faceswap_model: Optional[str] = None
+    faceswap_pixel_boost: Optional[str] = None
     # Re-anchor this segment's last frame to the faceswap face before it seeds the next
     # segment. Uses faceswap_image, so it only has an effect when faceswap is configured.
     seed_faceswap: bool = False
@@ -42,6 +44,8 @@ class SegmentResponse(BaseModel):
     faceswap_image: Optional[str]
     faceswap_faces_order: Optional[str]
     faceswap_faces_index: Optional[str]
+    faceswap_model: Optional[str] = None
+    faceswap_pixel_boost: Optional[str] = None
     seed_faceswap: bool = False
     negative_prompt: Optional[str] = None
     auto_finalize: bool
@@ -114,6 +118,8 @@ class SegmentClaimResponse(BaseModel):
     faceswap_image: Optional[str]
     faceswap_faces_order: Optional[str]
     faceswap_faces_index: Optional[str]
+    faceswap_model: Optional[str] = None
+    faceswap_pixel_boost: Optional[str] = None
     initial_reference_image: Optional[str] = None
     # Identity scoring ground truth: the JOB's starting image, i.e. segment 0's start frame.
     # Deliberately NOT identity_reference_image - that field is the PainterLongVideo anchor
@@ -237,6 +243,8 @@ class SegmentReprocessRequest(BaseModel):
     faceswap_image: Optional[str] = None
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
+    faceswap_model: Optional[str] = None
+    faceswap_pixel_boost: Optional[str] = None
 
 
 class HologramRequest(BaseModel):


### PR DESCRIPTION
API side of [wanly-gpu-daemon#100](https://github.com/DavidJBarnes/wanly-gpu-daemon/pull/100). Migration **055**.

## Why

A controlled sweep this week relocated the problem. Nothing on the generation side affects identity — with **no LoRA at all** a clip scores mean 0.695, identical to one with a purpose-trained character LoRA, and every sampler variation scored worse. Identity has to be *injected* by the swap. Both swap knobs that matter were hardcoded in the daemon.

`inswapper_128` is 128px native; `hyperswap_1c_256`, `simswap_256`, `hififace_unofficial_256` are 256 and `simswap_unofficial_512` is 512, so the crop is stretched half as far or not at all. `pixel_boost 512x512` on a ~100px face interpolates ~5x and then pixel-unshuffles into 16 strided sub-images carrying no extra real signal — ~16x compute for nothing.

## Change

Two nullable columns on `segments`, wired through `SegmentCreate` → claim → `SegmentClaimResponse` → daemon, plus `SegmentResponse` so the console can read them back. NULL means "daemon default", so behaviour is unchanged until a segment asks for something else.

## Tests

308 passed. Both new fields carry `= None` defaults — without them Pydantic makes them required and `SegmentClaimResponse` construction fails, which the existing claim-schema tests caught.

Single alembic head confirmed (055 → 054).

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct