### PR TITLE
Refuse to delete an image a job or segment still references (#156)

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -5,14 +5,13 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
 from app.config import settings
 from app.database import get_db
-from app.enums import JobStatus
-from app.models import Favorite, ImageMeta, Job
+from app.models import Favorite, ImageMeta, Job, Segment
 from app.schemas.images import ImageTagsUpdate
 from app.s3 import (
     delete_object,
@@ -28,6 +27,60 @@ from app.s3 import (
 router = APIRouter(tags=["images"])
 
 _FOLDER_NAME_RE = re.compile(r"^[a-zA-Z0-9 _-]+$")
+
+# Every column that can hold an s3:// path a user could delete through this router.
+# Job.identity_reference_image is deliberately absent: the daemon writes it into the *jobs*
+# bucket, so it can never be the target of DELETE /images.
+_JOB_IMAGE_COLUMNS = (Job.starting_image, Job.lynx_subject_image)
+_SEGMENT_IMAGE_COLUMNS = (Segment.start_image, Segment.faceswap_image)
+
+
+async def find_image_references(db: AsyncSession, paths: list[str]) -> dict[str, dict[str, list[str]]]:
+    """Map each still-referenced path to the jobs and segments holding it.
+
+    Deleting a referenced image fails silently: nothing breaks until a worker claims the
+    segment weeks later and S3 returns 404, which costs a pickup and shows up as a red
+    segment nowhere near the cause. That makes the check wider than it first looks:
+
+      - segment-level refs count, not just Job.starting_image. The validated identity recipe
+        sets Segment.faceswap_image on every job, so that is the common holder, and it was
+        invisible to the old listing query.
+      - ARCHIVED jobs count. Archiving hides a job from the UI; it does not stop its segments
+        being re-run, so an archived job's images are still live references.
+      - no user filter, since a reference from anyone's job 404s the worker just the same.
+    """
+    if not paths:
+        return {}
+
+    wanted = set(paths)
+    refs: dict[str, dict[str, list[str]]] = {}
+
+    def _hold(path: str | None, kind: str, holder_id) -> None:
+        if not path or path not in wanted:
+            return
+        entry = refs.setdefault(path, {"job_ids": [], "segment_ids": []})
+        if str(holder_id) not in entry[kind]:
+            entry[kind].append(str(holder_id))
+
+    job_rows = await db.execute(
+        select(Job.id, *_JOB_IMAGE_COLUMNS).where(
+            or_(*[col.in_(paths) for col in _JOB_IMAGE_COLUMNS])
+        )
+    )
+    for row in job_rows.all():
+        for value in row[1:]:
+            _hold(value, "job_ids", row[0])
+
+    seg_rows = await db.execute(
+        select(Segment.id, *_SEGMENT_IMAGE_COLUMNS).where(
+            or_(*[col.in_(paths) for col in _SEGMENT_IMAGE_COLUMNS])
+        )
+    )
+    for row in seg_rows.all():
+        for value in row[1:]:
+            _hold(value, "segment_ids", row[0])
+
+    return refs
 
 
 @router.post("/images/upload", dependencies=[Depends(verify_api_key_or_bearer)])
@@ -95,7 +148,6 @@ async def list_folders():
 async def list_folder_images(
     date: str,
     db: AsyncSession = Depends(get_db),
-    user = Depends(get_current_user),
 ):
     """List images in a date folder, with in_use flag indicating if used by any job."""
     bucket = settings.s3_images_bucket
@@ -106,12 +158,9 @@ async def list_folder_images(
     in_use_set: set[str] = set()
     tags_map: dict[str, str] = {}
     if paths:
-        result = await db.execute(
-            select(Job.starting_image)
-            .where(Job.user_id == user.id, Job.starting_image.in_(paths), Job.status != JobStatus.ARCHIVED)
-            .distinct()
-        )
-        in_use_set = {row[0] for row in result.all()}
+        # Same helper the delete endpoint gates on. When these two disagree the UI is the one
+        # that gets believed, which is how referenced images got deleted in the first place.
+        in_use_set = set(await find_image_references(db, paths))
 
         meta_result = await db.execute(
             select(ImageMeta.path, ImageMeta.tags).where(ImageMeta.path.in_(paths))
@@ -178,7 +227,6 @@ async def list_favorite_images(
 
 @router.get("/images/untagged", dependencies=[Depends(get_current_user)])
 async def list_untagged_images(
-    user=Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Return all images across all folders that have no tags — for tagging triage.
@@ -208,12 +256,7 @@ async def list_untagged_images(
         )
         tagged = {row[0] for row in meta_result.all() if row[1] and row[1].strip()}
 
-        in_use_result = await db.execute(
-            select(Job.starting_image)
-            .where(Job.user_id == user.id, Job.starting_image.in_(paths), Job.status != JobStatus.ARCHIVED)
-            .distinct()
-        )
-        in_use_set = {row[0] for row in in_use_result.all()}
+        in_use_set = set(await find_image_references(db, paths))
 
     untagged = [
         {
@@ -254,11 +297,31 @@ async def move_images(body: dict):
 
 
 @router.delete("/images", dependencies=[Depends(get_current_user)])
-async def delete_image(path: str = Query(...)):
-    """Delete a single image by S3 URI."""
+async def delete_image(
+    path: str = Query(...),
+    force: bool = Query(False),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a single image by S3 URI, refusing while a job or segment still points at it.
+
+    force=true skips the check for when the deletion is genuinely intended and the resulting
+    dangling reference is accepted.
+    """
     bucket = settings.s3_images_bucket
     if not path.startswith(f"s3://{bucket}/"):
         raise HTTPException(status_code=400, detail="Path must be in the images bucket")
+    if not force:
+        refs = await find_image_references(db, [path])
+        if path in refs:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": "Image is still referenced; pass force=true to delete anyway",
+                    "path": path,
+                    "job_ids": refs[path]["job_ids"],
+                    "segment_ids": refs[path]["segment_ids"],
+                },
+            )
     await asyncio.to_thread(delete_object, path)
     return {"ok": True}
 

--- a/tests/test_image_delete_refs.py
+++ b/tests/test_image_delete_refs.py
@@ -1,0 +1,204 @@
+"""Tests for refusing to delete an image that is still referenced.
+
+DELETE /images used to check only that the path was in the images bucket. Deleting a
+referenced image looked fine and stayed fine until a worker claimed the segment — often weeks
+later — and S3 answered 404, burning a pickup and surfacing as a red segment nowhere near the
+cause. The advisory in_use flag on the listing endpoint did not help: it looked at
+Job.starting_image only and skipped ARCHIVED jobs, so it reported "unused" for images that
+were very much in use, and the UI is the thing that gets believed.
+
+Both those blind spots get a test here, plus the force escape hatch and the case that must
+still delete. Unit-level (no live DB), matching the rest of this suite: _FakeSession answers
+the helper's SELECTs from in-memory ORM objects.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.enums import JobStatus
+from app.main import app
+from app.models import Job, Segment, User
+
+_fake_user = User(id=uuid.uuid4(), username="testuser", password_hash="x")
+
+BUCKET = "wanly-images"
+FACE = f"s3://{BUCKET}/2026-07-09/00054-swapped.png"
+START = f"s3://{BUCKET}/2026-07-09/00055-start.png"
+LOOSE = f"s3://{BUCKET}/2026-07-09/00056-unused.png"
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSession:
+    """Stands in for AsyncSession, answering find_image_references' SELECTs from ORM objects.
+
+    It reads the selected columns and the bound IN values off the statement rather than
+    matching a hardcoded query, so it does not have to be rewritten every time the helper's
+    column list widens — which is exactly the change this ticket is about.
+    """
+
+    def __init__(self, jobs=(), segments=()):
+        self._rows = {"jobs": list(jobs), "segments": list(segments)}
+
+    async def execute(self, query):
+        table = query.get_final_froms()[0].name
+        columns = list(query.selected_columns.keys())
+        wanted: set[str] = set()
+        for value in query.compile().params.values():
+            if isinstance(value, (list, tuple)):
+                wanted.update(v for v in value if isinstance(v, str))
+            elif isinstance(value, str):
+                wanted.add(value)
+
+        rows = []
+        for obj in self._rows.get(table, []):
+            values = tuple(getattr(obj, name, None) for name in columns)
+            if any(isinstance(v, str) and v in wanted for v in values):
+                rows.append(values)
+        return _FakeResult(rows)
+
+
+def _override(session):
+    app.dependency_overrides[get_current_user] = lambda: _fake_user
+    app.dependency_overrides[get_db] = lambda: session
+
+
+async def _delete(path, force=None):
+    from httpx import ASGITransport, AsyncClient
+
+    params = {"path": path}
+    if force is not None:
+        params["force"] = force
+    with patch("app.routes.images.delete_object") as deleter:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete("/images", params=params)
+    return resp, deleter
+
+
+class TestDeleteRefusesReferencedImages:
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_segment_faceswap_reference_returns_409(self):
+        """The identity recipe puts a face on every job's segments, and no job row mentions it —
+        this is the reference the old Job.starting_image-only check could never see."""
+        segment = Segment(id=uuid.uuid4(), prompt="x", faceswap_image=FACE)
+        _override(_FakeSession(segments=[segment]))
+
+        resp, deleter = await _delete(FACE)
+
+        assert resp.status_code == 409
+        assert str(segment.id) in resp.json()["detail"]["segment_ids"]
+        deleter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_archived_job_reference_returns_409(self):
+        """Archiving hides a job; it does not stop its segments being re-run, so its images are
+        still live references. The old query excluded archived jobs outright."""
+        job = Job(id=uuid.uuid4(), name="j", width=832, height=480, fps=16, seed=1,
+                  starting_image=START, status=JobStatus.ARCHIVED)
+        _override(_FakeSession(jobs=[job]))
+
+        resp, deleter = await _delete(START)
+
+        assert resp.status_code == 409
+        assert str(job.id) in resp.json()["detail"]["job_ids"]
+        deleter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_segment_start_image_reference_returns_409(self):
+        segment = Segment(id=uuid.uuid4(), prompt="x", start_image=START)
+        _override(_FakeSession(segments=[segment]))
+
+        resp, deleter = await _delete(START)
+
+        assert resp.status_code == 409
+        deleter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_409_names_every_holder(self):
+        """The point of the 409 body is to say what to fix; a bare "in use" leaves you hunting."""
+        job = Job(id=uuid.uuid4(), name="j", width=832, height=480, fps=16, seed=1,
+                  starting_image=FACE, status=JobStatus.PENDING)
+        segment = Segment(id=uuid.uuid4(), prompt="x", faceswap_image=FACE)
+        _override(_FakeSession(jobs=[job], segments=[segment]))
+
+        resp, _ = await _delete(FACE)
+
+        detail = resp.json()["detail"]
+        assert detail["job_ids"] == [str(job.id)]
+        assert detail["segment_ids"] == [str(segment.id)]
+
+    @pytest.mark.asyncio
+    async def test_force_deletes_a_referenced_image(self):
+        segment = Segment(id=uuid.uuid4(), prompt="x", faceswap_image=FACE)
+        _override(_FakeSession(segments=[segment]))
+
+        resp, deleter = await _delete(FACE, force="true")
+
+        assert resp.status_code == 200
+        deleter.assert_called_once_with(FACE)
+
+    @pytest.mark.asyncio
+    async def test_unreferenced_image_is_deleted(self):
+        """The check must not turn into "nothing is deletable" — rows that point elsewhere
+        are not holders."""
+        job = Job(id=uuid.uuid4(), name="j", width=832, height=480, fps=16, seed=1,
+                  starting_image=START, status=JobStatus.PENDING)
+        segment = Segment(id=uuid.uuid4(), prompt="x", faceswap_image=FACE)
+        _override(_FakeSession(jobs=[job], segments=[segment]))
+
+        resp, deleter = await _delete(LOOSE)
+
+        assert resp.status_code == 200
+        deleter.assert_called_once_with(LOOSE)
+
+    @pytest.mark.asyncio
+    async def test_wrong_bucket_still_rejected_before_any_db_work(self):
+        _override(_FakeSession())
+
+        resp, deleter = await _delete("s3://wanly-jobs/abc/last_frame.png")
+
+        assert resp.status_code == 400
+        deleter.assert_not_called()
+
+
+class TestListingAgreesWithDelete:
+    """The listing flag and the delete gate must come from the same query — the divergence is
+    what made this invisible: the UI said unused, the delete obeyed, the segment died later."""
+
+    def teardown_method(self):
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_faceswap_only_reference_reads_as_in_use(self):
+        from httpx import ASGITransport, AsyncClient
+
+        segment = Segment(id=uuid.uuid4(), prompt="x", faceswap_image=FACE)
+        _override(_FakeSession(segments=[segment]))
+
+        objects = [
+            {"Key": FACE.split(f"{BUCKET}/")[1], "Size": 10, "LastModified": "2026-07-09T00:00:00"},
+            {"Key": LOOSE.split(f"{BUCKET}/")[1], "Size": 10, "LastModified": "2026-07-09T00:00:00"},
+        ]
+        with patch("app.routes.images.list_objects", return_value=objects):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/images/folder/2026-07-09")
+
+        assert resp.status_code == 200
+        by_path = {item["path"]: item["in_use"] for item in resp.json()}
+        assert by_path[FACE] is True
+        assert by_path[LOOSE] is False


### PR DESCRIPTION
Fixes #156.

## Why

`DELETE /images` validated only that the path was in the images bucket. Deleting a still-referenced image succeeded quietly and stayed quiet until a worker claimed the segment — often weeks later — and S3 answered 404. That burns a worker pickup and surfaces as a red segment nowhere near its cause.

The `in_use` flag that should have prevented it was advisory, lived only on the listing endpoint, and was narrower than reality in two ways:

- it queried `Job.starting_image` alone, so `Segment.faceswap_image` — which the validated identity recipe sets on every job — was invisible to it
- it excluded `ARCHIVED` jobs, even though archiving does not stop a job's segments being re-run

So the UI said "unused" for images that were very much in use, and the UI is the thing that gets believed. That divergence is why the bug was invisible.

## What changed

- `find_image_references(db, paths)` in `app/routes/images.py` — one helper, returning `{path: {job_ids, segment_ids}}`. Covers `Job.starting_image`, `Job.lynx_subject_image`, `Segment.start_image`, `Segment.faceswap_image`, across **all** job statuses including archived, with no user filter (a reference from any job 404s the worker just the same).
- `DELETE /images` gates on it and returns **409** with the holding job/segment ids instead of deleting. `force=true` skips the check for when the deletion is genuinely intended.
- Both `GET /images/folder/{date}` and `GET /images/untagged` read `in_use` from the same helper, so the listing and the delete endpoint can no longer disagree.

`Job.identity_reference_image` is deliberately excluded: the daemon writes it into the *jobs* bucket, so it can never be the target of this endpoint. Noted in a comment next to the column list.

## Verification

Full suite green: **342 passed** (334 before, 8 new).

Deliberate-break check, both halves:

- disabled the `if not force:` gate in `delete_image` → the 4 refusal tests failed (faceswap-only ref, archived-job ref, segment start_image ref, holder-naming); restored → pass
- reverted the listing `in_use` to the old `Job.starting_image`-only query → `test_faceswap_only_reference_reads_as_in_use` failed; restored → pass

Tests are unit-level with a fake `AsyncSession` (no live DB), matching the rest of the suite. The fake reads selected columns and bound IN values off the statement rather than matching a hardcoded query, so it does not need rewriting when the helper's column list widens.

## Out of scope / follow-up

- The presigned-URL logging item in #156 is a daemon change, not touched here.
- `wanly-console`'s `deleteImage()` sends no `force` and has no 409 handling, so a refusal will surface as a generic error toast. Follow-up ticket filed.