### PR TITLE
Launch and terminate RunPod workers from the API

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,6 +15,27 @@ class Settings(BaseSettings):
     cors_origins: str = ""
     login_rate_limit: str = "5/minute"
     heartbeat_offline_seconds: int = 120
+
+    # RunPod worker launching (wanly-console#288).
+    #
+    # The key lives here rather than in the browser: creating a pod needs a read/write RunPod
+    # key, which can also terminate pods and volumes. There is no launch-only scope, so it must
+    # never reach the client.
+    #
+    # Defaults are the measured-best configuration, not arbitrary. 4090 because 3090 secure
+    # inventory is transient (present in one sample, gone the next) and could not be honoured.
+    # EU-RO-1 because network volumes are region-locked and it had 4090 capacity in 10/10
+    # samples, while every US storage-capable datacenter had 0-1/10.
+    runpod_api_key: str = ""
+    runpod_network_volume_id: str = ""
+    runpod_datacenter_id: str = "EU-RO-1"
+    runpod_gpu_type_id: str = "NVIDIA GeForce RTX 4090"
+    runpod_image: str = "davidjbarnes/wanly-gpu-docker:latest"
+    runpod_container_disk_gb: int = 30
+    runpod_volume_mount_path: str = "/workspace"
+    # What the launched worker is told to poll. Must be reachable FROM RunPod, so it cannot be
+    # localhost even though this server is the thing being pointed at.
+    runpod_worker_queue_url: str = "http://api.wanly22.com:8001"
     # Interim seam smoothing: crossfade (xfade) overlap between consecutive segments,
     # in seconds. 0 disables it (hard-cut concat, prior behavior). Superseded later by
     # VACE video-conditioned continuation.

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from slowapi.errors import RateLimitExceeded
 from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
 from app.limiter import limiter
-from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, segments, tags, video_presets, videos, wildcards, workers
+from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, runpod, segments, tags, video_presets, videos, wildcards, workers
 
 logger = logging.getLogger(__name__)
 
@@ -65,3 +65,4 @@ app.include_router(videos.router)
 app.include_router(wildcards.router)
 app.include_router(video_presets.router)
 app.include_router(workers.router)
+app.include_router(runpod.router)

--- a/app/routes/runpod.py
+++ b/app/routes/runpod.py
@@ -1,0 +1,108 @@
+"""Launch and terminate RunPod GPU workers from the console.
+
+The RunPod key stays server-side. Creating a pod requires a read/write key — one that can also
+terminate pods and delete volumes — and there is no launch-only scope, so it must never be
+handed to the browser.
+"""
+
+import re
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app import runpod_client
+from app.auth import get_current_user
+from app.config import settings
+from app.runpod_client import RunPodError
+from app.schemas.runpod import (
+    RunPodAvailability,
+    RunPodLaunchRequest,
+    RunPodWorker,
+)
+
+router = APIRouter()
+
+# RunPod pod names, and the FRIENDLY_NAME the worker registers under, both end up in logs and
+# on the Workers page. Keep them boring.
+_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9 ._-]{0,48}$")
+
+
+@router.get("/runpod/availability", response_model=RunPodAvailability,
+            dependencies=[Depends(get_current_user)])
+async def runpod_availability():
+    """Is the configured GPU purchasable in the configured datacenter right now?"""
+    try:
+        return await runpod_client.get_availability()
+    except RunPodError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+
+@router.get("/runpod/workers", response_model=list[RunPodWorker],
+            dependencies=[Depends(get_current_user)])
+async def list_runpod_workers():
+    try:
+        return await runpod_client.list_workers()
+    except RunPodError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+
+@router.post("/runpod/workers", response_model=RunPodWorker, status_code=201,
+             dependencies=[Depends(get_current_user)])
+async def launch_runpod_worker(body: RunPodLaunchRequest):
+    """Launch a worker, refusing early and legibly when there is no capacity."""
+    name = (body.name or "").strip()
+    if not _NAME_RE.match(name):
+        raise HTTPException(
+            status_code=400,
+            detail="Name must be 1-49 chars: letters, numbers, spaces, dot, dash, underscore.",
+        )
+
+    # Check stock first so "no 4090s right now" reads as exactly that, instead of surfacing as
+    # a RunPod spec error. This is best-effort — availability flaps, so the launch below can
+    # still fail — but it turns the common case into a useful message.
+    try:
+        availability = await runpod_client.get_availability()
+    except RunPodError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+    if not availability["available"]:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"No {settings.runpod_gpu_type_id} capacity in "
+                f"{settings.runpod_datacenter_id} right now. The datacenter is pinned because "
+                f"the network volume holding the models is region-locked to it. Try again "
+                f"shortly — availability changes minute to minute."
+            ),
+        )
+
+    # The worker needs the queue to claim from, and its own name so it registers legibly rather
+    # than as runpod-<podid>. QUEUE_API_KEY is this server's own daemon key.
+    env = {
+        "FRIENDLY_NAME": name,
+        "QUEUE_URL": body.queue_url or settings.runpod_worker_queue_url,
+        "QUEUE_API_KEY": settings.api_key,
+    }
+    if settings.runpod_api_key:
+        # Lets the worker stop its own pod when drained. Without it a drain leaves the pod
+        # running and the container simply respawns.
+        env["RUNPOD_API_KEY"] = settings.runpod_api_key
+
+    try:
+        return await runpod_client.launch_worker(name, env)
+    except RunPodError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+
+@router.delete("/runpod/workers/{pod_id}", status_code=204,
+               dependencies=[Depends(get_current_user)])
+async def terminate_runpod_worker(pod_id: str):
+    """Terminate a pod outright.
+
+    This is destructive and immediate: it does not wait for in-flight work. Draining from the
+    Workers page is the graceful path. Terminate exists for when the user has decided the pod
+    should go now.
+    """
+    try:
+        await runpod_client.terminate_worker(pod_id)
+    except RunPodError as e:
+        raise HTTPException(status_code=503, detail=str(e))

--- a/app/runpod_client.py
+++ b/app/runpod_client.py
@@ -1,0 +1,184 @@
+"""Thin RunPod client for launching and terminating GPU workers.
+
+Deliberately small. It knows how to ask whether a GPU is available, start one, list what is
+running, and terminate it — nothing else. Everything configurable lives in settings so a route
+never hardcodes a datacenter or a GPU.
+
+Two RunPod APIs are in play and the split is not arbitrary:
+
+  - REST (rest.runpod.io) for pod create/list/terminate. It is the current API and returns
+    ordinary JSON errors.
+  - GraphQL (api.runpod.io) for availability, because `gpuTypes(...).lowestPrice` is the only
+    place that reports stock for a specific GPU in a specific datacenter, and REST has no
+    equivalent.
+"""
+
+import httpx
+
+from app.config import settings
+
+REST = "https://rest.runpod.io/v1"
+GRAPHQL = "https://api.runpod.io/graphql"
+
+# Long enough for RunPod to actually place a pod, short enough that a hung request does not pin
+# a request worker. Pod creation is the slow one; it provisions before responding.
+_TIMEOUT = httpx.Timeout(connect=10.0, read=45.0, write=15.0, pool=10.0)
+
+
+class RunPodError(RuntimeError):
+    """A RunPod call failed in a way worth showing the user."""
+
+
+def _headers() -> dict:
+    if not settings.runpod_api_key:
+        raise RunPodError(
+            "RunPod is not configured on this server (RUNPOD_API_KEY is unset)."
+        )
+    return {"Authorization": f"Bearer {settings.runpod_api_key}"}
+
+
+async def get_availability() -> dict:
+    """Stock and price for the configured GPU in the configured datacenter.
+
+    Returns {"available": bool, "price": float|None, "stock": str|None, ...}.
+
+    Availability genuinely flaps — sampling one GPU/DC pair ten times over a few minutes has
+    returned stock in some samples and nothing in others. So this is a point-in-time answer and
+    a launch can still fail afterwards; it exists to give the user a useful "no capacity right
+    now" instead of an opaque failure.
+    """
+    query = """
+    query ($gpu: String, $dc: String) {
+      gpuTypes(input: {id: $gpu}) {
+        id
+        displayName
+        memoryInGb
+        lowestPrice(input: {gpuCount: 1, secureCloud: true, dataCenterId: $dc}) {
+          uninterruptablePrice
+          stockStatus
+        }
+      }
+    }
+    """
+    payload = {
+        "query": query,
+        "variables": {
+            "gpu": settings.runpod_gpu_type_id,
+            "dc": settings.runpod_datacenter_id,
+        },
+    }
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(GRAPHQL, json=payload, headers=_headers())
+    if resp.status_code == 401:
+        raise RunPodError("RunPod rejected the API key (401).")
+    if not resp.is_success:
+        raise RunPodError(f"RunPod availability check failed ({resp.status_code}).")
+
+    types = (resp.json().get("data") or {}).get("gpuTypes") or []
+    lowest = (types[0].get("lowestPrice") or {}) if types else {}
+    price = lowest.get("uninterruptablePrice")
+    return {
+        "gpu_type_id": settings.runpod_gpu_type_id,
+        "datacenter_id": settings.runpod_datacenter_id,
+        # No price means no inventory for this GPU in this datacenter right now.
+        "available": price is not None,
+        "price_per_hr": price,
+        "stock": lowest.get("stockStatus"),
+    }
+
+
+async def launch_worker(name: str, env: dict[str, str]) -> dict:
+    """Create a pod, attached to the configured network volume.
+
+    The volume is region-locked, which is why the datacenter is pinned rather than chosen: a
+    pod in the wrong datacenter cannot mount it, and RunPod does not fail loudly about that —
+    it just runs without the models and re-downloads ~39GB.
+    """
+    if not settings.runpod_network_volume_id:
+        raise RunPodError(
+            "RunPod is not configured on this server (RUNPOD_NETWORK_VOLUME_ID is unset)."
+        )
+
+    spec = {
+        "name": name,
+        "imageName": settings.runpod_image,
+        "gpuTypeIds": [settings.runpod_gpu_type_id],
+        "gpuCount": 1,
+        "cloudType": "SECURE",
+        "dataCenterIds": [settings.runpod_datacenter_id],
+        "networkVolumeId": settings.runpod_network_volume_id,
+        "containerDiskInGb": settings.runpod_container_disk_gb,
+        "volumeMountPath": settings.runpod_volume_mount_path,
+        "ports": ["8188/http", "22/tcp"],
+        "env": env,
+    }
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(f"{REST}/pods", json=spec, headers=_headers())
+
+    if resp.status_code == 401:
+        raise RunPodError("RunPod rejected the API key (401).")
+    if not resp.is_success:
+        # RunPod reports "no capacity" as a 4xx with prose. Pass it through rather than
+        # inventing our own wording — theirs distinguishes no-stock from a bad spec.
+        raise RunPodError(_readable_error(resp))
+
+    body = resp.json()
+    return {
+        "id": body.get("id"),
+        "name": body.get("name"),
+        "status": body.get("desiredStatus"),
+        "cost_per_hr": body.get("costPerHr"),
+    }
+
+
+async def list_workers() -> list[dict]:
+    """Pods currently known to RunPod, launched by us or otherwise."""
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.get(f"{REST}/pods", headers=_headers())
+    if not resp.is_success:
+        raise RunPodError(f"Could not list RunPod pods ({resp.status_code}).")
+    pods = resp.json()
+    pods = pods if isinstance(pods, list) else pods.get("data", [])
+    return [
+        {
+            "id": p.get("id"),
+            "name": p.get("name"),
+            "status": p.get("desiredStatus"),
+            "cost_per_hr": p.get("costPerHr"),
+            "gpu_type_id": (p.get("machine") or {}).get("gpuTypeId"),
+        }
+        for p in pods
+    ]
+
+
+async def terminate_worker(pod_id: str) -> None:
+    """Terminate a pod outright.
+
+    Terminate, not stop: a stopped pod stays EXITED and keeps billing for its disk. Callers are
+    responsible for knowing the worker has finished its work — GPU or VRAM going idle is NOT
+    that signal, because decode, RIFE, stitching, faceswap and identity scoring all run after
+    the GPU goes quiet (47s to over 2 minutes, measured).
+    """
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.delete(f"{REST}/pods/{pod_id}", headers=_headers())
+    # 404 means it is already gone, which is the state the caller wanted.
+    if resp.status_code == 404:
+        return
+    if not resp.is_success:
+        raise RunPodError(_readable_error(resp))
+
+
+def _readable_error(resp: httpx.Response) -> str:
+    """Pull something a human can act on out of a RunPod error response."""
+    try:
+        body = resp.json()
+    except Exception:
+        return f"RunPod returned {resp.status_code}: {resp.text[:200]}"
+    if isinstance(body, dict):
+        for key in ("error", "message", "detail"):
+            value = body.get(key)
+            if isinstance(value, str) and value:
+                return value
+            if isinstance(value, dict) and value.get("message"):
+                return str(value["message"])
+    return f"RunPod returned {resp.status_code}: {str(body)[:200]}"

--- a/app/schemas/runpod.py
+++ b/app/schemas/runpod.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+
+
+class RunPodAvailability(BaseModel):
+    gpu_type_id: str
+    datacenter_id: str
+    available: bool
+    price_per_hr: float | None = None
+    stock: str | None = None
+
+
+class RunPodWorker(BaseModel):
+    id: str
+    name: str | None = None
+    status: str | None = None
+    cost_per_hr: float | None = None
+    gpu_type_id: str | None = None
+
+
+class RunPodLaunchRequest(BaseModel):
+    name: str
+    # Override only when pointing a worker at something other than the configured queue —
+    # e.g. testing against a staging API. Normal launches leave it unset.
+    queue_url: str | None = None

--- a/tests/test_runpod_launcher.py
+++ b/tests/test_runpod_launcher.py
@@ -1,0 +1,133 @@
+"""Tests for the RunPod worker launcher (wanly-console#288).
+
+The valuable cases here are the refusals, not the happy path. Launching spends money per hour
+and the failure modes are all "it looked like it worked":
+
+  - no capacity must read as no capacity, not as an opaque RunPod spec error
+  - a missing key must say so rather than 500
+  - the datacenter must stay pinned to the volume's region, because a pod in the wrong region
+    silently runs without the models and re-downloads ~39GB instead of failing
+"""
+
+import httpx
+import pytest
+
+from app import runpod_client
+from app.config import settings
+from app.runpod_client import RunPodError
+
+
+class _Resp:
+    def __init__(self, status=200, payload=None, text=""):
+        self.status_code = status
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    @property
+    def is_success(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    """Stands in for httpx.AsyncClient, recording what was sent."""
+
+    calls: list = []
+
+    def __init__(self, responses):
+        self._responses = responses
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        _Client.calls.append(("POST", url, json, headers))
+        return self._responses.pop(0)
+
+    async def get(self, url, headers=None):
+        _Client.calls.append(("GET", url, None, headers))
+        return self._responses.pop(0)
+
+    async def delete(self, url, headers=None):
+        _Client.calls.append(("DELETE", url, None, headers))
+        return self._responses.pop(0)
+
+
+def _install(monkeypatch, *responses):
+    _Client.calls = []
+    monkeypatch.setattr(settings, "runpod_api_key", "rpa_test")
+    monkeypatch.setattr(settings, "runpod_network_volume_id", "vol_test")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _Client(list(responses)))
+
+
+def _availability_payload(price):
+    return {"data": {"gpuTypes": [{"lowestPrice": {
+        "uninterruptablePrice": price, "stockStatus": "Low" if price else None}}]}}
+
+
+class TestAvailability:
+    async def test_price_means_available(self, monkeypatch):
+        _install(monkeypatch, _Resp(payload=_availability_payload(0.74)))
+        out = await runpod_client.get_availability()
+        assert out["available"] is True
+        assert out["price_per_hr"] == 0.74
+
+    async def test_no_price_means_no_capacity(self, monkeypatch):
+        """RunPod reports 'no inventory' as a null price, not an error."""
+        _install(monkeypatch, _Resp(payload=_availability_payload(None)))
+        out = await runpod_client.get_availability()
+        assert out["available"] is False
+
+    async def test_rejected_key_says_so(self, monkeypatch):
+        _install(monkeypatch, _Resp(status=401))
+        with pytest.raises(RunPodError, match="401"):
+            await runpod_client.get_availability()
+
+    async def test_missing_key_is_a_clear_message_not_a_crash(self, monkeypatch):
+        monkeypatch.setattr(settings, "runpod_api_key", "")
+        with pytest.raises(RunPodError, match="RUNPOD_API_KEY"):
+            await runpod_client.get_availability()
+
+
+class TestLaunch:
+    async def test_pins_datacenter_volume_and_gpu(self, monkeypatch):
+        """The volume is region-locked. A pod in the wrong datacenter cannot mount it and
+        RunPod does not complain — it just re-downloads ~39GB and runs anyway."""
+        _install(monkeypatch, _Resp(status=201, payload={"id": "pod1", "name": "w"}))
+        await runpod_client.launch_worker("w", {"FRIENDLY_NAME": "w"})
+        _, url, body, _ = _Client.calls[0]
+        assert url.endswith("/pods")
+        assert body["dataCenterIds"] == [settings.runpod_datacenter_id]
+        assert body["networkVolumeId"] == "vol_test"
+        assert body["gpuTypeIds"] == [settings.runpod_gpu_type_id]
+        assert body["cloudType"] == "SECURE"
+
+    async def test_missing_volume_is_a_clear_message(self, monkeypatch):
+        _install(monkeypatch)
+        monkeypatch.setattr(settings, "runpod_network_volume_id", "")
+        with pytest.raises(RunPodError, match="RUNPOD_NETWORK_VOLUME_ID"):
+            await runpod_client.launch_worker("w", {})
+
+    async def test_runpod_error_prose_is_passed_through(self, monkeypatch):
+        """Their wording distinguishes no-stock from a bad spec; ours would not."""
+        _install(monkeypatch, _Resp(status=400, payload={"error": "no instances available"}))
+        with pytest.raises(RunPodError, match="no instances available"):
+            await runpod_client.launch_worker("w", {})
+
+
+class TestTerminate:
+    async def test_terminate_calls_delete(self, monkeypatch):
+        _install(monkeypatch, _Resp(status=204))
+        await runpod_client.terminate_worker("pod1")
+        method, url, _, _ = _Client.calls[0]
+        assert method == "DELETE" and url.endswith("/pods/pod1")
+
+    async def test_already_gone_is_success(self, monkeypatch):
+        """404 means the pod is in the state the caller asked for."""
+        _install(monkeypatch, _Resp(status=404))
+        await runpod_client.terminate_worker("pod1")


### PR DESCRIPTION
Backs wanly-console#288 — the API half.

The launcher is server-side because creating a pod needs a **read/write** RunPod key, which can also terminate pods and delete volumes. There is no launch-only scope, so it must never reach the browser.

`GET /runpod/availability` · `GET/POST /runpod/workers` · `DELETE /runpod/workers/{id}`

### The defaults are measured, not guessed

- **4090 only.** 3090 secure inventory is transient — present in one sample, gone in the next five. A 3090 option could not be honoured.
- **EU-RO-1.** Network volumes are region-locked, so the pod must launch beside the volume holding the 39GB model set. Sampling stock 10x per datacenter:

| DC | 4090 availability |
|---|---|
| EU-RO-1, EU-CZ-1 | 10/10 |
| EUR-IS-1 | 9/10 |
| US-NC-1 | 1/10 |
| all other US/CA storage DCs | 0/10 |

### Behaviour worth noting

**POST checks availability first**, so "no capacity right now" reads as exactly that instead of an opaque spec error. Best-effort only — availability flaps minute to minute, so the launch can still fail, and RunPod's own error prose is passed through because it distinguishes no-stock from a bad spec better than ours would.

**Terminate, not stop** — a stopped pod stays EXITED and keeps billing disk. Exposed only as an explicit user action.

**Terminate-on-drain is deliberately not here.** It belongs with wanly-gpu-daemon#110 and must be gated on the daemon confirming the segment is *uploaded*. GPU/VRAM idle is not that signal: decode, RIFE, stitching, faceswap and scoring all run after the GPU goes quiet — 47s to over 2 minutes, measured today.

### Tests

9 new, aimed at the refusals rather than the happy path, since every failure mode here looks like success. Verified they catch regressions: pinning the wrong datacenter and reporting stock unconditionally each fail their test. **351 pass.**

Deploy needs `RUNPOD_API_KEY` and `RUNPOD_NETWORK_VOLUME_ID` in `/opt/wanly-api/.env`; without them the endpoints return a clear 503 rather than failing obscurely.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct