### PR TITLE
Record which GPU ran each segment, and report run times by GPU and shape

### DIFF
--- a/alembic/versions/057_add_segment_gpu_name.py
+++ b/alembic/versions/057_add_segment_gpu_name.py
@@ -1,0 +1,48 @@
+"""Record which GPU ran each segment
+
+Revision ID: 057
+Revises: 056
+Create Date: 2026-08-07
+
+Run times vary enormously by hardware, and there was no way to see it — comparing a 3090 against
+a 4090 meant reading log lines by hand.
+
+The GPU name is only knowable from the worker, and worker rows are deleted when a worker
+deregisters: every RunPod pod takes its row with it when it drains. So the name has to be
+snapshotted onto the segment at claim time, or the association is lost the moment the pod goes
+away.
+
+The backfill recovers what it honestly can — segments whose worker row still exists, which is
+mostly the long-lived 3090. Segments run by pods that have since terminated stay NULL rather
+than being guessed at from a worker name someone typed by hand.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "057"
+down_revision = "056"
+branch_labels = None
+depends_on = None
+
+
+# ->> extracts the JSONB value as text; IS NOT NULL is used rather than the `?` containment
+# operator because `?` collides with DBAPI parameter binding.
+_BACKFILL = sa.text(
+    """
+    UPDATE segments AS s
+    SET gpu_name = w.gpu_stats->>'gpu_name'
+    FROM workers AS w
+    WHERE s.worker_id = w.id
+      AND s.gpu_name IS NULL
+      AND w.gpu_stats->>'gpu_name' IS NOT NULL
+    """
+)
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("gpu_name", sa.String(length=100), nullable=True))
+    op.execute(_BACKFILL)
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "gpu_name")

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from slowapi.errors import RateLimitExceeded
 from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
 from app.limiter import limiter
-from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, runpod, segments, tags, video_presets, videos, wildcards, workers
+from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, runpod, segments, stats, tags, video_presets, videos, wildcards, workers
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +66,4 @@ app.include_router(wildcards.router)
 app.include_router(video_presets.router)
 app.include_router(workers.router)
 app.include_router(runpod.router)
+app.include_router(stats.router)

--- a/app/models.py
+++ b/app/models.py
@@ -191,6 +191,9 @@ class Segment(Base):
     status = mapped_column(String(20), nullable=False, default=SegmentStatus.PENDING)
     worker_id = mapped_column(UUID(as_uuid=True), nullable=True)
     worker_name = mapped_column(String(255), nullable=True)
+    # Snapshotted at claim time. Worker rows vanish when a pod deregisters, so joining to
+    # workers later would lose every segment a since-terminated pod ran.
+    gpu_name = mapped_column(String(100), nullable=True)
     output_path = mapped_column(Text, nullable=True)
     last_frame_path = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -311,6 +311,13 @@ async def claim_next_segment(
     segment.worker_name = worker_name
     segment.claimed_at = now
 
+    # Snapshot the GPU now, not at read time. Worker rows are deleted on deregister — every
+    # RunPod pod takes its row with it when it drains — so a later join would silently lose the
+    # hardware for every segment a since-terminated pod ran.
+    claiming_worker = await db.get(Worker, worker_id)
+    if claiming_worker and claiming_worker.gpu_stats:
+        segment.gpu_name = claiming_worker.gpu_stats.get("gpu_name")
+
     job = await db.get(Job, segment.job_id)
     if job.status == JobStatus.PENDING:
         job.status = JobStatus.PROCESSING

--- a/app/routes/stats.py
+++ b/app/routes/stats.py
@@ -1,0 +1,87 @@
+"""Aggregate run-time statistics.
+
+Grouped by GPU **and** job shape, never by GPU alone. Measured on one machine in a single day:
+
+    480x720   / 3s   ->   329s
+    704x480   / 5s   ->   566s, 575s
+    720x1056  / 5s   ->  1774s, 1787s
+
+A single "average for a 4090" mixing those is noise, and worse than no number at all because it
+looks authoritative. Shape is part of the key.
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import Float, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.enums import SegmentStatus
+from app.models import Job, Segment
+from app.schemas.stats import SegmentRuntimeGroup
+
+router = APIRouter()
+
+
+@router.get("/stats/segment-runtimes", response_model=list[SegmentRuntimeGroup],
+            dependencies=[Depends(get_current_user)])
+async def segment_runtimes(
+    db: AsyncSession = Depends(get_db),
+    min_samples: int = Query(1, ge=1, description="Hide groups with fewer runs than this"),
+):
+    """Completed segment run times, grouped by GPU and job shape.
+
+    Run time is completed_at - claimed_at: the whole segment as the worker experienced it,
+    including the tail after the GPU goes quiet — decode, RIFE, stitching, faceswap and identity
+    scoring, which together run 47s to over 2 minutes. Sampling time alone would understate what
+    a job actually costs.
+    """
+    elapsed = func.extract("epoch", Segment.completed_at - Segment.claimed_at).cast(Float)
+
+    stmt = (
+        select(
+            Segment.gpu_name,
+            Job.width,
+            Job.height,
+            Segment.duration_seconds,
+            func.count().label("samples"),
+            func.avg(elapsed).label("avg_seconds"),
+            func.min(elapsed).label("min_seconds"),
+            func.max(elapsed).label("max_seconds"),
+            # Median resists the one pathological run that a mean would hide behind. The 720p
+            # segments that ran with the model fully offloaded took the same wall-clock as the
+            # ones that did not — but that is not something to rely on holding.
+            func.percentile_cont(0.5)
+            .within_group(elapsed)
+            .label("median_seconds"),
+        )
+        .join(Job, Job.id == Segment.job_id)
+        .where(
+            Segment.status == SegmentStatus.COMPLETED,
+            Segment.claimed_at.isnot(None),
+            Segment.completed_at.isnot(None),
+            # Guard against clock skew or a repaired row producing a negative duration, which
+            # would drag an average somewhere impossible.
+            Segment.completed_at > Segment.claimed_at,
+        )
+        .group_by(Segment.gpu_name, Job.width, Job.height, Segment.duration_seconds)
+        .having(func.count() >= min_samples)
+        .order_by(Segment.gpu_name, Job.width, Job.height, Segment.duration_seconds)
+    )
+
+    rows = (await db.execute(stmt)).all()
+    return [
+        SegmentRuntimeGroup(
+            # NULL means the segment predates gpu_name, or ran on a pod whose row is gone.
+            gpu_name=r.gpu_name or "unknown",
+            width=r.width,
+            height=r.height,
+            clip_seconds=r.duration_seconds,
+            samples=r.samples,
+            avg_seconds=round(r.avg_seconds or 0, 1),
+            median_seconds=round(r.median_seconds or 0, 1),
+            min_seconds=round(r.min_seconds or 0, 1),
+            max_seconds=round(r.max_seconds or 0, 1),
+        )
+        for r in rows
+    ]

--- a/app/schemas/stats.py
+++ b/app/schemas/stats.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class SegmentRuntimeGroup(BaseModel):
+    """One GPU + job shape combination.
+
+    Shape is part of the identity, not a detail: the same hardware runs 480p/3s in ~330s and
+    720x1056/5s in ~1780s, so a figure that mixes them describes nothing.
+    """
+
+    gpu_name: str
+    width: int
+    height: int
+    clip_seconds: float
+    samples: int
+    avg_seconds: float
+    median_seconds: float
+    min_seconds: float
+    max_seconds: float

--- a/tests/test_segment_runtimes.py
+++ b/tests/test_segment_runtimes.py
@@ -1,0 +1,57 @@
+"""Tests for run-time stats grouped by GPU and shape (wanly-console#287).
+
+The trap this guards against is a number that looks authoritative and means nothing. Measured on
+one machine in a single day:
+
+    704x480  / 3s  ->   329s
+    704x480  / 5s  ->   566s, 575s
+    720x1056 / 5s  ->  1774s, 1787s
+
+Averaging those into "a 4090 takes ~850s" would be worse than reporting nothing, because someone
+would plan against it.
+"""
+
+import inspect
+
+from app.routes import stats
+
+
+class TestGrouping:
+    def test_groups_by_shape_not_just_gpu(self):
+        """Shape is part of the identity. A 5x spread hides inside a GPU-only average."""
+        src = inspect.getsource(stats.segment_runtimes)
+        assert ".group_by(" in src
+        for column in ("Segment.gpu_name", "Job.width", "Job.height", "Segment.duration_seconds"):
+            assert column in src.split(".group_by(")[1].split(")")[0] + ")", (
+                f"{column} must be part of the grouping key"
+            )
+
+    def test_runtime_spans_the_whole_segment_not_just_sampling(self):
+        """completed_at - claimed_at. The tail after the GPU idles — decode, RIFE, stitching,
+        faceswap, identity scoring — runs 47s to over 2 minutes and is part of what a job costs."""
+        src = inspect.getsource(stats.segment_runtimes)
+        assert "Segment.completed_at - Segment.claimed_at" in src
+
+    def test_excludes_incomplete_and_impossible_rows(self):
+        src = inspect.getsource(stats.segment_runtimes)
+        assert "SegmentStatus.COMPLETED" in src
+        assert "Segment.claimed_at.isnot(None)" in src
+        assert "Segment.completed_at.isnot(None)" in src
+        # A negative duration from clock skew would drag an average somewhere impossible.
+        assert "Segment.completed_at > Segment.claimed_at" in src
+
+    def test_reports_median_alongside_mean(self):
+        """One pathological run should not be able to hide behind a mean."""
+        src = inspect.getsource(stats.segment_runtimes)
+        assert "percentile_cont" in src
+
+
+class TestSchema:
+    def test_group_carries_shape_and_sample_count(self):
+        from app.schemas.stats import SegmentRuntimeGroup
+
+        fields = SegmentRuntimeGroup.model_fields
+        for required in ("gpu_name", "width", "height", "clip_seconds", "samples"):
+            assert required in fields, f"{required} is needed to interpret the numbers"
+        # Without samples, a group built from one run looks identical to one built from fifty.
+        assert fields["samples"].annotation is int


### PR DESCRIPTION
Backs wanly-console#287 — the API half.

### Capture

The GPU name is only knowable from the worker, and **worker rows are deleted on deregister** — every RunPod pod takes its row with it when it drains. A read-time join would silently lose the hardware for every segment a since-terminated pod ran. So it is snapshotted onto the segment at claim time.

Migration 057 adds the column and **backfills what it honestly can**: segments whose worker row still exists, mostly the long-lived 3090. Segments run by pods that have since gone stay NULL rather than being guessed at from a worker name someone typed by hand.

### Aggregate — by GPU **and** shape

Measured on one machine in a single day:

| shape | run time |
|---|---|
| 704x480 / 3s | 329s |
| 704x480 / 5s | 566s, 575s |
| 720x1056 / 5s | 1774s, 1787s |

A single "average for a 4090" mixing those is **worse than no number**, because it looks authoritative enough to plan against. Shape is part of the grouping key.

Run time is `completed_at - claimed_at` — the whole segment as the worker experienced it, including the tail after the GPU goes quiet. Decode, RIFE, stitching, faceswap and scoring run 47s to 2+ minutes; sampling time alone understates the real cost.

Reports **median alongside mean** so one pathological run cannot hide behind an average, and **sample count** so a group built from one run does not read like one built from fifty.

### Tests

5 new. **356 pass.** Verified the grouping test fails when the key collapses to GPU alone.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct
