### PR TITLE
Keep a draining worker draining when it goes silent

### DIFF
--- a/app/heartbeat_monitor.py
+++ b/app/heartbeat_monitor.py
@@ -11,6 +11,33 @@ from app.models import Worker
 logger = logging.getLogger(__name__)
 
 
+def offline_sweep_conditions(cutoff):
+    """Which workers the sweep may mark offline.
+
+    Extracted so the rule has exactly one definition. Inlined in the update statement it could
+    only be tested by re-typing it, which is how a test ends up asserting what it wishes were
+    true rather than what the code does.
+    """
+    return (
+        # Silent for longer than the threshold.
+        Worker.last_heartbeat < cutoff,
+        # Already offline: nothing to change.
+        Worker.status != "offline",
+        # A draining worker keeps its status when it goes quiet.
+        #
+        # Overwriting it destroyed the drain: heartbeat() sets a previously-offline worker back
+        # to online-idle, so it resumed claiming as if nothing had been asked of it. That
+        # happened for real — a worker went silent for 240s during identity scoring and came
+        # back having forgotten it was draining.
+        #
+        # The blocking-scoring cause is fixed in wanly-gpu-daemon#117, but a drain must survive
+        # silence for ANY reason: network partition, GPU hang, crash. Losing an operator's
+        # explicit instruction because a heartbeat was late is never right — an unreachable
+        # drained worker should read as draining, not as available.
+        Worker.status != "draining",
+    )
+
+
 async def heartbeat_monitor():
     while True:
         await asyncio.sleep(15)
@@ -21,7 +48,7 @@ async def heartbeat_monitor():
             async with async_session() as session:
                 stmt = (
                     update(Worker)
-                    .where(Worker.last_heartbeat < cutoff, Worker.status != "offline")
+                    .where(*offline_sweep_conditions(cutoff))
                     .values(status="offline", comfyui_running=False)
                     .returning(Worker.id)
                 )

--- a/tests/test_offline_sweep.py
+++ b/tests/test_offline_sweep.py
@@ -1,0 +1,73 @@
+"""Tests for the sweep that marks silent workers offline (#161).
+
+This code had no tests at all, and it silently reverted an operator's drain.
+
+Sequence that happened for real: a worker went quiet for 240s while identity scoring blocked the
+daemon's event loop (wanly-gpu-daemon#117). The sweep flipped `draining` to `offline`. When
+heartbeats resumed, `heartbeat()` saw a previously-offline worker and set it back to
+`online-idle` — so it went straight back to claiming work, with no record that a drain had ever
+been requested.
+
+The daemon-side cause is fixed, but a drain has to survive silence for ANY reason: network
+partition, GPU hang, crash. These pin that.
+
+The suite has no database fixture and the models use JSONB, which SQLite cannot compile, so
+these assert the compiled predicate rather than executing it. That is a real limitation and it
+is why the rule was extracted into offline_sweep_conditions() — the test and the sweep now read
+from one definition instead of two that can drift.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import update
+
+from app.config import settings
+from app.heartbeat_monitor import offline_sweep_conditions
+from app.models import Worker
+
+
+def _sql(cutoff=None) -> str:
+    cutoff = cutoff or datetime.now(timezone.utc) - timedelta(seconds=120)
+    stmt = update(Worker).where(*offline_sweep_conditions(cutoff)).values(status="offline")
+    return str(stmt.compile(compile_kwargs={"literal_binds": False}))
+
+
+class TestDrainSurvivesSilence:
+    def test_draining_workers_are_excluded(self):
+        """The bug. Without this the drain is lost the moment a heartbeat is late."""
+        sql = _sql()
+        assert "status != " in sql
+        # Both exclusions must be present — offline AND draining.
+        assert sql.count("status !=") >= 2, (
+            "a draining worker must not be swept to offline; heartbeat() would then reset it to "
+            "online-idle and it would resume claiming"
+        )
+
+    def test_the_rule_has_one_definition(self):
+        """Re-typing the predicate in a test asserts what someone wished were true."""
+        import inspect
+
+        from app import heartbeat_monitor
+
+        src = inspect.getsource(heartbeat_monitor.heartbeat_monitor)
+        assert "offline_sweep_conditions(cutoff)" in src, (
+            "the sweep must build its WHERE from the shared predicate, or this test drifts "
+            "away from the code it is meant to protect"
+        )
+
+
+class TestSweepStillWorks:
+    def test_silence_is_still_what_triggers_it(self):
+        sql = _sql()
+        assert "last_heartbeat <" in sql
+
+    def test_already_offline_workers_are_skipped(self):
+        """Otherwise the sweep rewrites the same rows forever and logs them each pass."""
+        conditions = offline_sweep_conditions(datetime.now(timezone.utc))
+        rendered = " ".join(str(c) for c in conditions)
+        assert "status !=" in rendered
+
+    def test_threshold_is_several_missed_beats(self):
+        """The daemon heartbeats every 30s. Too tight and a slow request marks a live worker
+        dead; the post-sampling tail already pushed past 120s once."""
+        assert settings.heartbeat_offline_seconds >= 90, "fewer than 3 missed beats is twitchy"


### PR DESCRIPTION
Closes #161.

The offline sweep marked **any** worker offline after 120s without a heartbeat — including one that was `draining`. `heartbeat()` then sets a previously-offline worker back to `online-idle`, so it **resumed claiming as if nothing had been asked of it**.

This happened for real: a worker went quiet for 240s while identity scoring blocked the daemon's event loop, and came back having forgotten it was draining. That cause is fixed in wanly-gpu-daemon#117 — but a drain has to survive silence for **any** reason: network partition, GPU hang, crash. An unreachable drained worker should read as draining, not as available.

### Fourth instance of this bug class today

| where | how the drain was lost |
|---|---|
| wanly-console#286 | pod never stopped, container respawned, worker re-registered |
| wanly-gpu-daemon#110 | systemd `Restart=always` resurrected the daemon |
| wanly-gpu-daemon#113 | drain wait timed out at 600s against 1787s segments |
| **this one** | the offline sweep reverted the status |

The pattern: a drain is an explicit operator instruction, and every layer that can flip a worker's status was treating it as advisory.

### On the tests

The rule is extracted into `offline_sweep_conditions()` so the sweep and its tests read from **one** definition. Inlined, the only way to test it was to re-type it — which produces a test asserting what someone wished were true.

These remain SQL-level assertions: the suite has no database fixture and JSONB blocks SQLite. That limitation is recorded as #162, along with what it would take to fix.

**361 tests pass.** Verified the key test fails when the draining exclusion is removed.
