### PR TITLE
Add a database fixture so lifecycle rules can be tested by behaviour

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
     env:
       DATABASE_URL: postgresql+asyncpg://test:test@localhost/test
       JWT_SECRET: ci-test-secret-key
+      # Database-backed tests skip when no postgres is reachable, so the suite still runs on a
+      # laptop. In CI a skip is indistinguishable from a pass, which is how untested rules
+      # survive — so here they must run or fail.
+      REQUIRE_DB: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,79 @@ import os
 # them at module level via pydantic-settings.
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 os.environ.setdefault("JWT_SECRET", "test-secret-key-for-unit-tests")
+
+
+# ---------------------------------------------------------------------------
+# Database fixtures (#162)
+#
+# CI already runs a postgres service with DATABASE_URL pointing at it — what was missing was a
+# way for a test to open a session. Without one, every rule that lives in a WHERE clause could
+# only be checked by compiling the statement and asserting on the SQL string, which pins the
+# shape of a query and says nothing about its behaviour against real rows.
+#
+# The models use JSONB, so SQLite is not an option and there is no local fallback. Tests that
+# need a database SKIP when one is unreachable, so the suite still runs on a laptop with no
+# postgres — but CI sets REQUIRE_DB=1, which turns those skips into failures. A silently
+# skipped test in CI is indistinguishable from a passing one, and that is exactly how this
+# class of bug survives.
+# ---------------------------------------------------------------------------
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+def _test_database_url() -> str:
+    # A separate variable so a stray run can never point at anything real.
+    return os.environ.get("TEST_DATABASE_URL") or os.environ["DATABASE_URL"]
+
+
+# asyncpg connections are bound to the event loop that created them, and pytest-asyncio gives
+# each test its own loop. A session-scoped engine therefore fails with "attached to a different
+# loop" on the second test. The engine is per-test; only the CREATE TABLE work is done once.
+_tables_created = False
+
+
+@pytest_asyncio.fixture
+async def db_engine():
+    import pytest
+
+    global _tables_created
+    from app.models import Base
+
+    engine = create_async_engine(_test_database_url())
+    try:
+        if not _tables_created:
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+            _tables_created = True
+        else:
+            # Cheap connectivity probe, so an unreachable database still skips rather than
+            # failing every test with a connection error.
+            async with engine.connect():
+                pass
+    except Exception as e:  # noqa: BLE001 - any connection problem means "no database here"
+        await engine.dispose()
+        if os.environ.get("REQUIRE_DB"):
+            raise
+        pytest.skip(f"no test database available: {type(e).__name__}: {e}")
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db(db_engine):
+    """A session whose writes are rolled back at the end of the test.
+
+    Everything runs inside one outer transaction that is never committed, so tests cannot leak
+    rows into each other and order cannot matter. Code under test may call session.commit()
+    freely — it commits the inner nested transaction, not the outer one.
+    """
+    connection = await db_engine.connect()
+    transaction = await connection.begin()
+    session = async_sessionmaker(bind=connection, expire_on_commit=False)()
+    try:
+        yield session
+    finally:
+        await session.close()
+        await transaction.rollback()
+        await connection.close()

--- a/tests/test_offline_sweep_db.py
+++ b/tests/test_offline_sweep_db.py
@@ -1,0 +1,95 @@
+"""The offline sweep, run against a real database (#162).
+
+tests/test_offline_sweep.py asserts the shape of the WHERE clause. These execute it, which is
+the difference between "the predicate mentions draining" and "a draining worker actually
+survives the sweep".
+
+That distinction is not academic. The bug in #161 was a missing condition, and a shape test
+only catches it because someone thought to assert on that exact string. A behavioural test
+catches it because the worker is still draining afterwards.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select, update
+
+from app.config import settings
+from app.heartbeat_monitor import offline_sweep_conditions
+from app.models import Worker
+
+
+async def _worker(db, name: str, status: str, seconds_silent: int) -> Worker:
+    w = Worker(
+        friendly_name=name,
+        hostname="h",
+        ip_address="127.0.0.1",
+        status=status,
+        comfyui_running=True,
+        last_heartbeat=datetime.now(timezone.utc) - timedelta(seconds=seconds_silent),
+    )
+    db.add(w)
+    await db.flush()
+    return w
+
+
+async def _run_sweep(db) -> None:
+    """Exactly what heartbeat_monitor runs, against this session."""
+    cutoff = datetime.now(timezone.utc) - timedelta(
+        seconds=settings.heartbeat_offline_seconds
+    )
+    await db.execute(
+        update(Worker)
+        .where(*offline_sweep_conditions(cutoff))
+        .values(status="offline", comfyui_running=False)
+    )
+    await db.flush()
+
+
+async def _status(db, worker_id) -> str:
+    return (await db.execute(select(Worker.status).where(Worker.id == worker_id))).scalar_one()
+
+
+class TestOfflineSweepBehaviour:
+    async def test_a_silent_worker_is_marked_offline(self, db):
+        w = await _worker(db, "silent", "online-idle", seconds_silent=600)
+        await _run_sweep(db)
+        assert await _status(db, w.id) == "offline"
+
+    async def test_a_draining_worker_survives_silence(self, db):
+        """#161. Marking it offline made heartbeat() reset it to online-idle, so it resumed
+        claiming as if the drain had never been requested."""
+        w = await _worker(db, "draining-silent", "draining", seconds_silent=600)
+        await _run_sweep(db)
+        assert await _status(db, w.id) == "draining", (
+            "a drain must survive silence for any reason — network partition, GPU hang, crash"
+        )
+
+    async def test_a_live_worker_is_untouched(self, db):
+        w = await _worker(db, "live", "online-busy", seconds_silent=5)
+        await _run_sweep(db)
+        assert await _status(db, w.id) == "online-busy"
+
+    async def test_a_busy_but_silent_worker_is_marked_offline(self, db):
+        """Not a special case — this is the one that surprised us. A worker mid-segment whose
+        event loop was blocked went silent and was correctly swept; the bug was that it took a
+        pending drain with it."""
+        w = await _worker(db, "busy-silent", "online-busy", seconds_silent=600)
+        await _run_sweep(db)
+        assert await _status(db, w.id) == "offline"
+
+    @pytest.mark.parametrize("seconds,expected", [
+        (settings.heartbeat_offline_seconds - 5, "online-idle"),
+        (settings.heartbeat_offline_seconds + 5, "offline"),
+    ])
+    async def test_the_boundary_is_where_it_claims_to_be(self, db, seconds, expected):
+        """A shape test cannot see an off-by-one in the cutoff, or a cutoff built from the
+        wrong clock."""
+        w = await _worker(db, f"boundary-{seconds}", "online-idle", seconds_silent=seconds)
+        await _run_sweep(db)
+        assert await _status(db, w.id) == expected
+
+    async def test_rows_do_not_leak_between_tests(self, db):
+        """The outer transaction is rolled back, so every test sees only what it created."""
+        names = (await db.execute(select(Worker.friendly_name))).scalars().all()
+        assert names == [], f"leaked rows from a previous test: {names}"


### PR DESCRIPTION
Closes #162.

**A correction to that ticket first:** it claimed CI had "no database, no container". That was wrong — the workflow has run a postgres service with `DATABASE_URL` pointed at it all along. What was missing was only a way for a test to *open a session*, which makes this far smaller than I scoped it.

### What this adds

A per-test session whose writes roll back, so tests cannot leak rows into each other and order cannot matter. Code under test may `commit()` freely — it commits the inner nested transaction, not the outer one.

The engine is **per-test** rather than session-scoped: asyncpg connections bind to the event loop that created them and pytest-asyncio gives each test its own, so a session-scoped engine fails with `attached to a different loop` on the second test. Only `CREATE TABLE` is done once.

### Skips locally, required in CI

Tests needing a database skip when none is reachable, so the suite still runs on a laptop. CI sets `REQUIRE_DB=1`, turning those skips into failures — **a silently skipped test in CI is indistinguishable from a passing one**, and that is exactly how untested rules survive.

### It proves itself on the bug from #161

| test style | what it asserts |
|---|---|
| `test_offline_sweep.py` | the WHERE clause *mentions* draining |
| `test_offline_sweep_db.py` | a draining worker *is still draining afterwards* |

The second catches the bug because the behaviour is wrong, not because someone thought to assert on that exact string.

It also covers what a shape test structurally cannot see — the **boundary**: a worker 5s inside the threshold stays online, one 5s past it goes offline. An off-by-one in the cutoff, or a cutoff built from the wrong clock, is invisible to SQL inspection.

### Verification

- **368 pass** with a database, **361 pass + 7 skip** without.
- Verified against a throwaway postgres locally, then confirmed the draining test **fails** when the exclusion is removed and passes when restored.

This unblocks the Tier 2 tests for wanly-console#296 (auto-reserve), which is sequenced behind it.
