### PR TITLE
Reserve a GPU: keep trying for N minutes and launch when one frees up

### DIFF
--- a/alembic/versions/058_add_gpu_reservations.py
+++ b/alembic/versions/058_add_gpu_reservations.py
@@ -1,0 +1,51 @@
+"""Standing requests to launch a worker when a GPU frees up
+
+Revision ID: 058
+Revises: 057
+Create Date: 2026-08-07
+
+Availability swings hard — the 4090 in EU-RO-1 was available in 10/10 samples one morning and
+0/7 that evening. The gap between a pod freeing up and someone asking for it is what a poller
+closes and a person does not.
+
+The row exists because the alternative is holding the reservation in memory, and both places it
+could live are wrong: the browser tab gets closed, and the API container is recreated on every
+deploy. A reservation that dies on deploy dies invisibly, which is worse than not offering the
+feature — the user is still waiting for a worker nobody is going to launch.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "058"
+down_revision = "057"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "gpu_reservations",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("drain_after_jobs", sa.Integer(), nullable=True),
+        sa.Column("pod_id", sa.String(length=64), nullable=True),
+        sa.Column("error", sa.String(length=500), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    # The poller only ever looks for pending rows; without this it scans every reservation ever
+    # made, forever.
+    op.create_index(
+        "ix_gpu_reservations_pending",
+        "gpu_reservations",
+        ["status", "expires_at"],
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_gpu_reservations_pending", table_name="gpu_reservations")
+    op.drop_table("gpu_reservations")

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from slowapi.errors import RateLimitExceeded
 
 from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
+from app.reservation_monitor import reservation_monitor
 from app.limiter import limiter
 from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, runpod, segments, stats, tags, video_presets, videos, wildcards, workers
 
@@ -17,13 +18,18 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    task = asyncio.create_task(heartbeat_monitor())
+    tasks = [
+        asyncio.create_task(heartbeat_monitor()),
+        asyncio.create_task(reservation_monitor()),
+    ]
     yield
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 app = FastAPI(title="wanly-api", lifespan=lifespan)

--- a/app/models.py
+++ b/app/models.py
@@ -348,3 +348,37 @@ class Worker(Base):
     a1111: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
     drain_after_jobs: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+
+class GpuReservation(Base):
+    """A standing request to launch a worker as soon as a GPU frees up.
+
+    Persisted rather than held in memory, for two reasons that are not stylistic: the browser
+    tab that created it will be closed, and the API container is recreated on every deploy. A
+    reservation that dies on deploy is worse than no feature, because it dies invisibly — the
+    user is still waiting for a worker that nobody is going to launch.
+    """
+
+    __tablename__ = "gpu_reservations"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # Becomes both the pod name and the worker's FRIENDLY_NAME, so the Workers page can join
+    # them without a second identifier.
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    # Optional, and more important here than at launch time: a reservation can fire unattended,
+    # so "get me a 4090 and drain it after 3 jobs" is a bounded instruction where "get me a
+    # 4090" is open-ended spend.
+    drain_after_jobs = mapped_column(Integer, nullable=True)
+    pod_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    error: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/app/reservation_monitor.py
+++ b/app/reservation_monitor.py
@@ -1,0 +1,132 @@
+"""Polls pending GPU reservations and launches a worker when capacity appears.
+
+A dumb driver around reservations.decide(). Every judgement lives there, pure and tested as a
+table; this file only does the I/O and the state transitions.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import select, update
+
+from app import runpod_client
+from app.config import settings
+from app.database import async_session
+from app.models import GpuReservation
+from app.reservations import Action, ReservationStatus, decide
+
+logger = logging.getLogger(__name__)
+
+# Availability is checked, not held — losing a race to another customer is expected and normal.
+# A tighter loop would not win meaningfully more often and would hammer the API for it.
+POLL_SECONDS = 45
+
+
+async def reservation_monitor():
+    import asyncio
+
+    while True:
+        await asyncio.sleep(POLL_SECONDS)
+        try:
+            await run_once()
+        except Exception:
+            logger.exception("Reservation monitor error")
+
+
+async def run_once() -> None:
+    """One pass over pending reservations."""
+    async with async_session() as session:
+        pending = (
+            await session.execute(
+                select(GpuReservation).where(GpuReservation.status == ReservationStatus.PENDING)
+            )
+        ).scalars().all()
+
+        if not pending:
+            return
+
+        # One availability check for the whole pass. Every reservation targets the same GPU in
+        # the same datacenter, because the network volume is region-locked — so asking once per
+        # reservation would only multiply the requests.
+        try:
+            availability = await runpod_client.get_availability()
+            available = bool(availability.get("available"))
+            probe_error = None
+        except Exception as e:  # noqa: BLE001 - classified by decide()
+            available = False
+            probe_error = e
+
+        now = datetime.now(timezone.utc)
+        for reservation in pending:
+            decision = decide(
+                status=reservation.status,
+                expires_at=reservation.expires_at,
+                pod_id=reservation.pod_id,
+                available=available,
+                now=now,
+                last_error=probe_error,
+            )
+            await _apply(session, reservation, decision, now)
+
+        await session.commit()
+
+
+async def _apply(session, reservation: GpuReservation, decision, now) -> None:
+    if decision.action is Action.WAIT:
+        return
+
+    if decision.action is Action.EXPIRE:
+        reservation.status = ReservationStatus.EXPIRED
+        logger.info("Reservation %s expired without capacity", reservation.name)
+        return
+
+    if decision.action is Action.ABORT:
+        reservation.status = ReservationStatus.FAILED
+        reservation.error = decision.reason[:500]
+        logger.error("Reservation %s aborted: %s", reservation.name, decision.reason)
+        return
+
+    # LAUNCH. Claim the row first, with a conditional update that can only succeed once.
+    #
+    # Two passes overlapping — a slow launch, a restarted container, a second worker process —
+    # would otherwise each see a pending row and each launch a pod, billing in parallel. The
+    # database is the only place that can arbitrate this; an in-process lock cannot.
+    claimed = await session.execute(
+        update(GpuReservation)
+        .where(
+            GpuReservation.id == reservation.id,
+            GpuReservation.status == ReservationStatus.PENDING,
+            GpuReservation.pod_id.is_(None),
+        )
+        .values(status=ReservationStatus.LAUNCHED, updated_at=now)
+        .returning(GpuReservation.id)
+    )
+    if claimed.scalar_one_or_none() is None:
+        logger.info("Reservation %s already claimed by another pass", reservation.name)
+        return
+
+    reservation.attempts = (reservation.attempts or 0) + 1
+    env = {
+        "FRIENDLY_NAME": reservation.name,
+        "QUEUE_URL": settings.runpod_worker_queue_url,
+        "QUEUE_API_KEY": settings.api_key,
+    }
+    if settings.runpod_api_key:
+        env["RUNPOD_API_KEY"] = settings.runpod_api_key
+
+    try:
+        pod = await runpod_client.launch_worker(reservation.name, env)
+    except Exception as e:  # noqa: BLE001
+        # Release the claim so the window can still be used — unless the error is fatal, which
+        # decide() will catch on the next pass and turn into an abort.
+        reservation.status = ReservationStatus.PENDING
+        reservation.error = str(e)[:500]
+        logger.warning("Reservation %s launch failed: %s", reservation.name, e)
+        return
+
+    reservation.pod_id = pod.get("id")
+    reservation.error = None
+    logger.info(
+        "Reservation %s launched pod %s (attempt %d)",
+        reservation.name, reservation.pod_id, reservation.attempts,
+    )

--- a/app/reservations.py
+++ b/app/reservations.py
@@ -1,0 +1,125 @@
+"""Deciding what to do with a GPU reservation.
+
+A reservation is "keep trying to launch a worker until you get one or the window closes".
+Availability swings hard — the 4090 in EU-RO-1 was available in 10/10 samples one morning and
+0/7 that evening — so the gap between a pod freeing up and someone asking for it is exactly what
+a poller closes and a person does not.
+
+Everything that has to be *correct* lives in decide(), which is pure: no clock, no database, no
+network. The poller is a dumb driver around it. That is deliberate — the interesting cases here
+are temporal (expiry boundaries, a clock that jumps) and adversarial (a revoked key retried for
+an hour), and none of them are worth testing through a loop and a database if they can be a row
+in a table instead.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+
+class ReservationStatus(str, Enum):
+    PENDING = "pending"
+    LAUNCHED = "launched"
+    EXPIRED = "expired"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+class Action(str, Enum):
+    LAUNCH = "launch"
+    WAIT = "wait"
+    EXPIRE = "expire"
+    ABORT = "abort"
+
+
+@dataclass(frozen=True)
+class Decision:
+    action: Action
+    reason: str = ""
+
+
+def decide(
+    *,
+    status: str,
+    expires_at: datetime,
+    pod_id: str | None,
+    available: bool,
+    now: datetime,
+    last_error: Exception | None = None,
+) -> Decision:
+    """What should happen to this reservation on this poll pass?
+
+    `now` is a parameter and never read from the clock inside, so a 60 minute window, an exact
+    boundary and a backwards clock jump are all testable in microseconds.
+    """
+    # Terminal states first. A cancelled reservation must not launch even if a GPU is sitting
+    # there, and a launched one must never launch twice — that is the difference between one
+    # pod and two, billing in parallel.
+    if pod_id:
+        return Decision(Action.WAIT, "already launched")
+    if status in (
+        ReservationStatus.CANCELLED,
+        ReservationStatus.EXPIRED,
+        ReservationStatus.FAILED,
+        ReservationStatus.LAUNCHED,
+    ):
+        return Decision(Action.WAIT, f"terminal: {status}")
+
+    # A fatal error means stop, not keep trying. Retrying a revoked key for 60 minutes wastes
+    # the window and teaches nothing; the user learns their reservation "expired" when it in
+    # fact never had a chance.
+    if last_error is not None and not is_capacity_error(last_error):
+        return Decision(Action.ABORT, f"{type(last_error).__name__}: {last_error}")
+
+    # Expiry beats availability. Launching a pod at the instant the window closes gives the user
+    # a worker they have stopped expecting and are not watching.
+    if now >= expires_at:
+        return Decision(Action.EXPIRE, "window closed")
+
+    if available:
+        return Decision(Action.LAUNCH, "capacity available")
+    return Decision(Action.WAIT, "no capacity yet")
+
+
+# RunPod reports "no inventory" as prose in a 4xx, not as a distinct code, so the retry/abort
+# split has to be made on the message. Erring toward ABORT would strand a reservation on a
+# transient blip; erring toward WAIT burns the window on an unfixable error. These phrases are
+# what RunPod actually returns for capacity.
+_CAPACITY_PHRASES = (
+    "no instances available",
+    "no longer any instances available",
+    "not enough free gpu",
+    "out of capacity",
+    "no capacity",
+)
+
+
+def is_capacity_error(error: Exception) -> bool:
+    """Is this the kind of failure that trying again might fix?
+
+    Unknown errors are treated as capacity errors — i.e. retryable — because the window bounds
+    the damage either way, while wrongly aborting loses a reservation the user asked for. The
+    errors we know are fatal are named explicitly.
+    """
+    text = str(error).lower()
+
+    # Configuration and credential problems: another 40 attempts will not help.
+    fatal_markers = (
+        "401",
+        "unauthorized",
+        "rejected the api key",
+        "runpod_api_key",
+        "runpod_network_volume_id",
+        "not configured",
+        "invalid",
+        "does not exist",
+        "not found",
+    )
+    if any(marker in text for marker in fatal_markers):
+        return False
+
+    if any(phrase in text for phrase in _CAPACITY_PHRASES):
+        return True
+
+    # Unknown: retry within the window.
+    return True

--- a/app/routes/runpod.py
+++ b/app/routes/runpod.py
@@ -6,12 +6,20 @@ handed to the browser.
 """
 
 import re
+import uuid
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import runpod_client
 from app.auth import get_current_user
 from app.config import settings
+from app.database import get_db
+from app.models import GpuReservation
+from app.reservations import ReservationStatus
+from app.schemas.reservations import ReservationCreate, ReservationResponse
 from app.runpod_client import RunPodError
 from app.schemas.runpod import (
     RunPodAvailability,
@@ -106,3 +114,77 @@ async def terminate_runpod_worker(pod_id: str):
         await runpod_client.terminate_worker(pod_id)
     except RunPodError as e:
         raise HTTPException(status_code=503, detail=str(e))
+
+
+@router.get("/runpod/reservations", response_model=list[ReservationResponse],
+            dependencies=[Depends(get_current_user)])
+async def list_reservations(db: AsyncSession = Depends(get_db)):
+    """Reservations that are still waiting, newest first.
+
+    Terminal ones are not returned: the point of this list is "what is still going to spend
+    money", and a wall of expired rows buries that.
+    """
+    rows = (
+        await db.execute(
+            select(GpuReservation)
+            .where(GpuReservation.status == ReservationStatus.PENDING)
+            .order_by(GpuReservation.created_at.desc())
+        )
+    ).scalars().all()
+    return rows
+
+
+@router.post("/runpod/reservations", response_model=ReservationResponse, status_code=201,
+             dependencies=[Depends(get_current_user)])
+async def create_reservation(body: ReservationCreate, db: AsyncSession = Depends(get_db)):
+    """Keep trying to launch a worker until one is available or the window closes."""
+    name = (body.name or "").strip()
+    if not _NAME_RE.match(name):
+        raise HTTPException(
+            status_code=400,
+            detail="Name must be 1-49 chars: letters, numbers, spaces, dot, dash, underscore.",
+        )
+
+    # One pending reservation per name, or two of them race to launch pods that would both try
+    # to register as the same worker.
+    existing = (
+        await db.execute(
+            select(GpuReservation).where(
+                GpuReservation.name == name,
+                GpuReservation.status == ReservationStatus.PENDING,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A reservation named '{name}' is already waiting.",
+        )
+
+    reservation = GpuReservation(
+        id=uuid.uuid4(),
+        name=name,
+        status=ReservationStatus.PENDING,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=body.minutes),
+        drain_after_jobs=body.drain_after_jobs,
+    )
+    db.add(reservation)
+    await db.commit()
+    await db.refresh(reservation)
+    return reservation
+
+
+@router.delete("/runpod/reservations/{reservation_id}", status_code=204,
+               dependencies=[Depends(get_current_user)])
+async def cancel_reservation(reservation_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    """Cancel a pending reservation.
+
+    Does not touch a pod that has already launched — by then it is a worker, and the Workers
+    page is where a worker is stopped.
+    """
+    reservation = await db.get(GpuReservation, reservation_id)
+    if not reservation:
+        raise HTTPException(status_code=404, detail="Reservation not found")
+    if reservation.status == ReservationStatus.PENDING:
+        reservation.status = ReservationStatus.CANCELLED
+        await db.commit()

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -52,9 +52,36 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
             comfyui_running=body.comfyui_running,
         )
         db.add(worker)
+
+    # A reservation may have asked for a drain policy up front. Apply it the moment the worker
+    # it was waiting for appears.
+    #
+    # It has to happen here rather than at launch: the pod exists minutes before the worker
+    # registers, and drain_after_jobs lives on the worker row, which does not exist until now.
+    # Without this a reservation made at 11pm produces a worker that runs until someone notices
+    # — which is the whole thing the option was added to prevent.
+    await _apply_reserved_drain(db, worker)
+
     await db.commit()
     await db.refresh(worker)
     return worker
+
+
+async def _apply_reserved_drain(db: AsyncSession, worker: Worker) -> None:
+    from app.models import GpuReservation
+
+    result = await db.execute(
+        select(GpuReservation).where(
+            GpuReservation.name == worker.friendly_name,
+            GpuReservation.drain_after_jobs.isnot(None),
+            GpuReservation.status == "launched",
+        )
+    )
+    reservation = result.scalars().first()
+    # Only set it on a fresh registration. Overwriting an existing countdown would restart it
+    # every time the worker re-registers, which on a container restart means it never drains.
+    if reservation and worker.drain_after_jobs is None and worker.status != "draining":
+        worker.drain_after_jobs = reservation.drain_after_jobs
 
 
 @router.delete("/workers/{worker_id}", status_code=204, dependencies=[Depends(verify_api_key_or_bearer)])

--- a/app/schemas/reservations.py
+++ b/app/schemas/reservations.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ReservationCreate(BaseModel):
+    name: str
+    # The window. Bounded because an unbounded reservation is just a pod launch you cannot see
+    # coming.
+    minutes: int = Field(default=30, ge=1, le=720)
+    # Optional, and the reason it exists here rather than at launch: a reservation can fire
+    # unattended, so a drain policy is what turns "get me a 4090" into a bounded instruction.
+    drain_after_jobs: int | None = Field(default=None, ge=1, le=100)
+
+
+class ReservationResponse(BaseModel):
+    id: UUID
+    name: str
+    status: str
+    expires_at: datetime
+    drain_after_jobs: int | None = None
+    pod_id: str | None = None
+    error: str | None = None
+    attempts: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/tests/test_reservation_decide.py
+++ b/tests/test_reservation_decide.py
@@ -1,0 +1,104 @@
+"""The reservation decision table (wanly-console#296).
+
+Everything that must be correct about a reservation is a case here: it is pure, so a 60 minute
+window, an exact boundary and a clock that jumps backwards all run in microseconds.
+
+The two that matter most are the error split. A reservation spends money unattended — that is
+its purpose, and the drain-at-reservation option exists because it can fire at 11:47pm with
+nobody watching. Retrying a revoked key for the full window wastes it silently; aborting on a
+transient blip loses a reservation the user asked for.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.reservations import Action, ReservationStatus, decide, is_capacity_error
+
+NOW = datetime(2026, 8, 7, 12, 0, tzinfo=timezone.utc)
+LATER = NOW + timedelta(minutes=30)
+
+
+def _decide(**overrides):
+    kwargs = dict(
+        status=ReservationStatus.PENDING,
+        expires_at=LATER,
+        pod_id=None,
+        available=False,
+        now=NOW,
+        last_error=None,
+    )
+    kwargs.update(overrides)
+    return decide(**kwargs)
+
+
+class TestCoreCases:
+    def test_capacity_inside_the_window_launches(self):
+        assert _decide(available=True).action is Action.LAUNCH
+
+    def test_no_capacity_inside_the_window_waits(self):
+        assert _decide(available=False).action is Action.WAIT
+
+    def test_no_capacity_past_the_deadline_expires(self):
+        assert _decide(available=False, now=LATER).action is Action.EXPIRE
+
+    def test_capacity_past_the_deadline_still_expires(self):
+        """Do not launch on the way out. The user has stopped expecting a worker and is not
+        watching one they would then be billed for."""
+        assert _decide(available=True, now=LATER).action is Action.EXPIRE
+
+    def test_the_boundary_is_inclusive_of_expiry(self):
+        assert _decide(available=True, now=LATER - timedelta(seconds=1)).action is Action.LAUNCH
+        assert _decide(available=True, now=LATER).action is Action.EXPIRE
+
+
+class TestNeverLaunchesTwice:
+    def test_a_reservation_with_a_pod_never_launches_again(self):
+        """The difference between one pod and two billing in parallel."""
+        assert _decide(pod_id="pod123", available=True).action is not Action.LAUNCH
+
+    @pytest.mark.parametrize("status", [
+        ReservationStatus.CANCELLED,
+        ReservationStatus.EXPIRED,
+        ReservationStatus.FAILED,
+        ReservationStatus.LAUNCHED,
+    ])
+    def test_terminal_states_never_launch(self, status):
+        assert _decide(status=status, available=True).action is not Action.LAUNCH
+
+    def test_cancelled_wins_over_available_capacity(self):
+        assert _decide(status=ReservationStatus.CANCELLED, available=True).action is Action.WAIT
+
+
+class TestErrorHandling:
+    def test_a_fatal_error_aborts_rather_than_burning_the_window(self):
+        d = _decide(last_error=RuntimeError("RunPod rejected the API key (401)."), available=True)
+        assert d.action is Action.ABORT
+        assert "401" in d.reason
+
+    def test_a_capacity_error_keeps_waiting(self):
+        d = _decide(last_error=RuntimeError("no instances available"), available=False)
+        assert d.action is Action.WAIT
+
+
+class TestErrorClassification:
+    @pytest.mark.parametrize("message", [
+        "no instances available",
+        "There are no longer any instances available with the requested specifications",
+        "out of capacity",
+    ])
+    def test_capacity_messages_are_retryable(self, message):
+        assert is_capacity_error(RuntimeError(message)) is True
+
+    @pytest.mark.parametrize("message", [
+        "RunPod rejected the API key (401).",
+        "RunPod is not configured on this server (RUNPOD_API_KEY is unset).",
+        "RUNPOD_NETWORK_VOLUME_ID is unset",
+        "network volume does not exist",
+    ])
+    def test_configuration_and_credential_failures_are_fatal(self, message):
+        assert is_capacity_error(RuntimeError(message)) is False
+
+    def test_unknown_errors_are_retried_within_the_window(self):
+        """The window bounds the damage; wrongly aborting loses a reservation outright."""
+        assert is_capacity_error(RuntimeError("something nobody has seen before")) is True

--- a/tests/test_reservations_db.py
+++ b/tests/test_reservations_db.py
@@ -1,0 +1,145 @@
+"""Reservation guarantees that need a real database (wanly-console#296).
+
+These are the Tier 2 cases that #162 unblocked. They cannot be faked honestly: the correct
+implementation of "at most one pod" is a conditional UPDATE that can only succeed once, and a
+mock cannot demonstrate that it holds under a second pass.
+
+This matters more here than elsewhere because a reservation spends money unattended. A double
+launch is two pods billing in parallel with nobody watching.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select, update
+
+from app.models import GpuReservation, Worker
+from app.reservations import ReservationStatus
+
+
+async def _reservation(db, name="res-1", status=ReservationStatus.PENDING, **kw):
+    r = GpuReservation(
+        id=uuid.uuid4(),
+        name=name,
+        status=status,
+        expires_at=kw.pop("expires_at", datetime.now(timezone.utc) + timedelta(minutes=30)),
+        **kw,
+    )
+    db.add(r)
+    await db.flush()
+    return r
+
+
+async def _claim(db, reservation_id) -> bool:
+    """The poller's claim: a conditional update that can only succeed once."""
+    result = await db.execute(
+        update(GpuReservation)
+        .where(
+            GpuReservation.id == reservation_id,
+            GpuReservation.status == ReservationStatus.PENDING,
+            GpuReservation.pod_id.is_(None),
+        )
+        .values(status=ReservationStatus.LAUNCHED)
+        .returning(GpuReservation.id)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+class TestAtMostOnePod:
+    async def test_a_second_pass_cannot_claim_the_same_reservation(self, db):
+        """Two overlapping passes — a slow launch, a restarted container — would otherwise each
+        see a pending row and each launch a pod, billing in parallel."""
+        r = await _reservation(db)
+        assert await _claim(db, r.id) is True
+        assert await _claim(db, r.id) is False, "the second pass must not launch a second pod"
+
+    async def test_a_reservation_with_a_pod_cannot_be_reclaimed(self, db):
+        r = await _reservation(db, status=ReservationStatus.PENDING, pod_id="pod-existing")
+        assert await _claim(db, r.id) is False
+
+    async def test_cancelling_before_the_claim_prevents_the_launch(self, db):
+        r = await _reservation(db)
+        await db.execute(
+            update(GpuReservation)
+            .where(GpuReservation.id == r.id)
+            .values(status=ReservationStatus.CANCELLED)
+        )
+        assert await _claim(db, r.id) is False
+
+
+class TestSurvivesRestart:
+    async def test_a_pending_reservation_is_found_by_a_fresh_query(self, db):
+        """The state lives in the row, not in the process. A deploy recreates the container;
+        the reservation has to still be there afterwards or it dies invisibly."""
+        await _reservation(db, name="survives")
+        found = (
+            await db.execute(
+                select(GpuReservation).where(
+                    GpuReservation.status == ReservationStatus.PENDING
+                )
+            )
+        ).scalars().all()
+        assert [r.name for r in found] == ["survives"]
+
+    async def test_terminal_reservations_are_not_polled_again(self, db):
+        for status in (
+            ReservationStatus.EXPIRED,
+            ReservationStatus.CANCELLED,
+            ReservationStatus.FAILED,
+            ReservationStatus.LAUNCHED,
+        ):
+            await _reservation(db, name=f"done-{status}", status=status)
+        pending = (
+            await db.execute(
+                select(GpuReservation).where(
+                    GpuReservation.status == ReservationStatus.PENDING
+                )
+            )
+        ).scalars().all()
+        assert pending == []
+
+
+class TestReservedDrainPolicy:
+    async def test_the_policy_reaches_the_worker_when_it_registers(self, db):
+        """The pod exists minutes before the worker row does, and drain_after_jobs lives on the
+        worker — so the policy has to be applied at registration or not at all."""
+        from app.routes.workers import _apply_reserved_drain
+
+        await _reservation(
+            db, name="reserved-worker", status=ReservationStatus.LAUNCHED, drain_after_jobs=3
+        )
+        worker = Worker(
+            friendly_name="reserved-worker", hostname="h", ip_address="127.0.0.1",
+        )
+        db.add(worker)
+        await db.flush()
+
+        await _apply_reserved_drain(db, worker)
+        assert worker.drain_after_jobs == 3
+
+    async def test_an_existing_countdown_is_not_restarted(self, db):
+        """A container restart re-registers the worker. Overwriting the countdown each time
+        would mean it never reaches zero and never drains."""
+        from app.routes.workers import _apply_reserved_drain
+
+        await _reservation(
+            db, name="mid-drain", status=ReservationStatus.LAUNCHED, drain_after_jobs=3
+        )
+        worker = Worker(
+            friendly_name="mid-drain", hostname="h", ip_address="127.0.0.1",
+            drain_after_jobs=1,
+        )
+        db.add(worker)
+        await db.flush()
+
+        await _apply_reserved_drain(db, worker)
+        assert worker.drain_after_jobs == 1, "the countdown must keep counting down"
+
+    async def test_a_worker_with_no_reservation_is_untouched(self, db):
+        from app.routes.workers import _apply_reserved_drain
+
+        worker = Worker(friendly_name="3090.zero", hostname="h", ip_address="127.0.0.1")
+        db.add(worker)
+        await db.flush()
+        await _apply_reserved_drain(db, worker)
+        assert worker.drain_after_jobs is None


### PR DESCRIPTION
Backs wanly-console#296 — the API half.

Availability swings hard: the 4090 in EU-RO-1 was available in **10/10 samples one morning and 0/7 that evening**. The gap between a pod freeing up and someone asking for it is exactly what a poller closes and a person does not. RunPod has no reservation API, so polling is the only mechanism.

`POST/GET/DELETE /runpod/reservations`, plus a poller started with the app.

### Everything that must be correct is pure

`reservations.decide()` takes no clock, no database, no network — `now` is a parameter. A 60 minute window, an exact expiry boundary and a backwards clock jump all test in microseconds. The poller is a dumb driver around it.

Three decisions worth stating:

- **Expiry beats availability.** Launching at the instant the window closes hands you a worker you have stopped expecting and are not watching.
- **Fatal errors abort, they do not retry.** Retrying a revoked key for 60 minutes burns the window and then reports "expired" for something that never had a chance. Unknown errors *are* retried — the window bounds the damage, while a wrong abort loses the reservation outright.
- **At most one pod**, enforced by a conditional `UPDATE` that can only succeed once. Two overlapping passes — a slow launch, a restarted container — would otherwise each launch a pod and bill in parallel. Only the database can arbitrate that.

### Reservations are rows, not memory

The tab that created one gets closed, and the container is recreated on every deploy. A reservation that dies on deploy dies **invisibly** — the user is still waiting for a worker nobody is going to launch.

### The optional drain policy

Applied when the reserved worker *registers*, not at launch: the pod exists minutes before the worker row does, and `drain_after_jobs` lives on the worker. An existing countdown is never restarted, or a container restart would reset it forever and it would never drain.

This is the option that makes an unattended launch safe — "get me a 4090 and drain it after 3 jobs" is bounded; "get me a 4090" is open-ended spend.

### Tests

**397 pass**, including the Tier 2 cases wanly-api#162 unblocked — at-most-one-pod under a second pass, cancel-before-claim, and the drain policy reaching the worker. 21 pure decision cases besides.

Verified the three double-launch tests **fail** against a naive update-by-id.
