### PR TITLE
Let a worker report which RunPod pod it is

### DIFF
--- a/alembic/versions/059_add_worker_runpod_pod_id.py
+++ b/alembic/versions/059_add_worker_runpod_pod_id.py
@@ -1,0 +1,33 @@
+"""Let a worker say which RunPod pod it is
+
+Revision ID: 059
+Revises: 058
+Create Date: 2026-08-08
+
+The console pairs RunPod pods with registered workers so a pod that is still booting shows as
+"Starting" and stops showing once its worker appears. That pairing was done on name, which only
+holds for pods launched through the console launcher — it sets the pod name and FRIENDLY_NAME to
+the same value.
+
+A pod launched from the RunPod template gets an auto-generated name (valid_chocolate_cockroach)
+while its worker registers as runpod-<pod id>. Those never match, so the pod showed as "Starting"
+forever alongside the worker it had already become.
+
+The worker knows its own pod id — RunPod injects RUNPOD_POD_ID and the daemon already reads it
+for self-termination. Reporting it removes the guessing entirely.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "059"
+down_revision = "058"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("workers", sa.Column("runpod_pod_id", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "runpod_pod_id")

--- a/app/models.py
+++ b/app/models.py
@@ -341,6 +341,10 @@ class Worker(Base):
     ip_address: Mapped[str] = mapped_column(String(45), nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="online-idle")
     comfyui_running: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # Set by workers running on RunPod. NULL for the 3090 and anything else self-hosted.
+    # Pairing pods to workers by name only worked for launcher-created pods; this is the
+    # identifier both sides actually agree on.
+    runpod_pod_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     last_heartbeat: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     registered_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     gpu_stats: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -40,6 +40,9 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
         worker.hostname = body.hostname
         worker.ip_address = body.ip_address
         worker.comfyui_running = body.comfyui_running
+        # Re-registering after a container restart can land on a new pod id.
+        if body.runpod_pod_id:
+            worker.runpod_pod_id = body.runpod_pod_id
         worker.status, worker.drain_after_jobs = reregistered_drain_state(
             worker.status, worker.drain_after_jobs
         )
@@ -50,6 +53,7 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
             hostname=body.hostname,
             ip_address=body.ip_address,
             comfyui_running=body.comfyui_running,
+            runpod_pod_id=body.runpod_pod_id,
         )
         db.add(worker)
 

--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -10,10 +10,13 @@ class WorkerRegister(BaseModel):
     hostname: str
     ip_address: str
     comfyui_running: bool = False
+    # Optional: only RunPod workers have one, and older daemons do not send it.
+    runpod_pod_id: str | None = None
 
 
 class WorkerHeartbeat(BaseModel):
     comfyui_running: bool
+    runpod_pod_id: str | None = None
     gpu_stats: dict[str, Any] | None = None
     sd_scripts: dict[str, Any] | None = None
     a1111: dict[str, Any] | None = None

--- a/tests/test_offline_sweep_db.py
+++ b/tests/test_offline_sweep_db.py
@@ -93,3 +93,46 @@ class TestOfflineSweepBehaviour:
         """The outer transaction is rolled back, so every test sees only what it created."""
         names = (await db.execute(select(Worker.friendly_name))).scalars().all()
         assert names == [], f"leaked rows from a previous test: {names}"
+
+
+class TestWorkerReportsPodId:
+    """A worker on RunPod must be pairable with its pod (wanly-console#291 follow-up).
+
+    Pairing on name only worked for pods created by the console launcher, which sets the pod
+    name and FRIENDLY_NAME to the same value. A pod launched from the RunPod template gets an
+    auto-generated name while its worker registers as runpod-<pod id>, so the two never matched
+    and the pod showed as "Starting" forever beside the worker it had already become.
+    """
+
+    async def test_pod_id_round_trips(self, db):
+        from app.models import Worker
+
+        w = Worker(
+            friendly_name="runpod-abc123",
+            hostname="h",
+            ip_address="127.0.0.1",
+            runpod_pod_id="abc123",
+        )
+        db.add(w)
+        await db.flush()
+
+        from sqlalchemy import select
+
+        got = (
+            await db.execute(select(Worker.runpod_pod_id).where(Worker.id == w.id))
+        ).scalar_one()
+        assert got == "abc123"
+
+    async def test_self_hosted_workers_have_none(self, db):
+        """The 3090 is not a pod. NULL must be a normal, expected value."""
+        from sqlalchemy import select
+
+        from app.models import Worker
+
+        w = Worker(friendly_name="3090.zero", hostname="h", ip_address="127.0.0.1")
+        db.add(w)
+        await db.flush()
+        got = (
+            await db.execute(select(Worker.runpod_pod_id).where(Worker.id == w.id))
+        ).scalar_one()
+        assert got is None


### PR DESCRIPTION
The console pairs pods with workers so a booting pod shows as **Starting** and stops showing once its worker registers. I paired them **on name** — which only holds for pods created by the console launcher, since that sets the pod name and `FRIENDLY_NAME` to the same value.

A pod launched from the **RunPod template** gets an auto-generated name while its worker registers as `runpod-<pod id>`:

| | |
|---|---|
| pod name | `valid_chocolate_cockroach` |
| worker name | `runpod-iihtdha72899sn` |

Those never match, so the pod showed as Starting indefinitely beside the worker it had already become.

### Why not just pattern-match `runpod-<id>`

It would paper over this exact case and break again the moment someone sets `FRIENDLY_NAME` by hand. The worker **already knows its pod id** — RunPod injects `RUNPOD_POD_ID` and the daemon reads it for self-termination — so reporting it removes the guessing entirely.

Optional and nullable: the 3090 is not a pod, and older daemons do not send it. Re-registration updates it, since a container restart can land on a different pod.

**399 tests pass**, including a DB-backed round-trip and the NULL case for self-hosted workers.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct