### PR TITLE
Target community 4090s, and stop assuming a network volume

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -22,13 +22,24 @@ class Settings(BaseSettings):
     # key, which can also terminate pods and volumes. There is no launch-only scope, so it must
     # never reach the client.
     #
-    # Defaults are the measured-best configuration, not arbitrary. 4090 because 3090 secure
-    # inventory is transient (present in one sample, gone the next) and could not be honoured.
-    # EU-RO-1 because network volumes are region-locked and it had 4090 capacity in 10/10
-    # samples, while every US storage-capable datacenter had 0-1/10.
+    # Community 4090, no network volume — decided 2026-08-08 on measured cost.
+    #
+    # Per 720p segment: community 4090 $0.104, secure 4090 + volume $0.226, community 3090
+    # $0.109. Community 4090 is the same price per segment as a 3090 while being ~1.6x faster
+    # (1098s vs 1781s), and it drops the volume's $7/mo. Secure never breaks even: it is cheaper
+    # only on boot (2 min vs 13), which one segment of runtime repays.
+    #
+    # The trade is that community cannot mount a network volume, so every pod re-downloads ~39GB
+    # (~13 min, ~$0.07). Worth it when a pod stays up for several segments; not when launching
+    # repeatedly for one.
+    #
+    # All three are settings rather than constants so switching back is config, not a deploy.
+    # Empty volume id and empty datacenter mean "do not pin" — required for community, which has
+    # neither.
     runpod_api_key: str = ""
+    runpod_cloud_type: str = "COMMUNITY"
     runpod_network_volume_id: str = ""
-    runpod_datacenter_id: str = "EU-RO-1"
+    runpod_datacenter_id: str = ""
     runpod_gpu_type_id: str = "NVIDIA GeForce RTX 4090"
     runpod_image: str = "davidjbarnes/wanly-gpu-docker:latest"
     runpod_container_disk_gb: int = 30

--- a/app/routes/runpod.py
+++ b/app/routes/runpod.py
@@ -73,12 +73,22 @@ async def launch_runpod_worker(body: RunPodLaunchRequest):
         raise HTTPException(status_code=503, detail=str(e))
 
     if not availability["available"]:
+        where = (
+            f"in {settings.runpod_datacenter_id}"
+            if settings.runpod_datacenter_id
+            else "on any datacenter"
+        )
+        why = (
+            " The datacenter is pinned because the network volume holding the models is "
+            "region-locked to it."
+            if settings.runpod_datacenter_id
+            else ""
+        )
         raise HTTPException(
             status_code=503,
             detail=(
-                f"No {settings.runpod_gpu_type_id} capacity in "
-                f"{settings.runpod_datacenter_id} right now. The datacenter is pinned because "
-                f"the network volume holding the models is region-locked to it. Try again "
+                f"No {settings.runpod_gpu_type_id} capacity {where} "
+                f"({settings.runpod_cloud_type.lower()} cloud) right now.{why} Try again "
                 f"shortly — availability changes minute to minute."
             ),
         )

--- a/app/runpod_client.py
+++ b/app/runpod_client.py
@@ -29,6 +29,10 @@ class RunPodError(RuntimeError):
     """A RunPod call failed in a way worth showing the user."""
 
 
+def _is_secure() -> bool:
+    return settings.runpod_cloud_type.upper() == "SECURE"
+
+
 def _headers() -> dict:
     if not settings.runpod_api_key:
         raise RunPodError(
@@ -47,26 +51,41 @@ async def get_availability() -> dict:
     a launch can still fail afterwards; it exists to give the user a useful "no capacity right
     now" instead of an opaque failure.
     """
-    query = """
-    query ($gpu: String, $dc: String) {
-      gpuTypes(input: {id: $gpu}) {
-        id
-        displayName
-        memoryInGb
-        lowestPrice(input: {gpuCount: 1, secureCloud: true, dataCenterId: $dc}) {
-          uninterruptablePrice
-          stockStatus
+    # dataCenterId is omitted entirely when nothing is pinned. Passing null narrows the query
+    # to "datacenters with no id", which reports no capacity anywhere — the failure would look
+    # exactly like being out of stock.
+    if settings.runpod_datacenter_id:
+        query = """
+        query ($gpu: String, $secure: Boolean, $dc: String) {
+          gpuTypes(input: {id: $gpu}) {
+            id
+            lowestPrice(input: {gpuCount: 1, secureCloud: $secure, dataCenterId: $dc}) {
+              uninterruptablePrice
+              stockStatus
+            }
+          }
         }
-      }
-    }
-    """
-    payload = {
-        "query": query,
-        "variables": {
+        """
+        variables = {
             "gpu": settings.runpod_gpu_type_id,
+            "secure": _is_secure(),
             "dc": settings.runpod_datacenter_id,
-        },
-    }
+        }
+    else:
+        query = """
+        query ($gpu: String, $secure: Boolean) {
+          gpuTypes(input: {id: $gpu}) {
+            id
+            lowestPrice(input: {gpuCount: 1, secureCloud: $secure}) {
+              uninterruptablePrice
+              stockStatus
+            }
+          }
+        }
+        """
+        variables = {"gpu": settings.runpod_gpu_type_id, "secure": _is_secure()}
+
+    payload = {"query": query, "variables": variables}
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
         resp = await client.post(GRAPHQL, json=payload, headers=_headers())
     if resp.status_code == 401:
@@ -79,7 +98,8 @@ async def get_availability() -> dict:
     price = lowest.get("uninterruptablePrice")
     return {
         "gpu_type_id": settings.runpod_gpu_type_id,
-        "datacenter_id": settings.runpod_datacenter_id,
+        "datacenter_id": settings.runpod_datacenter_id or "any",
+        "cloud_type": settings.runpod_cloud_type,
         # No price means no inventory for this GPU in this datacenter right now.
         "available": price is not None,
         "price_per_hr": price,
@@ -90,28 +110,29 @@ async def get_availability() -> dict:
 async def launch_worker(name: str, env: dict[str, str]) -> dict:
     """Create a pod, attached to the configured network volume.
 
-    The volume is region-locked, which is why the datacenter is pinned rather than chosen: a
-    pod in the wrong datacenter cannot mount it, and RunPod does not fail loudly about that —
-    it just runs without the models and re-downloads ~39GB.
+    On community cloud there is no volume and no datacenter pin, so the pod lands wherever there
+    is capacity and stages its own models. When a volume IS configured, the datacenter must be
+    pinned to match it: a pod in the wrong region cannot mount it, and RunPod does not fail
+    loudly about that — it just runs without the models and re-downloads ~39GB.
     """
-    if not settings.runpod_network_volume_id:
-        raise RunPodError(
-            "RunPod is not configured on this server (RUNPOD_NETWORK_VOLUME_ID is unset)."
-        )
-
     spec = {
         "name": name,
         "imageName": settings.runpod_image,
         "gpuTypeIds": [settings.runpod_gpu_type_id],
         "gpuCount": 1,
-        "cloudType": "SECURE",
-        "dataCenterIds": [settings.runpod_datacenter_id],
-        "networkVolumeId": settings.runpod_network_volume_id,
+        "cloudType": settings.runpod_cloud_type,
         "containerDiskInGb": settings.runpod_container_disk_gb,
         "volumeMountPath": settings.runpod_volume_mount_path,
         "ports": ["8188/http", "22/tcp"],
         "env": env,
     }
+    # Only sent when configured. Community cloud supports neither, and a network volume is
+    # region-locked — so pinning a datacenter is meaningful only when there is a volume to sit
+    # beside. Sending either on community would be rejected or silently ignored.
+    if settings.runpod_network_volume_id:
+        spec["networkVolumeId"] = settings.runpod_network_volume_id
+    if settings.runpod_datacenter_id:
+        spec["dataCenterIds"] = [settings.runpod_datacenter_id]
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
         resp = await client.post(f"{REST}/pods", json=spec, headers=_headers())
 

--- a/tests/test_runpod_launcher.py
+++ b/tests/test_runpod_launcher.py
@@ -62,6 +62,8 @@ def _install(monkeypatch, *responses):
     _Client.calls = []
     monkeypatch.setattr(settings, "runpod_api_key", "rpa_test")
     monkeypatch.setattr(settings, "runpod_network_volume_id", "vol_test")
+    monkeypatch.setattr(settings, "runpod_cloud_type", "SECURE")
+    monkeypatch.setattr(settings, "runpod_datacenter_id", "EU-RO-1")
     monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _Client(list(responses)))
 
 
@@ -107,11 +109,18 @@ class TestLaunch:
         assert body["gpuTypeIds"] == [settings.runpod_gpu_type_id]
         assert body["cloudType"] == "SECURE"
 
-    async def test_missing_volume_is_a_clear_message(self, monkeypatch):
-        _install(monkeypatch)
+    async def test_community_sends_no_volume_or_datacenter(self, monkeypatch):
+        """Community cloud supports neither. Sending them is rejected or silently ignored, and
+        a datacenter pin only means anything when there is a volume to sit beside."""
+        _install(monkeypatch, _Resp(status=201, payload={"id": "pod1"}))
+        monkeypatch.setattr(settings, "runpod_cloud_type", "COMMUNITY")
         monkeypatch.setattr(settings, "runpod_network_volume_id", "")
-        with pytest.raises(RunPodError, match="RUNPOD_NETWORK_VOLUME_ID"):
-            await runpod_client.launch_worker("w", {})
+        monkeypatch.setattr(settings, "runpod_datacenter_id", "")
+        await runpod_client.launch_worker("w", {})
+        _, _, body, _ = _Client.calls[0]
+        assert body["cloudType"] == "COMMUNITY"
+        assert "networkVolumeId" not in body
+        assert "dataCenterIds" not in body
 
     async def test_runpod_error_prose_is_passed_through(self, monkeypatch):
         """Their wording distinguishes no-stock from a bad spec; ours would not."""
@@ -131,3 +140,38 @@ class TestTerminate:
         """404 means the pod is in the state the caller asked for."""
         _install(monkeypatch, _Resp(status=404))
         await runpod_client.terminate_worker("pod1")
+
+
+class TestAvailabilityFollowsTheConfiguredCloud:
+    """Asking the wrong cloud reports the wrong answer, and the two differ by 2x in price and
+    wildly in stock: community 4090 was purchasable in 6/6 samples while secure showed 0/7
+    earlier the same evening."""
+
+    async def test_community_queries_community(self, monkeypatch):
+        _install(monkeypatch, _Resp(payload=_availability_payload(0.34)))
+        monkeypatch.setattr(settings, "runpod_cloud_type", "COMMUNITY")
+        monkeypatch.setattr(settings, "runpod_datacenter_id", "")
+        out = await runpod_client.get_availability()
+        _, _, body, _ = _Client.calls[0]
+        assert body["variables"]["secure"] is False
+        assert out["price_per_hr"] == 0.34
+
+    async def test_no_datacenter_is_omitted_not_sent_as_null(self, monkeypatch):
+        """Passing dataCenterId: null narrows the query to datacenters with no id, which reports
+        no capacity anywhere — indistinguishable from being genuinely out of stock."""
+        _install(monkeypatch, _Resp(payload=_availability_payload(0.34)))
+        monkeypatch.setattr(settings, "runpod_cloud_type", "COMMUNITY")
+        monkeypatch.setattr(settings, "runpod_datacenter_id", "")
+        await runpod_client.get_availability()
+        _, _, body, _ = _Client.calls[0]
+        assert "dc" not in body["variables"]
+        assert "dataCenterId" not in body["query"]
+
+    async def test_secure_with_a_datacenter_still_pins_it(self, monkeypatch):
+        _install(monkeypatch, _Resp(payload=_availability_payload(0.74)))
+        monkeypatch.setattr(settings, "runpod_cloud_type", "SECURE")
+        monkeypatch.setattr(settings, "runpod_datacenter_id", "EU-RO-1")
+        await runpod_client.get_availability()
+        _, _, body, _ = _Client.calls[0]
+        assert body["variables"]["secure"] is True
+        assert body["variables"]["dc"] == "EU-RO-1"


### PR DESCRIPTION
Decided on measured cost. Per 720×1056/5s segment:

| option | $/segment | runtime |
|---|---|---|
| **community 4090** | **$0.104** | 1098s |
| community 3090 | $0.109 | 1781s |
| secure 4090 + volume | $0.226 | 1098s |

Community 4090 costs the **same per segment as a 3090 while being ~1.6× faster**, and drops the volume's $7/mo. Secure never breaks even — it is cheaper only on boot (2 min vs 13), which a single segment of runtime repays.

The trade is real and accepted: community cannot mount a network volume, so every pod re-downloads ~39GB (~13 min, ~$0.07). Worth it when a pod stays up for several segments; not when launching repeatedly for one.

### Configurable, not hardcoded

Cloud type, network volume and datacenter are now settings, so switching back is config rather than a deploy. Empty volume + empty datacenter mean **do not pin** — neither is sent in the pod spec when unset, because a datacenter pin is only meaningful when there is a region-locked volume to sit beside.

### One subtle trap avoided

The availability query now **omits** `dataCenterId` rather than passing `null`. Null narrows the query to datacenters with no id, which reports no capacity anywhere — a failure indistinguishable from genuinely being out of stock, and one that would have made every single launch decline. There is a test pinning that.

The out-of-capacity message adapts too: *"the datacenter is pinned because the volume is region-locked to it"* is nonsense when there is no volume.

**385 tests pass.**
