### PR TITLE
Make a reservation actually attempt, whatever the price check says

### DIFF
--- a/app/reservations.py
+++ b/app/reservations.py
@@ -76,9 +76,24 @@ def decide(
     if now >= expires_at:
         return Decision(Action.EXPIRE, "window closed")
 
-    if available:
-        return Decision(Action.LAUNCH, "capacity available")
-    return Decision(Action.WAIT, "no capacity yet")
+    # Attempt regardless of what the price check said. It is advice, not a gate.
+    #
+    # `available` comes from gpuTypes.lowestPrice, which answers "is this GPU sold here" — a
+    # different question from "will a host accept this pod", and measured 2026-08-08 it is wrong
+    # in BOTH directions. Community 4090 reported available/"Low" through an hour in which every
+    # create failed. Minutes after a 3090 pod placed on the first try, the 3090 reported no price
+    # at all — and a live 3090 reservation then sat at attempts=0, never calling RunPod once,
+    # because this branch believed it.
+    #
+    # Gating on it is worst precisely here. A reservation exists to keep trying; refusing to try
+    # on an unreliable signal makes it do nothing for hours and then report "expired without
+    # capacity", which reads as "RunPod had none" when the truth is "we never asked". The create
+    # call is the only honest test, its failures are classified by is_capacity_error(), and the
+    # window is what bounds the cost.
+    return Decision(
+        Action.LAUNCH,
+        "capacity available" if available else "no price quoted; attempting anyway",
+    )
 
 
 # RunPod reports "no inventory" as prose in a 4xx, not as a distinct code, so the retry/abort

--- a/tests/test_reservation_decide.py
+++ b/tests/test_reservation_decide.py
@@ -36,8 +36,13 @@ class TestCoreCases:
     def test_capacity_inside_the_window_launches(self):
         assert _decide(available=True).action is Action.LAUNCH
 
-    def test_no_capacity_inside_the_window_waits(self):
-        assert _decide(available=False).action is Action.WAIT
+    def test_no_price_quoted_still_attempts(self):
+        # The price check is advice, not a gate. Measured 2026-08-08 it is wrong in BOTH
+        # directions: community 4090 reported available through an hour of total failure, and
+        # the 3090 reported NO PRICE minutes after a 3090 pod placed on the first try. A live
+        # reservation then sat at attempts=0 and expired without ever calling RunPod. A
+        # reservation that will not try is not a reservation.
+        assert _decide(available=False).action is Action.LAUNCH
 
     def test_no_capacity_past_the_deadline_expires(self):
         assert _decide(available=False, now=LATER).action is Action.EXPIRE
@@ -76,9 +81,13 @@ class TestErrorHandling:
         assert d.action is Action.ABORT
         assert "401" in d.reason
 
-    def test_a_capacity_error_keeps_waiting(self):
+    def test_a_capacity_error_keeps_the_reservation_alive(self):
+        # The point is that it does not ABORT -- a transient capacity failure must not kill a
+        # window the user is still inside. Since the price check no longer gates, "alive" now
+        # means it tries again rather than idles.
         d = _decide(last_error=RuntimeError("no instances available"), available=False)
-        assert d.action is Action.WAIT
+        assert d.action is not Action.ABORT
+        assert d.action is Action.LAUNCH
 
 
 class TestErrorClassification:


### PR DESCRIPTION
## Caught live, during a reservation test

A 3090 reservation sat at `attempts=0` through an entire test window, never calling RunPod once:

```
RES 3090-1  status=pending  gpu=RTX 3090  attempts=0  expires=16:25:08
```

Cause:

```
NVIDIA GeForce RTX 3090   available=False  price=None  stock=None
decide(...) -> wait | no capacity yet
```

The user would eventually have seen *"expired without capacity"* — which reads as "RunPod had none", when the truth is **we never asked**.

## This is an incomplete fix in #169

#169 removed the price gate from the manual launcher and the PR said the check "no longer blocks a launch". That was only true for the button. `decide()` still required `available=True`, and the reservation path is where it does the most damage — it fails silently over hours rather than immediately, and it's the path meant to run unattended.

## The signal is wrong in both directions — now measured twice

| GPU | price check said | reality |
|---|---|---|
| Community 4090 | `available: True`, stock `Low` | every create failed for an hour |
| Community 3090 | `available: False`, no price | pod placed on the first try |

`gpuTypes.lowestPrice` answers *"is this GPU sold here"*. That is not *"will a host accept this pod"*.

## Change

`decide()` returns LAUNCH regardless; `available` only colours the reason string. The create call is the only honest test, its failures are already classified by `is_capacity_error()`, and the window bounds the cost. **A reservation that will not try is not a reservation.**

Two tests asserted the old gate and are rewritten, not deleted. The capacity-error case still matters — but what it must prove is that a transient failure doesn't ABORT a window the user is still inside, not that it idles.

398 passing.

## Known trade-off, not addressed here

The poller now attempts every `POLL_SECONDS` (45s) for the life of the window — up to ~960 creates on a 12-hour reservation. Typical 30–60 minute windows are 40–80, which is fine. If RunPod rate-limits, the response classifies as unknown and stays retryable, so it degrades to noise rather than breakage. Backoff keyed on `attempts` would need a `last_attempt_at` column; worth doing if long windows become common, but I'd rather not add state to a pure function on speculation.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct