### PR TITLE
Give the pod a volume, or it has nowhere to put 37GB of models

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,13 @@ class Settings(BaseSettings):
     runpod_gpu_type_ids: str = "NVIDIA GeForce RTX 4090,NVIDIA GeForce RTX 3090"
     runpod_image: str = "davidjbarnes/wanly-gpu-docker:latest"
     runpod_container_disk_gb: int = 30
+    # Disk mounted at runpod_volume_mount_path. REQUIRED without a network volume: the models are
+    # ~37GB (two 13.3GB experts, a 6.7GB text encoder, CLIP vision, VAE, LoRAs, FaceFusion) and
+    # download_models.sh puts them in /workspace. Setting volumeMountPath WITHOUT this allocates
+    # no volume at all, so /workspace silently lands on the 30GB container disk and staging dies
+    # partway with "No space left on device". 0 disables (correct only when a network volume
+    # supplies the mount instead).
+    runpod_volume_gb: int = 60
     runpod_volume_mount_path: str = "/workspace"
     # What the launched worker is told to poll. Must be reachable FROM RunPod, so it cannot be
     # localhost even though this server is the thing being pointed at.

--- a/app/runpod_client.py
+++ b/app/runpod_client.py
@@ -151,8 +151,13 @@ async def launch_worker(name: str, env: dict[str, str], gpu_type_id: str | None 
     # Only sent when configured. Community cloud supports neither, and a network volume is
     # region-locked — so pinning a datacenter is meaningful only when there is a volume to sit
     # beside. Sending either on community would be rejected or silently ignored.
+    # A network volume supplies the mount when configured; otherwise the pod needs its own disk.
+    # Sending neither leaves volumeMountPath pointing at the container disk, which is not big
+    # enough for the model set and fails during staging rather than at create time.
     if settings.runpod_network_volume_id:
         spec["networkVolumeId"] = settings.runpod_network_volume_id
+    elif settings.runpod_volume_gb:
+        spec["volumeInGb"] = settings.runpod_volume_gb
     if settings.runpod_datacenter_id:
         spec["dataCenterIds"] = [settings.runpod_datacenter_id]
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:

--- a/tests/test_runpod_launcher.py
+++ b/tests/test_runpod_launcher.py
@@ -121,6 +121,9 @@ class TestLaunch:
         assert body["cloudType"] == "COMMUNITY"
         assert "networkVolumeId" not in body
         assert "dataCenterIds" not in body
+        # ...but it MUST still get a disk. Without a network volume this is the only thing that
+        # makes volumeMountPath mean anything.
+        assert body["volumeInGb"] == settings.runpod_volume_gb
 
     async def test_runpod_error_prose_is_passed_through(self, monkeypatch):
         """Their wording distinguishes no-stock from a bad spec; ours would not."""
@@ -260,3 +263,47 @@ class TestPlacementFailureWording:
         with pytest.raises(RunPodError) as e:
             await runpod_client.launch_worker("w", {})
         assert "different GPU" in str(e.value)
+
+
+class TestPodHasSomewhereToPutTheModels:
+    """A pod without a volume dies during staging, not at create time.
+
+    Reported 2026-08-08 from a live community pod: "No space left on device (os error 28)".
+    The spec set volumeMountPath=/workspace but never volumeInGb, so RunPod allocated NO volume
+    and /workspace fell back onto the 30GB container disk. download_models.sh pulls ~37GB there
+    (two 13.3GB experts, a 6.7GB text encoder, CLIP vision, VAE, LoRAs, FaceFusion). It cannot fit.
+
+    It had always worked before because a network volume supplied the mount. Terminating that
+    volume removed the storage and nothing replaced it. Create still succeeded, which is why
+    probing placement did not catch it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_community_pod_gets_a_volume_big_enough_for_the_models(self, monkeypatch):
+        _install(monkeypatch, _Resp(status=201, payload={"id": "pod1"}))
+        monkeypatch.setattr(settings, "runpod_cloud_type", "COMMUNITY")
+        monkeypatch.setattr(settings, "runpod_network_volume_id", "")
+        await runpod_client.launch_worker("w", {})
+        body = _Client.calls[0][2]
+        assert body["volumeMountPath"] == settings.runpod_volume_mount_path
+        # 37GB of models plus room to generate into. A mount path with no volume behind it is
+        # the exact bug this guards.
+        assert body["volumeInGb"] >= 45
+
+    @pytest.mark.asyncio
+    async def test_a_network_volume_replaces_the_pod_disk_rather_than_adding_one(self, monkeypatch):
+        # Paying for both would be waste, and the models live on the network volume already.
+        _install(monkeypatch, _Resp(status=201, payload={"id": "pod1"}))
+        monkeypatch.setattr(settings, "runpod_network_volume_id", "vol_test")
+        await runpod_client.launch_worker("w", {})
+        body = _Client.calls[0][2]
+        assert body["networkVolumeId"] == "vol_test"
+        assert "volumeInGb" not in body
+
+    @pytest.mark.asyncio
+    async def test_zero_disables_it_for_the_network_volume_case(self, monkeypatch):
+        _install(monkeypatch, _Resp(status=201, payload={"id": "pod1"}))
+        monkeypatch.setattr(settings, "runpod_network_volume_id", "")
+        monkeypatch.setattr(settings, "runpod_volume_gb", 0)
+        await runpod_client.launch_worker("w", {})
+        assert "volumeInGb" not in _Client.calls[0][2]


### PR DESCRIPTION
A live community pod died during staging:

```
RuntimeError: Task error: File reconstruction error: IO Error: No space left on device (os error 28)
```

## Cause

The spec set `volumeMountPath: /workspace` and **never set `volumeInGb`**. RunPod then allocates no volume at all, so `/workspace` silently falls back onto the 30 GB container disk — most of which the image already occupies.

`download_models.sh` pulls roughly 37 GB into it:

```
wan2.2_i2v_high_noise_14B_fp8    13.31 GB
wan2.2_i2v_low_noise_14B_fp8     13.31 GB
umt5_xxl_fp8_e4m3fn               ~6.7 GB
clip_vision_h                      1.18 GB
wan_2.1_vae                        0.24 GB
+ lightx2v LoRAs, inswapper, FaceFusion
```

It cannot fit, and never could.

This worked before only because a **network volume** supplied the mount. Terminating that volume removed the storage and nothing replaced it — so **the community path has never run a job**, only started one.

## Why probing didn't catch it

The earlier probes that established community placement created pods and terminated them within seconds. They proved RunPod would **accept** the spec. They never proved a pod could **work** — create succeeds, and staging dies minutes later. Placement and viability are different questions and I only tested the first.

## Change

`volumeInGb` is sent whenever there is no network volume to supply the mount. Default 60 GB: comfortable headroom over the model set, without asking for so much disk that placement narrows further — which matters while community 4090s already struggle to place at all.

A network volume still takes precedence when configured, since paying for both would be waste and the models already live there. `0` disables it explicitly for that case.

401 passing, 4 new — including one asserting the community pod gets a volume of at least 45 GB, which is the exact bug.

## Not addressed

Whether 30 GB of container disk is right, and whether the models should be baked into the image instead of downloaded every boot. Every fresh pod re-pulls 37 GB, which is slow and repeated. Worth its own change.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct