### PR TITLE
Record what a human saw in a segment

### DIFF
--- a/alembic/versions/061_add_segment_observations.py
+++ b/alembic/versions/061_add_segment_observations.py
@@ -1,0 +1,46 @@
+"""Record what a human saw in a segment
+
+Revision ID: 061
+Revises: 060
+Create Date: 2026-08-08
+
+The automated metrics cannot rank quality, and we know this rather than suspect it: on the one
+controlled pair where both a measurement and a human judgement exist, the expression score ranked
+them backwards (daemon#123). A gaping mouth is the largest landmark excursion a face can make, so
+the metric scores the very artifact that makes a segment look worse.
+
+So human judgement is the ranking channel, and until now it lived in a text file beside the app.
+This gives it a home next to the numbers it has to be read against.
+
+Three columns rather than one, because free text alone does not aggregate:
+
+  notes             - what was seen, in words.
+  rating            - 1-5 overall. Enough to rank the arms of a paired test, which is the
+                      comparison these experiments are built around.
+  observation_tags  - a controlled vocabulary, comma separated. This is the valuable one: tags
+                      like "mouth-void" are LABELLED GROUND TRUTH, and a few dozen of them turn
+                      fixing the expression metric from guesswork into a fitting problem -- we can
+                      ask whether any computable signal predicts the label.
+
+Nullable throughout and touched by nothing in generation: annotation must never be able to change
+what a segment produces.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "061"
+down_revision = "060"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("notes", sa.Text(), nullable=True))
+    op.add_column("segments", sa.Column("rating", sa.SmallInteger(), nullable=True))
+    op.add_column("segments", sa.Column("observation_tags", sa.String(length=500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "observation_tags")
+    op.drop_column("segments", "rating")
+    op.drop_column("segments", "notes")

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, Boolean, DateTime, Float, ForeignKey, Index, Integer, JSON, String, Text, UniqueConstraint
+from sqlalchemy import BigInteger, Boolean, DateTime, Float, ForeignKey, Index, Integer, JSON, SmallInteger, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -128,6 +128,14 @@ class Segment(Base):
     seed_faceswap = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     auto_finalize = mapped_column(Boolean, nullable=False, default=False)
     transition = mapped_column(String(20), nullable=True, default=None)
+    # Human observation. The metrics cannot rank quality -- expression rewards the mouth-gape
+    # artifact it should penalise -- so what a person saw is primary evidence, not a footnote.
+    # None of these three are read by generation; annotation must never change output.
+    notes = mapped_column(Text, nullable=True)
+    rating = mapped_column(SmallInteger, nullable=True)
+    # Controlled vocabulary, comma separated. Free-form would drift ("mouth void" vs "black
+    # mouth") and stop grouping, which destroys the only thing these are for.
+    observation_tags = mapped_column(String(500), nullable=True)
     trim_start_frames = mapped_column(Integer, nullable=False, default=0)
     trim_end_frames = mapped_column(Integer, nullable=False, default=0)
     motion_keywords = mapped_column(JSON, nullable=True)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -22,6 +22,8 @@ from app.helpers import upload_faceswap_image
 from app.models import AppSetting, Job, Lora, Segment, User, Video, VideoSettingsPreset, Wildcard, Worker
 from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
+    OBSERVATION_TAGS,
+    SegmentAnnotation,
     FramePreview,
     FramePreviewResponse,
     HologramRequest,
@@ -1295,3 +1297,64 @@ async def delete_segment(
         job.status = JobStatus.AWAITING
 
     await db.commit()
+
+
+@router.get("/segments/observation-tags", response_model=list[str],
+            dependencies=[Depends(get_current_user)])
+async def list_observation_tags():
+    """The controlled vocabulary, served rather than hardcoded in the console.
+
+    One source of truth so a tag written by the UI is the same string any later analysis groups
+    on. That grouping is the whole value: "mouth-void" and "mouth void" are two labels.
+    """
+    return OBSERVATION_TAGS
+
+
+@router.patch("/segments/{segment_id}/annotation", response_model=SegmentResponse)
+async def annotate_segment(
+    segment_id: UUID,
+    body: SegmentAnnotation,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Record what a human saw in this segment.
+
+    Deliberately separate from the daemon's PATCH /segments/{id}: that one carries an API key and
+    writes generation state. This is user-authenticated, writes only annotation, and touches
+    nothing generation reads -- an observation must never be able to change output.
+
+    Fields are individually optional so the modal can save a rating without clearing notes, but
+    an explicitly-sent empty value still clears, because "I typed notes by mistake" needs an undo.
+    """
+    result = await db.execute(
+        select(Segment)
+        .join(Job, Segment.job_id == Job.id)
+        .where(Segment.id == segment_id, Job.user_id == user.id)
+    )
+    segment = result.scalar_one_or_none()
+    if segment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Segment not found")
+
+    fields = body.model_dump(exclude_unset=True)
+
+    if "notes" in fields:
+        segment.notes = (fields["notes"] or "").strip() or None
+    if "rating" in fields:
+        segment.rating = fields["rating"]
+    if "observation_tags" in fields:
+        tags = fields["observation_tags"] or []
+        unknown = [t for t in tags if t not in OBSERVATION_TAGS]
+        if unknown:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown observation tag(s): {', '.join(unknown)}. "
+                       f"Allowed: {', '.join(OBSERVATION_TAGS)}",
+            )
+        # Deduped and stored in vocabulary order, so two segments tagged the same way produce
+        # identical strings and group without normalising at read time.
+        ordered = [t for t in OBSERVATION_TAGS if t in set(tags)]
+        segment.observation_tags = ",".join(ordered) or None
+
+    await db.commit()
+    await db.refresh(segment)
+    return segment

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -28,6 +28,30 @@ class SegmentCreate(BaseModel):
     video_preset_id: Optional[UUID] = None
 
 
+# The vocabulary lives server-side so the console and any analysis agree on the exact strings.
+# Grouping is the entire point of tags; two spellings of the same observation are two labels.
+OBSERVATION_TAGS = [
+    "mouth-void",
+    "teeth-mush",
+    "frozen-face",
+    "blurry-face",
+    "identity-drift",
+    "good-expression",
+    "good-motion",
+    "good-detail",
+]
+
+
+class SegmentAnnotation(BaseModel):
+    """What a human saw. Never read by generation."""
+
+    notes: Optional[str] = Field(None, max_length=4000)
+    rating: Optional[int] = Field(None, ge=1, le=5, description="Overall, 1-5")
+    # Sent as a list and stored comma separated; validated against OBSERVATION_TAGS so a typo
+    # cannot quietly create a ninth tag that groups with nothing.
+    observation_tags: Optional[list[str]] = None
+
+
 class SegmentResponse(BaseModel):
     id: UUID
     job_id: UUID
@@ -50,6 +74,9 @@ class SegmentResponse(BaseModel):
     negative_prompt: Optional[str] = None
     auto_finalize: bool
     transition: Optional[str]
+    notes: Optional[str] = None
+    rating: Optional[int] = None
+    observation_tags: Optional[str] = None
     trim_start_frames: int
     trim_end_frames: int
     motion_keywords: Optional[list[str]] = None
@@ -217,6 +244,9 @@ class SegmentClipResponse(BaseModel):
 
 
 class SegmentTrimUpdate(BaseModel):
+    notes: Optional[str] = None
+    rating: Optional[int] = None
+    observation_tags: Optional[str] = None
     trim_start_frames: int = Field(ge=0)
     trim_end_frames: int = Field(ge=0)
 

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -31,24 +31,28 @@ class SegmentCreate(BaseModel):
 # The vocabulary lives server-side so the console and any analysis agree on the exact strings.
 # Grouping is the entire point of tags; two spellings of the same observation are two labels.
 #
-# Motion is split by person deliberately. motion_magnitude is whole-frame Farneback optical flow:
-# it sums every moving pixel, so a lively woman with a static man scores identically to the
-# reverse. The metric cannot separate them even in principle, which makes these tags the ONLY
-# source of per-person motion data we will ever have.
+# Every tag is <location>-<condition>: where you were looking, then what was wrong or right with
+# it. That keeps the chip row scannable by region and makes the set extensible without debate
+# about naming -- a new observation about the eyes is eyes-<something>, not a fresh coinage.
+#
 OBSERVATION_TAGS = [
-    # Defects
+    # Face
+    "face-frozen",
+    "face-blurry",
+    "face-expressive",
     "mouth-void",
     "teeth-mush",
-    "frozen-face",
-    "blurry-face",
     "identity-drift",
-    "weak-motion-him",
-    "weak-motion-her",
-    # Positives -- rating is one all-in number, so per-axis signal has to live here.
-    "good-expression",
-    "good-motion-him",
-    "good-motion-her",
-    "good-detail",
+    # Motion, per person. motion_magnitude is whole-frame Farneback optical flow: it sums every
+    # moving pixel, so a lively woman with a static man scores identically to the reverse. The
+    # metric cannot separate them even in principle, which makes these the ONLY per-person
+    # motion data obtainable.
+    "him-static",
+    "her-static",
+    "him-strong",
+    "her-strong",
+    # Body
+    "anatomy-break",
 ]
 
 

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -30,14 +30,24 @@ class SegmentCreate(BaseModel):
 
 # The vocabulary lives server-side so the console and any analysis agree on the exact strings.
 # Grouping is the entire point of tags; two spellings of the same observation are two labels.
+#
+# Motion is split by person deliberately. motion_magnitude is whole-frame Farneback optical flow:
+# it sums every moving pixel, so a lively woman with a static man scores identically to the
+# reverse. The metric cannot separate them even in principle, which makes these tags the ONLY
+# source of per-person motion data we will ever have.
 OBSERVATION_TAGS = [
+    # Defects
     "mouth-void",
     "teeth-mush",
     "frozen-face",
     "blurry-face",
     "identity-drift",
+    "weak-motion-him",
+    "weak-motion-her",
+    # Positives -- rating is one all-in number, so per-axis signal has to live here.
     "good-expression",
-    "good-motion",
+    "good-motion-him",
+    "good-motion-her",
     "good-detail",
 ]
 

--- a/tests/test_segment_annotation.py
+++ b/tests/test_segment_annotation.py
@@ -17,26 +17,33 @@ class TestVocabulary:
     def test_covers_the_artifacts_actually_observed(self):
         # Named from real reports, not invented: the open-mouth failure was described as
         # "blank/black space mouth" with "messy teeth and lips".
-        for tag in ("mouth-void", "teeth-mush", "frozen-face"):
+        for tag in ("mouth-void", "teeth-mush", "face-frozen"):
             assert tag in OBSERVATION_TAGS
 
     def test_carries_positive_labels_too(self):
         # Rating is one all-in number, so per-axis signal has to come from somewhere. Positive
         # tags are what let "the motion was good but the mouth was a void" survive as data.
-        for tag in ("good-motion-her", "good-expression", "good-detail"):
+        for tag in ("her-strong", "face-expressive"):
             assert tag in OBSERVATION_TAGS
 
     def test_motion_is_labelled_per_person(self):
         # motion_magnitude is whole-frame optical flow -- it sums every moving pixel, so a lively
         # woman with a static man scores the same as the reverse. The metric cannot tell them
         # apart even in principle, so these tags are the only per-person motion data obtainable.
-        for tag in ("good-motion-him", "good-motion-her",
-                    "weak-motion-him", "weak-motion-her"):
+        for tag in ("him-strong", "her-strong", "him-static", "her-static"):
             assert tag in OBSERVATION_TAGS
-        assert "good-motion" not in OBSERVATION_TAGS
 
     def test_no_duplicates(self):
         assert len(OBSERVATION_TAGS) == len(set(OBSERVATION_TAGS))
+
+    def test_every_tag_follows_location_condition(self):
+        # The scheme is what keeps the set extensible without renaming debates: a new observation
+        # about the eyes is eyes-<something>. A tag that does not split cannot be grouped by
+        # region, which is how the chip row is laid out and how analysis will slice it.
+        for tag in OBSERVATION_TAGS:
+            location, _, condition = tag.partition("-")
+            assert location and condition, f"{tag} is not <location>-<condition>"
+            assert tag.islower() and " " not in tag
 
 
 class TestAnnotationSchema:
@@ -62,7 +69,7 @@ class TestTagOrdering:
     def test_storage_order_is_vocabulary_order_not_input_order(self):
         # Two segments tagged the same way must produce identical strings, or grouping needs
         # normalising at read time and every later analysis has to remember to do it.
-        chosen = {"good-motion-her", "mouth-void"}
+        chosen = {"her-strong", "mouth-void"}
         ordered = [t for t in OBSERVATION_TAGS if t in chosen]
-        reversed_input = {"mouth-void", "good-motion-her"}
+        reversed_input = {"mouth-void", "her-strong"}
         assert ordered == [t for t in OBSERVATION_TAGS if t in reversed_input]

--- a/tests/test_segment_annotation.py
+++ b/tests/test_segment_annotation.py
@@ -23,8 +23,17 @@ class TestVocabulary:
     def test_carries_positive_labels_too(self):
         # Rating is one all-in number, so per-axis signal has to come from somewhere. Positive
         # tags are what let "the motion was good but the mouth was a void" survive as data.
-        for tag in ("good-motion", "good-expression", "good-detail"):
+        for tag in ("good-motion-her", "good-expression", "good-detail"):
             assert tag in OBSERVATION_TAGS
+
+    def test_motion_is_labelled_per_person(self):
+        # motion_magnitude is whole-frame optical flow -- it sums every moving pixel, so a lively
+        # woman with a static man scores the same as the reverse. The metric cannot tell them
+        # apart even in principle, so these tags are the only per-person motion data obtainable.
+        for tag in ("good-motion-him", "good-motion-her",
+                    "weak-motion-him", "weak-motion-her"):
+            assert tag in OBSERVATION_TAGS
+        assert "good-motion" not in OBSERVATION_TAGS
 
     def test_no_duplicates(self):
         assert len(OBSERVATION_TAGS) == len(set(OBSERVATION_TAGS))
@@ -53,7 +62,7 @@ class TestTagOrdering:
     def test_storage_order_is_vocabulary_order_not_input_order(self):
         # Two segments tagged the same way must produce identical strings, or grouping needs
         # normalising at read time and every later analysis has to remember to do it.
-        chosen = {"good-motion", "mouth-void"}
+        chosen = {"good-motion-her", "mouth-void"}
         ordered = [t for t in OBSERVATION_TAGS if t in chosen]
-        reversed_input = {"mouth-void", "good-motion"}
+        reversed_input = {"mouth-void", "good-motion-her"}
         assert ordered == [t for t in OBSERVATION_TAGS if t in reversed_input]

--- a/tests/test_segment_annotation.py
+++ b/tests/test_segment_annotation.py
@@ -1,0 +1,59 @@
+"""Tests for segment annotation (human observations).
+
+The point of these fields is that the automated metrics cannot rank quality -- on the one
+controlled pair where both exist, the expression score ranked them backwards, because a gaping
+mouth is the largest landmark excursion a face can make and the metric rewards it (daemon#123).
+
+So the valuable property is that tags GROUP. A vocabulary that admits near-misses produces
+"mouth-void" and "mouth void" as separate labels and destroys the only thing they are for.
+"""
+
+import pytest
+
+from app.schemas.segments import OBSERVATION_TAGS, SegmentAnnotation
+
+
+class TestVocabulary:
+    def test_covers_the_artifacts_actually_observed(self):
+        # Named from real reports, not invented: the open-mouth failure was described as
+        # "blank/black space mouth" with "messy teeth and lips".
+        for tag in ("mouth-void", "teeth-mush", "frozen-face"):
+            assert tag in OBSERVATION_TAGS
+
+    def test_carries_positive_labels_too(self):
+        # Rating is one all-in number, so per-axis signal has to come from somewhere. Positive
+        # tags are what let "the motion was good but the mouth was a void" survive as data.
+        for tag in ("good-motion", "good-expression", "good-detail"):
+            assert tag in OBSERVATION_TAGS
+
+    def test_no_duplicates(self):
+        assert len(OBSERVATION_TAGS) == len(set(OBSERVATION_TAGS))
+
+
+class TestAnnotationSchema:
+    def test_rating_is_bounded(self):
+        with pytest.raises(Exception):
+            SegmentAnnotation(rating=0)
+        with pytest.raises(Exception):
+            SegmentAnnotation(rating=6)
+        assert SegmentAnnotation(rating=3).rating == 3
+
+    def test_everything_is_optional_so_a_partial_save_is_possible(self):
+        # Saving a rating must not blank out notes typed earlier.
+        a = SegmentAnnotation(rating=4)
+        assert a.model_dump(exclude_unset=True) == {"rating": 4}
+
+    def test_an_explicit_null_is_distinguishable_from_an_absent_field(self):
+        # This is the difference between "leave notes alone" and "clear my notes".
+        assert "notes" in SegmentAnnotation(notes=None).model_dump(exclude_unset=True)
+        assert "notes" not in SegmentAnnotation(rating=2).model_dump(exclude_unset=True)
+
+
+class TestTagOrdering:
+    def test_storage_order_is_vocabulary_order_not_input_order(self):
+        # Two segments tagged the same way must produce identical strings, or grouping needs
+        # normalising at read time and every later analysis has to remember to do it.
+        chosen = {"good-motion", "mouth-void"}
+        ordered = [t for t in OBSERVATION_TAGS if t in chosen]
+        reversed_input = {"mouth-void", "good-motion"}
+        assert ordered == [t for t in OBSERVATION_TAGS if t in reversed_input]


### PR DESCRIPTION
The automated metrics cannot rank quality, and we know this rather than suspect it: on the one controlled pair where both a measurement and a human judgement exist, **the expression score ranked them backwards** (daemon#123). A gaping mouth is the largest landmark excursion a face can make, so the metric scores the exact artifact that makes a segment look worse.

That makes human judgement the ranking channel — and until now it lived in a text file beside the app.

## Three fields, not one

Free text preserves observations but doesn't aggregate. Fifteen segments this round and more next; "what did we conclude" becomes re-reading prose.

| field | purpose |
|---|---|
| `notes` | what was seen, in words |
| `rating` | 1–5 overall — enough to rank the arms of a paired test, which is what these experiments are built around |
| `observation_tags` | controlled vocabulary |

**The tags are the valuable part.** `mouth-void` on forty segments is *labelled ground truth*, and that turns fixing the expression metric from guesswork into a fitting problem — we can ask whether any computable signal predicts the label. Without labels, daemon#123 has no way forward but speculation.

## Vocabulary

```
mouth-void  teeth-mush  frozen-face  blurry-face  identity-drift
weak-motion-him  weak-motion-her
good-expression  good-motion-him  good-motion-her  good-detail
```

**Motion is split by person deliberately.** `motion_magnitude` is whole-frame Farneback optical flow — it sums every moving pixel, so a lively woman with a static man scores identically to the reverse. The metric cannot separate them even in principle, which makes these tags the only per-person motion data obtainable. A single `good-motion` would discard that distinction at the one point where it exists.

Positive labels are included because `rating` is a single all-in number, so per-axis signal has to live somewhere — "the motion was good but the mouth was a void" needs to survive as data.

## Notes on the shape

- Vocabulary is **served from the API** (`GET /segments/observation-tags`) rather than hardcoded in the console, so a tag written by the UI is the same string later analysis groups on. Tags are stored in vocabulary order, so identical observations produce identical strings and grouping needs no normalising at read time.
- **Separate endpoint** from the daemon's `PATCH /segments/{id}`: that one carries an API key and writes generation state. This is user-authenticated and writes only annotation.
- **Nothing here is read by generation.** An observation must never be able to change output.
- Fields are individually optional (`exclude_unset`), so saving a rating doesn't blank notes typed earlier — but an explicit null still clears, because a mistyped note needs an undo.

408 passing, 8 new. Console side (modal per segment in Job Detail) follows separately.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct