### PR TITLE
Add pace tags, and reject contradictory observations

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -22,6 +22,7 @@ from app.helpers import upload_faceswap_image
 from app.models import AppSetting, Job, Lora, Segment, User, Video, VideoSettingsPreset, Wildcard, Worker
 from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
+    EXCLUSIVE_TAG_GROUPS,
     OBSERVATION_TAGS,
     SegmentAnnotation,
     FramePreview,
@@ -1350,9 +1351,17 @@ async def annotate_segment(
                 detail=f"Unknown observation tag(s): {', '.join(unknown)}. "
                        f"Allowed: {', '.join(OBSERVATION_TAGS)}",
             )
+        chosen = set(tags)
+        for group in EXCLUSIVE_TAG_GROUPS:
+            clash = sorted(chosen & group)
+            if len(clash) > 1:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Contradictory tags: {', '.join(clash)}. Pick one.",
+                )
         # Deduped and stored in vocabulary order, so two segments tagged the same way produce
         # identical strings and group without normalising at read time.
-        ordered = [t for t in OBSERVATION_TAGS if t in set(tags)]
+        ordered = [t for t in OBSERVATION_TAGS if t in chosen]
         segment.observation_tags = ",".join(ordered) or None
 
     await db.commit()

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -51,8 +51,24 @@ OBSERVATION_TAGS = [
     "her-static",
     "him-strong",
     "her-strong",
+    # Pace. Unlike every other axis, the middle value has to be explicit: with only fast/slow,
+    # an untagged segment is ambiguous between "the pace was fine" and "I did not judge the
+    # pace", and those are different data.
+    "pace-slow",
+    "pace-right",
+    "pace-fast",
     # Body
     "anatomy-break",
+]
+
+# Sets whose members contradict each other. A segment cannot be both too fast and too slow, and
+# a man cannot be both static and thrusting strongly. Rejecting these server-side matters because
+# the tags exist to be ground truth -- a contradictory label is worse than a missing one, since
+# it quietly poisons whatever it is later used to validate.
+EXCLUSIVE_TAG_GROUPS = [
+    {"pace-slow", "pace-right", "pace-fast"},
+    {"him-static", "him-strong"},
+    {"her-static", "her-strong"},
 ]
 
 

--- a/tests/test_segment_annotation.py
+++ b/tests/test_segment_annotation.py
@@ -10,7 +10,7 @@ So the valuable property is that tags GROUP. A vocabulary that admits near-misse
 
 import pytest
 
-from app.schemas.segments import OBSERVATION_TAGS, SegmentAnnotation
+from app.schemas.segments import EXCLUSIVE_TAG_GROUPS, OBSERVATION_TAGS, SegmentAnnotation
 
 
 class TestVocabulary:
@@ -73,3 +73,35 @@ class TestTagOrdering:
         ordered = [t for t in OBSERVATION_TAGS if t in chosen]
         reversed_input = {"mouth-void", "her-strong"}
         assert ordered == [t for t in OBSERVATION_TAGS if t in reversed_input]
+
+
+class TestPace:
+    def test_pace_has_an_explicit_middle(self):
+        # Every other axis can leave "fine" implicit by being untagged. Pace cannot: with only
+        # fast and slow, an untagged segment is ambiguous between "the pace was right" and "I
+        # did not judge the pace", and those are different data.
+        for tag in ("pace-slow", "pace-right", "pace-fast"):
+            assert tag in OBSERVATION_TAGS
+
+
+class TestContradictoryTags:
+    """Tags exist to be ground truth, so a contradictory label is worse than a missing one --
+    it quietly poisons whatever it is later used to validate."""
+
+    def test_pace_values_are_mutually_exclusive(self):
+        group = next(g for g in EXCLUSIVE_TAG_GROUPS if "pace-fast" in g)
+        assert {"pace-slow", "pace-right", "pace-fast"} == group
+
+    def test_a_person_cannot_be_static_and_strong(self):
+        assert {"him-static", "him-strong"} in EXCLUSIVE_TAG_GROUPS
+        assert {"her-static", "her-strong"} in EXCLUSIVE_TAG_GROUPS
+
+    def test_compatible_face_tags_are_not_restricted(self):
+        # A face can be blurry AND frozen. Over-constraining would lose real observations.
+        for group in EXCLUSIVE_TAG_GROUPS:
+            assert not {"face-blurry", "face-frozen"} <= group
+
+    def test_every_exclusive_member_is_in_the_vocabulary(self):
+        for group in EXCLUSIVE_TAG_GROUPS:
+            for tag in group:
+                assert tag in OBSERVATION_TAGS


### PR DESCRIPTION
## Pace

`pace-slow` · `pace-right` · `pace-fast`

**The middle value has to be explicit**, unlike every other axis. With only fast and slow, an untagged segment is ambiguous between "the pace was fine" and "I didn't judge the pace" — and those are different data. Everywhere else absence can safely mean "nothing notable"; here it can't.

## Contradictory tags are now rejected

A segment cannot be both too fast and too slow. A man cannot be both static and thrusting strongly.

```
pace-slow / pace-right / pace-fast
him-static / him-strong
her-static / her-strong
```

Enforced server-side because these tags exist to be **ground truth** — a contradictory label is worse than a missing one, since it quietly poisons whatever it's later used to validate. If we're going to ask whether a computable signal predicts `pace-fast`, the labels can't disagree with themselves.

Exclusivity is declared per group rather than inferred from the location prefix, because **most locations are not exclusive** — a face can be blurry *and* frozen at once, and over-constraining would throw away real observations.

415 passing, 5 new. Console side (single-select behaviour in the modal) is wanly-console#306.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct