### PR TITLE
Add bodies-unison

### DIFF
--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -57,7 +57,12 @@ OBSERVATION_TAGS = [
     "pace-slow",
     "pace-right",
     "pace-fast",
-    # Body
+    # Body mechanics. bodies-unison is the single largest quality differentiator observed so far
+    # and no metric can see it: two bodies rocking together generate ENORMOUS whole-frame optical
+    # flow while being the wrong motion entirely. The 5-rated segment scored 0.545 and a 3-rated
+    # one scored 1.162. motion_magnitude measures quantity; this tag is the only record of
+    # correctness.
+    "bodies-unison",
     "anatomy-break",
 ]
 

--- a/tests/test_segment_annotation.py
+++ b/tests/test_segment_annotation.py
@@ -105,3 +105,18 @@ class TestContradictoryTags:
         for group in EXCLUSIVE_TAG_GROUPS:
             for tag in group:
                 assert tag in OBSERVATION_TAGS
+
+
+class TestBodyMechanics:
+    def test_unison_is_labelled(self):
+        # The largest observed quality differentiator, and invisible to every metric: two bodies
+        # rocking together produce enormous whole-frame optical flow while being the wrong motion.
+        # A 5-rated segment scored 0.545; a 3-rated one scored 1.162. Without this tag the
+        # distinction survives only in free text and cannot be aggregated.
+        assert "bodies-unison" in OBSERVATION_TAGS
+
+    def test_unison_is_not_exclusive_with_strong_motion(self):
+        # Both people CAN be moving strongly and still be moving wrongly -- that is exactly the
+        # observed case. Making these exclusive would force a choice that misdescribes it.
+        for group in EXCLUSIVE_TAG_GROUPS:
+            assert not {"bodies-unison", "him-strong"} <= group


### PR DESCRIPTION
The largest quality differentiator observed so far, and **invisible to every metric we have**.

Two bodies rocking together in unison generate enormous whole-frame optical flow while being the wrong motion entirely:

```
5-rated segment ("motion is spot on")        motion 0.545
3-rated segment ("moving in unison...
                 should be smacking")        motion 1.162
```

`motion_magnitude` measures quantity; this is a question of correctness. Without the tag the distinction survives only in free text and cannot be aggregated — and it is the thing separating a 3 from a 5.

Deliberately **not** exclusive with `him-strong`/`her-strong`. Both people can be moving strongly and still be moving wrongly — that is exactly the observed case, and forcing a choice would misdescribe it.

No console change needed: the modal groups by location prefix and `bodies-` already falls into Body.

417 passing, 2 new.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct