### PR TITLE
Rename bodies-unison to bodies-rocking, and add bodies-impact

### DIFF
--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -57,12 +57,20 @@ OBSERVATION_TAGS = [
     "pace-slow",
     "pace-right",
     "pace-fast",
-    # Body mechanics. bodies-unison is the single largest quality differentiator observed so far
-    # and no metric can see it: two bodies rocking together generate ENORMOUS whole-frame optical
-    # flow while being the wrong motion entirely. The 5-rated segment scored 0.545 and a 3-rated
-    # one scored 1.162. motion_magnitude measures quantity; this tag is the only record of
-    # correctness.
-    "bodies-unison",
+    # Body mechanics -- the single largest quality differentiator observed so far, and one no
+    # metric can see: two bodies rocking TOGETHER generate enormous whole-frame optical flow
+    # while being the wrong motion entirely. The 5-rated segment scored 0.545 and a 3-rated one
+    # scored 1.162. motion_magnitude measures quantity; these record correctness.
+    #
+    # "rocking" is the reviewer's own word for the failure ("they are moving in unison, they
+    # should be smacking together, not rocking") and it is used deliberately: the earlier name,
+    # bodies-unison, described the behaviour without saying it was wrong, where every other tag
+    # puts the judgement in the condition.
+    "bodies-rocking",
+    # The positive is needed for the same reason pace-right is: without it, an untagged segment
+    # is ambiguous between "the bodies impacted properly" and "I did not judge the mechanics" --
+    # and impact is the outcome round 2 is hunting for.
+    "bodies-impact",
     "anatomy-break",
 ]
 
@@ -74,6 +82,7 @@ EXCLUSIVE_TAG_GROUPS = [
     {"pace-slow", "pace-right", "pace-fast"},
     {"him-static", "him-strong"},
     {"her-static", "her-strong"},
+    {"bodies-rocking", "bodies-impact"},
 ]
 
 

--- a/tests/test_segment_annotation.py
+++ b/tests/test_segment_annotation.py
@@ -108,15 +108,22 @@ class TestContradictoryTags:
 
 
 class TestBodyMechanics:
-    def test_unison_is_labelled(self):
-        # The largest observed quality differentiator, and invisible to every metric: two bodies
-        # rocking together produce enormous whole-frame optical flow while being the wrong motion.
-        # A 5-rated segment scored 0.545; a 3-rated one scored 1.162. Without this tag the
-        # distinction survives only in free text and cannot be aggregated.
-        assert "bodies-unison" in OBSERVATION_TAGS
+    def test_the_condition_carries_the_judgement(self):
+        # bodies-unison described the behaviour without saying it was wrong, unlike every other
+        # tag. "rocking" is the reviewer's own word for the failure and reads as a defect.
+        assert "bodies-rocking" in OBSERVATION_TAGS
+        assert "bodies-unison" not in OBSERVATION_TAGS
 
-    def test_unison_is_not_exclusive_with_strong_motion(self):
+    def test_impact_is_labelled_too(self):
+        # Same reason pace-right exists: without it, untagged is ambiguous between "the bodies
+        # impacted properly" and "I did not judge the mechanics".
+        assert "bodies-impact" in OBSERVATION_TAGS
+
+    def test_rocking_and_impact_are_mutually_exclusive(self):
+        assert {"bodies-rocking", "bodies-impact"} in EXCLUSIVE_TAG_GROUPS
+
+    def test_rocking_is_not_exclusive_with_strong_motion(self):
         # Both people CAN be moving strongly and still be moving wrongly -- that is exactly the
         # observed case. Making these exclusive would force a choice that misdescribes it.
         for group in EXCLUSIVE_TAG_GROUPS:
-            assert not {"bodies-unison", "him-strong"} <= group
+            assert not {"bodies-rocking", "him-strong"} <= group


### PR DESCRIPTION
`bodies-unison` described the behaviour without saying it was **wrong**. Every other tag puts the judgement in the condition — `face-frozen`, `him-static` — so this one read as neutral, and it was ambiguous whether tagging it meant "they moved together" or "they moved together and that's the defect".

`bodies-rocking` uses the reviewer's own word for the failure:

> *"They are moving in unison, they should be smacking together, not rocking."*

It names exactly the observed thing and reads unmistakably as a defect.

**`bodies-impact` is added** for the same reason `pace-right` exists: without a positive, an untagged segment is ambiguous between "the bodies impacted properly" and "I didn't judge the mechanics". Impact is also the outcome round 2 is hunting for, so its absence has to be distinguishable from its non-assessment.

The two are mutually exclusive and rejected together server-side, like `pace-*` and `him-static`/`him-strong`.

Nothing had been tagged with the old name (checked: 0 rows), so no migration is needed.

419 passing.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct