### PR TITLE
Rename the body-mechanics tags onto the travel axis

### DIFF
--- a/alembic/versions/062_rename_body_mechanics_tags.py
+++ b/alembic/versions/062_rename_body_mechanics_tags.py
@@ -1,0 +1,52 @@
+"""Rename the body-mechanics observation tags onto the travel axis
+
+Revision ID: 062
+Revises: 061
+Create Date: 2026-08-08
+
+The tag went through three names in one day, which is worth recording because each rename
+sharpened what was actually being judged:
+
+  bodies-unison   described the behaviour without saying it was wrong, unlike every other tag
+  bodies-rocking  used the reviewer's own word, but "rocking" is how the failure LOOKS from
+                  outside, not what is missing
+  bodies-locked   names the mechanism: the bodies stay joined and there is no relative travel
+
+The axis is travel. He withdraws and re-enters, so the two bodies separate and rejoin along an
+axis; the failure is that they move as one unit. Naming both ends for travel -- locked and
+in-out -- keeps the judgement on the thing being judged, where "impact" named only the collision
+at the end of a stroke rather than the displacement producing it.
+
+Renamed in place rather than deprecated: five segments carry the old values and the labels exist
+to be aggregated. Two spellings of one observation is exactly the failure a controlled
+vocabulary is for. Substring replacement is safe here because no other tag contains these as a
+prefix, and the replacements occupy the same positions in OBSERVATION_TAGS, so the stored
+vocabulary ordering is preserved.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "062"
+down_revision = "061"
+branch_labels = None
+depends_on = None
+
+_RENAMES = [("bodies-rocking", "bodies-locked"), ("bodies-impact", "bodies-inout")]
+
+
+def _apply(pairs):
+    for old, new in pairs:
+        op.execute(
+            sa.text(
+                "UPDATE segments SET observation_tags = replace(observation_tags, :old, :new) "
+                "WHERE observation_tags LIKE :pat"
+            ).bindparams(old=old, new=new, pat=f"%{old}%")
+        )
+
+
+def upgrade() -> None:
+    _apply(_RENAMES)
+
+
+def downgrade() -> None:
+    _apply([(new, old) for old, new in _RENAMES])

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -58,19 +58,16 @@ OBSERVATION_TAGS = [
     "pace-right",
     "pace-fast",
     # Body mechanics -- the single largest quality differentiator observed so far, and one no
-    # metric can see: two bodies rocking TOGETHER generate enormous whole-frame optical flow
+    # metric can see: two bodies moving as ONE UNIT generate enormous whole-frame optical flow
     # while being the wrong motion entirely. The 5-rated segment scored 0.545 and a 3-rated one
     # scored 1.162. motion_magnitude measures quantity; these record correctness.
     #
-    # "rocking" is the reviewer's own word for the failure ("they are moving in unison, they
-    # should be smacking together, not rocking") and it is used deliberately: the earlier name,
-    # bodies-unison, described the behaviour without saying it was wrong, where every other tag
-    # puts the judgement in the condition.
-    "bodies-rocking",
-    # The positive is needed for the same reason pace-right is: without it, an untagged segment
-    # is ambiguous between "the bodies impacted properly" and "I did not judge the mechanics" --
-    # and impact is the outcome round 2 is hunting for.
-    "bodies-impact",
+    # The axis is TRAVEL: he withdraws and re-enters, so the bodies separate and rejoin along an
+    # axis. What fails is not that they "rock" -- that is only how the failure looks from outside
+    # -- it is that they stay joined and there is no relative displacement between them. Naming
+    # both ends for travel keeps the judgement on the thing being judged.
+    "bodies-locked",
+    "bodies-inout",
     "anatomy-break",
 ]
 
@@ -82,7 +79,7 @@ EXCLUSIVE_TAG_GROUPS = [
     {"pace-slow", "pace-right", "pace-fast"},
     {"him-static", "him-strong"},
     {"her-static", "her-strong"},
-    {"bodies-rocking", "bodies-impact"},
+    {"bodies-locked", "bodies-inout"},
 ]
 
 

--- a/tests/test_segment_annotation.py
+++ b/tests/test_segment_annotation.py
@@ -108,22 +108,20 @@ class TestContradictoryTags:
 
 
 class TestBodyMechanics:
-    def test_the_condition_carries_the_judgement(self):
-        # bodies-unison described the behaviour without saying it was wrong, unlike every other
-        # tag. "rocking" is the reviewer's own word for the failure and reads as a defect.
-        assert "bodies-rocking" in OBSERVATION_TAGS
-        assert "bodies-unison" not in OBSERVATION_TAGS
+    def test_both_ends_name_the_same_axis(self):
+        # The axis is TRAVEL: he withdraws and re-enters. "rocking" described how the failure
+        # looks from outside rather than what is missing, and "impact" named the collision rather
+        # than the displacement that produces it. Both ends now name travel.
+        assert "bodies-locked" in OBSERVATION_TAGS
+        assert "bodies-inout" in OBSERVATION_TAGS
+        for retired in ("bodies-rocking", "bodies-impact", "bodies-unison"):
+            assert retired not in OBSERVATION_TAGS
 
-    def test_impact_is_labelled_too(self):
-        # Same reason pace-right exists: without it, untagged is ambiguous between "the bodies
-        # impacted properly" and "I did not judge the mechanics".
-        assert "bodies-impact" in OBSERVATION_TAGS
+    def test_travel_ends_are_mutually_exclusive(self):
+        assert {"bodies-locked", "bodies-inout"} in EXCLUSIVE_TAG_GROUPS
 
-    def test_rocking_and_impact_are_mutually_exclusive(self):
-        assert {"bodies-rocking", "bodies-impact"} in EXCLUSIVE_TAG_GROUPS
-
-    def test_rocking_is_not_exclusive_with_strong_motion(self):
+    def test_locked_is_not_exclusive_with_strong_motion(self):
         # Both people CAN be moving strongly and still be moving wrongly -- that is exactly the
         # observed case. Making these exclusive would force a choice that misdescribes it.
         for group in EXCLUSIVE_TAG_GROUPS:
-            assert not {"bodies-rocking", "him-strong"} <= group
+            assert not {"bodies-locked", "him-strong"} <= group


### PR DESCRIPTION
**The axis is travel.** He withdraws and re-enters, so the two bodies separate and rejoin along an axis. The failure is that they stay joined and move as one unit.

`rocking` described how that *looks from outside* rather than what is missing. `impact` named the collision at the end of a stroke rather than the displacement that produces it. Both ends now name travel:

```
bodies-locked   joined, no relative travel
bodies-inout    clear withdrawal and re-entry
```

Third name in a day — `unison` → `rocking` → `locked` — and each rename sharpened what was actually being judged. Worth recording rather than hiding, since the vocabulary converging is the point of having one.

**Migration 062 renames in place** rather than deprecating. Five segments already carry the old values, the labels exist to be aggregated, and two spellings of one observation is exactly the failure a controlled vocabulary prevents. Substring replacement is safe here: no other tag contains these as a prefix, and the replacements hold the same positions in `OBSERVATION_TAGS`, so stored ordering is preserved. Downgrade reverses it.

418 passing. Console side: wanly-console#307.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct