### PR TITLE
Search images by filename, not only by tags

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -361,6 +361,30 @@ async def update_image_tags(
     return {"path": path, "tags": tags_val}
 
 
+def search_pattern(q: str) -> str:
+    """The LIKE pattern for a user's query, with their wildcards neutralised.
+
+    "%" and "_" are LIKE wildcards and filenames are full of both, so a query for "a_b" must not
+    silently match "axb", and "100%" must not become match-everything. The backslash is escaped
+    first, or escaping the wildcards would itself be re-escaped.
+    """
+    safe = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{safe}%"
+
+
+def search_clause(q: str):
+    """Match a query against tags OR filename.
+
+    A disjunction, not a conjunction: an untagged image has NULL tags, and requiring both would
+    leave it permanently unfindable -- which is the case this exists for.
+    """
+    pattern = search_pattern(q)
+    return or_(
+        ImageMeta.tags.ilike(pattern, escape="\\"),
+        ImageMeta.path.ilike(pattern, escape="\\"),
+    )
+
+
 @router.get("/images/search", dependencies=[Depends(get_current_user)])
 async def search_images(
     q: str = Query(..., min_length=1, max_length=500),
@@ -369,18 +393,23 @@ async def search_images(
     db: AsyncSession = Depends(get_db),
     user = Depends(get_current_user),
 ):
-    """Search images across all folders by tags (case-insensitive partial match)."""
-    safe = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    pattern = f"%{safe}%"
+    """Search images across all folders by tag or filename (case-insensitive partial match).
 
-    count_q = select(func.count()).select_from(ImageMeta).where(
-        ImageMeta.tags.ilike(pattern, escape="\\")
-    )
+    Path is matched as well as tags because the filename is often the only handle a user has.
+    Images arrive named like "00111-1696092597-swapped.png", get referenced by that name in job
+    configs, notes and conversations, and are spread across dated folders -- so "which folder was
+    00111 in" was unanswerable from the UI, and an untagged image was unfindable by any means at
+    all. Matching the path also makes a folder name a usable query, which is a free side effect
+    of storing the full key.
+    """
+    matches = search_clause(q)
+
+    count_q = select(func.count()).select_from(ImageMeta).where(matches)
     total = (await db.execute(count_q)).scalar() or 0
 
     meta_q = (
         select(ImageMeta)
-        .where(ImageMeta.tags.ilike(pattern, escape="\\"))
+        .where(matches)
         .order_by(ImageMeta.updated_at.desc())
         .offset(offset)
         .limit(limit)

--- a/tests/test_image_search.py
+++ b/tests/test_image_search.py
@@ -1,0 +1,61 @@
+"""Image search must match the filename, not only tags.
+
+The filename is often the only handle a user has. Images arrive named like
+"00111-1696092597-swapped.png", are referred to by that name in job configs, notes and
+conversation, and are spread across dated folders -- so "which folder was 00111 in" was
+unanswerable from the UI, and an untagged image was unfindable by any means at all.
+
+Measured against production before the fix: searching "00111" returned 0 results; matching the
+path as well returns 10.
+"""
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.dialects import postgresql
+
+from app.models import ImageMeta
+from app.routes.images import search_clause, search_pattern
+
+
+def _sql(stmt) -> str:
+    """Render against the dialect we actually run on.
+
+    The generic dialect emits ILIKE as lower(x) LIKE lower(y), so asserting on the rendered
+    operator under the default dialect tests SQLAlchemy's fallback rather than our query.
+    """
+    return str(stmt.compile(dialect=postgresql.dialect(),
+                            compile_kwargs={"literal_binds": True}))
+
+
+class TestSearchClause:
+    def test_matches_path_as_well_as_tags(self):
+        sql = _sql(search_clause("00111"))
+        assert "image_meta.tags ILIKE" in sql
+        assert "image_meta.path ILIKE" in sql
+
+    def test_it_is_a_disjunction_not_a_conjunction(self):
+        # An untagged image has NULL tags. Requiring both would make it permanently unfindable,
+        # which is the exact case this fix exists for.
+        sql = _sql(search_clause("x"))
+        assert " OR " in sql
+        assert " AND " not in sql
+
+    def test_wildcards_in_the_query_are_escaped(self):
+        # A user typing "100%" must not turn into a match-everything pattern. Asserted on the
+        # pattern rather than the rendered SQL, where literal_binds doubles % for paramstyle.
+        assert search_pattern("100%") == "%100\\%%"
+
+    def test_underscores_are_escaped(self):
+        # "_" is a single-character wildcard in LIKE, and filenames are full of them.
+        assert search_pattern("a_b") == "%a\\_b%"
+
+    def test_backslash_is_escaped_before_the_wildcards(self):
+        # Escaping the wildcards first would then re-escape their backslashes.
+        assert search_pattern("a\\b") == "%a\\\\b%"
+
+    def test_count_and_page_use_the_same_predicate(self):
+        # If the count and the page query diverge, pagination reports a total it cannot deliver.
+        clause = search_clause("00111")
+        count_sql = _sql(select(func.count()).select_from(ImageMeta).where(clause))
+        page_sql = _sql(select(ImageMeta).where(clause))
+        for fragment in ("image_meta.tags ILIKE", "image_meta.path ILIKE"):
+            assert fragment in count_sql and fragment in page_sql


### PR DESCRIPTION
`/images/search` only ever matched `ImageMeta.tags`. The filename was never searchable.

That matters because **the filename is often the only handle a user has.** Images arrive named like `00111-1696092597-swapped.png`, get referred to by that name in job configs, notes and conversation, and are spread across dated folders. So "which folder was `00111` in" was unanswerable from the UI — and an **untagged image was unfindable by any means at all**.

Measured against production:

```
query "00111"    tags-only: 0     tags-or-path: 10
query "c2b18f"   tags-only: 0     tags-or-path: 1
query "00005"    tags-only: 0     tags-or-path: 12
```

A **disjunction**, not a conjunction: an untagged image has NULL tags, and requiring both would leave exactly the images this exists for permanently hidden. Matching the path also makes a folder name a usable query — a free side effect of storing the full key.

## On the tests

The pattern building and the predicate are now named functions rather than inline expressions, so the tests exercise the **real escaping** instead of a copy of it. My first attempt duplicated the logic in the test file, which would have passed regardless of what the route did.

Escaping is asserted on the pattern rather than on rendered SQL: `literal_binds` doubles `%` for paramstyle, so asserting on the rendered string tests the renderer rather than the query. `%` and `_` are LIKE wildcards and filenames are full of both — a query for `a_b` must not match `axb`, and `100%` must not become match-everything.

424 passing, 6 new.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct