### PR TITLE
Serialise deploys so two close merges cannot race

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,20 @@ permissions:
   id-token: write
   contents: read
 
+# One deploy at a time. The steps are already idempotent -- they stop and remove the container
+# before starting it -- but two runs interleaving defeats that: both remove, both start, and the
+# second gets "the container name /wanly-api is already in use". Seen 2026-08-08 when two PRs
+# merged nineteen seconds apart, and the failure is worse than a red build. Whichever run loses
+# the race is arbitrary, so a close pair can leave the OLDER image running while CI reports
+# success on the newer commit -- stale code with no signal that anything went wrong.
+#
+# cancel-in-progress is false on purpose. Cancelling a deploy mid-flight can leave the host with
+# no container at all, having already removed the previous one. Queueing costs a few minutes and
+# still converges on the newest commit, because a third run supersedes the one waiting.
+concurrency:
+  group: deploy-api
+  cancel-in-progress: false
+
 env:
   AWS_REGION: us-west-2
   ECR_REPOSITORY: wanly-api


### PR DESCRIPTION
Two PRs merged **nineteen seconds apart** today and the second deploy failed:

```
docker: Error response from daemon: Conflict. The container name "/wanly-api"
is already in use by container "bf09bbaed2e3b2..."
```

## It is not a missing `docker rm`

The steps already stop and remove the container before starting it. That is idempotent on its own but does not survive interleaving:

```
run B:  docker stop / docker rm     (nothing there)
run A:  docker stop / docker rm     (nothing there)
run A:  docker run --name wanly-api  -> creates it
run B:  docker run --name wanly-api  -> conflict
```

## The red build is not the real risk

**Which run loses is arbitrary.** A close pair can leave the OLDER image running while CI reports success on the newer commit — stale code with no signal that anything is wrong.

Today the loser happened to be the older commit (`2ed151f`, the estimator refit) and the newer one (`920700b`) was already live, and since the older is an ancestor of the newer nothing was actually missing. That was luck. The same race with the merges reversed would have left the estimator change live and the RunPod change silently absent.

## Why `cancel-in-progress: false`

Cancelling a deploy mid-flight can leave the host with **no container at all**, having already removed the previous one. Queueing costs a few minutes and still converges on the newest commit, because a third run supersedes the one waiting.

`wanly-console` has the same shape and the same gap — fixed in wanly-console#309.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct