### PR TITLE
Say so when there is queued work and nobody to do it

### DIFF
--- a/app/queue_health.py
+++ b/app/queue_health.py
@@ -1,0 +1,60 @@
+"""Is there work with nobody to do it?
+
+The 3090's host rebooted on 2026-08-08 and its container had restart=no, so the worker never came
+back. It was found thirteen hours later, by hand, with four segments queued the whole time. Every
+fact needed to catch it was already in the database -- a stale last_heartbeat, a worker marked
+offline, segments sitting pending. Nothing put them together.
+
+The distinction that matters, and the one the UI did not draw: an offline worker with an empty
+queue is housekeeping, while an offline worker with queued work is an outage. They looked
+identical.
+
+The judgement lives here as a pure function for the same reason reservations.decide() does: the
+interesting cases are combinatorial rather than temporal, and they are worth pinning as a table
+instead of through a database and a page render.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+# Statuses that mean a worker can pick up work. "draining" deliberately does NOT count: a draining
+# worker finishes what it holds and takes nothing new, so a queue with only draining workers is
+# every bit as stalled as one with none -- it just has not noticed yet.
+LIVE_STATUSES = frozenset({"online-idle", "online-busy"})
+
+
+@dataclass(frozen=True)
+class QueueHealth:
+    pending_segments: int
+    live_workers: int
+    stalled: bool
+    last_worker_seen: datetime | None = None
+
+    @property
+    def summary(self) -> str:
+        if not self.stalled:
+            return ""
+        s = "s" if self.pending_segments != 1 else ""
+        return f"{self.pending_segments} segment{s} queued and no workers online"
+
+
+def assess(
+    *,
+    pending_segments: int,
+    worker_statuses: list[str],
+    last_worker_seen: datetime | None = None,
+) -> QueueHealth:
+    """Stalled means there is work AND nobody who can take it.
+
+    Both halves are required. Queued work with a busy worker is a queue doing its job, and no
+    workers with an empty queue is a quiet night -- neither is worth interrupting anyone over.
+    Raising on either alone would produce an alarm that fires constantly and then gets ignored,
+    which is worse than the silence it replaced.
+    """
+    live = sum(1 for s in worker_statuses if s in LIVE_STATUSES)
+    return QueueHealth(
+        pending_segments=pending_segments,
+        live_workers=live,
+        stalled=pending_segments > 0 and live == 0,
+        last_worker_seen=last_worker_seen,
+    )

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -2,13 +2,15 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import verify_api_key, verify_api_key_or_bearer
 from app.database import get_db
-from app.models import Worker
-from app.schemas.workers import WorkerDrain, WorkerHeartbeat, WorkerRegister, WorkerRename, WorkerResponse, WorkerStatusUpdate
+from app.enums import JobStatus, SegmentStatus
+from app.models import Job, Segment, Worker
+from app.queue_health import assess
+from app.schemas.workers import QueueHealthResponse, WorkerDrain, WorkerHeartbeat, WorkerRegister, WorkerRename, WorkerResponse, WorkerStatusUpdate
 
 router = APIRouter()
 
@@ -220,6 +222,40 @@ async def list_workers(
         stmt = stmt.where(Worker.status == status)
     result = await db.execute(stmt)
     return result.scalars().all()
+
+
+@router.get("/queue-health", response_model=QueueHealthResponse,
+            dependencies=[Depends(verify_api_key_or_bearer)])
+async def queue_health(db: AsyncSession = Depends(get_db)):
+    """Is there queued work with nobody to do it?
+
+    Cheap enough to poll from any page. Counts only segments whose JOB is also live -- an
+    archived job's segments are unclaimable by design and would otherwise raise a permanent
+    false alarm (see #177).
+    """
+    pending = (await db.execute(
+        select(func.count())
+        .select_from(Segment)
+        .join(Job, Segment.job_id == Job.id)
+        .where(
+            Segment.status == SegmentStatus.PENDING,
+            Job.status.in_([JobStatus.PENDING, JobStatus.PROCESSING]),
+        )
+    )).scalar() or 0
+
+    rows = (await db.execute(select(Worker.status, Worker.last_heartbeat))).all()
+    health = assess(
+        pending_segments=pending,
+        worker_statuses=[r[0] for r in rows],
+        last_worker_seen=max((r[1] for r in rows), default=None),
+    )
+    return QueueHealthResponse(
+        pending_segments=health.pending_segments,
+        live_workers=health.live_workers,
+        stalled=health.stalled,
+        last_worker_seen=health.last_worker_seen,
+        summary=health.summary,
+    )
 
 
 @router.get("/workers/{worker_id}", response_model=WorkerResponse, dependencies=[Depends(verify_api_key_or_bearer)])

--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -34,6 +34,22 @@ class WorkerDrain(BaseModel):
     after_jobs: int | None = None
 
 
+class QueueHealthResponse(BaseModel):
+    """Work waiting versus workers able to take it.
+
+    `stalled` requires BOTH halves: queued work with a busy worker is a queue doing its job, and
+    no workers with an empty queue is a quiet night. An alarm on either alone fires constantly
+    and then gets ignored.
+    """
+
+    pending_segments: int
+    live_workers: int
+    stalled: bool
+    last_worker_seen: datetime | None = None
+    # Pre-rendered so every surface phrases an outage identically.
+    summary: str = ""
+
+
 class WorkerResponse(BaseModel):
     id: uuid.UUID
     friendly_name: str

--- a/tests/test_queue_health.py
+++ b/tests/test_queue_health.py
@@ -1,0 +1,57 @@
+"""Stalled = work exists AND nobody can take it.
+
+The 3090's host rebooted on 2026-08-08 and its container had restart=no. It stayed down for
+thirteen hours with four segments queued and was found by hand. Every fact needed to catch it was
+already in the database; nothing combined them.
+"""
+
+from datetime import datetime, timezone
+
+from app.queue_health import LIVE_STATUSES, assess
+
+
+class TestStalled:
+    def test_work_and_no_workers_is_the_outage(self):
+        h = assess(pending_segments=4, worker_statuses=[])
+        assert h.stalled
+        assert h.summary == "4 segments queued and no workers online"
+
+    def test_offline_workers_do_not_count_as_present(self):
+        # The real case: the worker row still existed, marked offline. A naive "are there any
+        # workers" check would have seen one and stayed quiet for thirteen hours.
+        h = assess(pending_segments=4, worker_statuses=["offline"])
+        assert h.stalled
+        assert h.live_workers == 0
+
+    def test_queued_work_with_a_busy_worker_is_not_an_outage(self):
+        # This is just a queue doing its job. Alarming here would fire constantly.
+        assert not assess(pending_segments=12, worker_statuses=["online-busy"]).stalled
+
+    def test_no_workers_and_no_work_is_a_quiet_night(self):
+        assert not assess(pending_segments=0, worker_statuses=[]).stalled
+        assert not assess(pending_segments=0, worker_statuses=["offline"]).stalled
+
+    def test_a_draining_worker_does_not_keep_the_queue_alive(self):
+        # Draining means "finish what you hold, take nothing new", so a queue served only by
+        # draining workers is every bit as stalled -- it just has not noticed yet.
+        assert "draining" not in LIVE_STATUSES
+        assert assess(pending_segments=3, worker_statuses=["draining"]).stalled
+
+    def test_one_live_worker_among_dead_ones_is_enough(self):
+        h = assess(pending_segments=9, worker_statuses=["offline", "offline", "online-idle"])
+        assert not h.stalled
+        assert h.live_workers == 1
+
+
+class TestSummary:
+    def test_singular_reads_correctly(self):
+        assert assess(pending_segments=1, worker_statuses=[]).summary.startswith("1 segment ")
+
+    def test_empty_when_healthy(self):
+        # The caller renders on truthiness, so a healthy summary must not be a non-empty string.
+        assert assess(pending_segments=0, worker_statuses=["online-idle"]).summary == ""
+
+    def test_last_worker_seen_is_carried_through(self):
+        seen = datetime(2026, 8, 8, 19, 28, tzinfo=timezone.utc)
+        assert assess(pending_segments=4, worker_statuses=["offline"],
+                      last_worker_seen=seen).last_worker_seen == seen


### PR DESCRIPTION
Closes #183.

The 3090's host rebooted and its container had `restart=no`, so the worker never came back. It was found **thirteen hours later, by hand**, because someone happened to ask whether the machine was reachable. Four segments sat unclaimed the whole time.

Every fact needed to catch it was already in the database — a stale `last_heartbeat`, a worker the sweep had marked `offline`, segments sitting `pending`. Nothing put them together.

**The distinction the UI never drew:** an offline worker with an empty queue is housekeeping; an offline worker with queued work is an outage. They rendered identically.

## The change

`GET /queue-health` — one query, cheap enough to poll from any page:

```json
{"pending_segments": 4, "live_workers": 0, "stalled": true,
 "last_worker_seen": "...", "summary": "4 segments queued and no workers online"}
```

The judgement is a pure function, for the same reason `reservations.decide()` is one: the interesting cases are combinatorial rather than temporal, and are worth pinning as a table rather than through a database and a page render.

## Two decisions worth reviewing

**Stalled requires both halves.** Queued work with a busy worker is a queue doing its job; no workers with an empty queue is a quiet night. An alarm on either alone fires most of the time and then stops being read — which is exactly the failure mode of the thing it replaces.

**`draining` does not count as live.** A draining worker finishes what it holds and takes nothing new, so a queue served only by draining workers is just as stalled; it has only not noticed yet.

Segments are counted only when their **job** is also live, so an archived job's unclaimable segments (see #177) cannot raise a permanent false alarm.

456 passing, 9 new. Console banner in wanly-console#310.

## Direct cause, fixed separately

The container had `restart=no`. Fixed in place with `docker update --restart unless-stopped`, no downtime — but that lives on the container rather than in whatever recreates it. #183 carries the open question of whether the 3090's container should be started by systemd, which would also give it a documented launch command instead of one that exists only in shell history.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct