### PR TITLE
Add mouth-looping

### DIFF
--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -41,6 +41,12 @@ OBSERVATION_TAGS = [
     "face-blurry",
     "face-expressive",
     "mouth-void",
+    # Repetitive rather than absent: the same open-close cycle looping for the whole segment,
+    # "goldfish mouth". Distinct from face-frozen (no movement) and mouth-void (the gaping black
+    # space), and worth its own label because it inflates the expression metric rather than
+    # depressing it -- sustained large landmark displacement is exactly what that metric rewards,
+    # which makes this the third artifact it scores as a success.
+    "mouth-looping",
     "teeth-mush",
     "identity-drift",
     # Motion, per person. motion_magnitude is whole-frame Farneback optical flow: it sums every

--- a/tests/test_segment_annotation.py
+++ b/tests/test_segment_annotation.py
@@ -33,6 +33,12 @@ class TestVocabulary:
         for tag in ("him-strong", "her-strong", "him-static", "her-static"):
             assert tag in OBSERVATION_TAGS
 
+    def test_repetition_is_distinguishable_from_absence(self):
+        # "goldfish mouth" -- the same cycle looping all segment -- is neither a frozen face nor
+        # a gaping one, and it inflates the expression metric instead of depressing it.
+        for tag in ("mouth-looping", "face-frozen", "mouth-void"):
+            assert tag in OBSERVATION_TAGS
+
     def test_no_duplicates(self):
         assert len(OBSERVATION_TAGS) == len(set(OBSERVATION_TAGS))
 


### PR DESCRIPTION
The same open-close cycle repeating for a whole segment — "goldfish mouth". Observed several times on 2026-08-09.

It is **neither** `face-frozen` (the absence of movement) **nor** `mouth-void` (the gaping black space), so both existing tags misdescribe it.

## Why it earns a label rather than a note

**It inflates the expression metric.** Sustained large landmark displacement is precisely what that metric measures, so a mouth cycling open and closed for five seconds scores as *highly expressive*.

That makes this the **third artifact the metric scores as a success**:

| artifact | what the metric does |
|---|---|
| `mouth-void` (gape) | largest landmark excursion available — scores highest |
| unison rocking | enormous whole-frame optical flow — 3-rated segment scored 1.162, 5-rated scored 0.545 |
| `mouth-looping` | sustained displacement — reads as expressive |

Each one is independent evidence for #123, and together they suggest the expression metric is not merely imprecise but systematically inverted on the failures that matter.

448 passing.

No console change needed — the modal groups by location prefix and `mouth-` already falls under Face.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct