### PR TITLE
Discard a segment instead of deleting it, keeping the feedback

### DIFF
--- a/alembic/versions/063_discard_segment.py
+++ b/alembic/versions/063_discard_segment.py
@@ -1,0 +1,48 @@
+"""Soft-delete a segment, keeping its feedback
+
+Revision ID: 063
+Revises: 062
+Create Date: 2026-08-09
+
+Deleting a segment destroyed the row, and with it the rating, tags and notes recorded against it.
+That was tolerable when a segment was just output; it is not now that the annotations are the
+primary evidence in every experiment -- a bad segment is often the MOST informative one, and
+throwing away the observation to get it out of the video is exactly backwards.
+
+The unique constraint on (job_id, index) becomes PARTIAL, covering only live rows. That is what
+lets a discarded segment 2 and its replacement both be "segment 2": the discarded row keeps its
+index so the record reads correctly, and the regenerated one takes the same position in the
+video. Without this the replacement would have to be appended at the end and would play out of
+order.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "063"
+down_revision = "062"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "segments",
+        sa.Column("discarded", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.drop_constraint("uq_segments_job_index", "segments", type_="unique")
+    op.create_index(
+        "uq_segments_job_index_live",
+        "segments",
+        ["job_id", "index"],
+        unique=True,
+        postgresql_where=sa.text("NOT discarded"),
+    )
+
+
+def downgrade() -> None:
+    # Discarded rows must go before the full constraint can be restored, or duplicate indices
+    # would block it. They are the only rows that can legally share an index.
+    op.execute(sa.text("DELETE FROM segments WHERE discarded"))
+    op.drop_index("uq_segments_job_index_live", table_name="segments")
+    op.create_unique_constraint("uq_segments_job_index", "segments", ["job_id", "index"])
+    op.drop_column("segments", "discarded")

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, Boolean, DateTime, Float, ForeignKey, Index, Integer, JSON, SmallInteger, String, Text, UniqueConstraint
+from sqlalchemy import BigInteger, Boolean, DateTime, Float, ForeignKey, Index, Integer, JSON, SmallInteger, String, Text, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -100,7 +100,11 @@ class Job(Base):
 class Segment(Base):
     __tablename__ = "segments"
     __table_args__ = (
-        UniqueConstraint("job_id", "index", name="uq_segments_job_index"),
+        # PARTIAL: live rows only. A discarded segment keeps its index so the record reads
+        # correctly, and its replacement takes the same position in the video -- otherwise the
+        # regenerated segment would have to be appended and would play out of order.
+        Index("uq_segments_job_index_live", "job_id", "index",
+              unique=True, postgresql_where=text("NOT discarded")),
         Index("ix_segments_job_id", "job_id"),
         Index("ix_segments_status", "status"),
     )
@@ -108,6 +112,10 @@ class Segment(Base):
     id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     job_id = mapped_column(UUID(as_uuid=True), ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False)
     index = mapped_column(Integer, nullable=False)
+    # Soft delete. The row and its rating, tags and notes survive; the video does not include it.
+    # A bad segment is often the most informative one, so discarding the observation to get it out
+    # of the cut is exactly backwards.
+    discarded = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     prompt = mapped_column(Text, nullable=False)
     prompt_template = mapped_column(Text, nullable=True)
     duration_seconds = mapped_column(Float, nullable=False, default=5.0)

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -319,10 +319,18 @@ async def list_jobs(
     counts_map: dict[UUID, tuple[int, int]] = {}
     if job_ids:
         counts_result = await db.execute(
+            # Progress excludes discarded segments from BOTH halves. A job whose only bad
+            # segment was discarded should read 4/4, not 5/5 with one of them not in the video.
+            #
+            # Run-time totals elsewhere deliberately still INCLUDE discarded work: the GPU time
+            # was genuinely spent, and hiding it would understate what a job cost.
             select(
                 Segment.job_id,
-                func.count().label("total"),
-                func.count(case((Segment.status == SegmentStatus.COMPLETED, 1))).label("completed"),
+                func.count(case((Segment.discarded.is_(False), 1))).label("total"),
+                func.count(case(
+                    ((Segment.status == SegmentStatus.COMPLETED)
+                     & Segment.discarded.is_(False), 1)
+                )).label("completed"),
             )
             .where(Segment.job_id.in_(job_ids))
             .group_by(Segment.job_id)

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -1276,6 +1276,52 @@ async def cancel_segment(
     return segment
 
 
+@router.post("/segments/{segment_id}/discard", response_model=SegmentResponse)
+async def discard_segment(
+    segment_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Take a segment out of the video without losing what was recorded about it.
+
+    Deleting destroys the row, and with it the rating, tags and notes. That was tolerable when a
+    segment was only output; it is not now that annotations are the primary evidence in every
+    experiment. A bad segment is frequently the MOST informative one, and discarding the
+    observation in order to get it out of the cut is exactly backwards.
+
+    The row keeps its index, so the record reads as "the discarded version of segment 2" and a
+    regenerated segment can take the same position. The unique constraint is partial for that
+    reason -- see migration 063.
+
+    Output files are deliberately NOT removed. The clip is the evidence behind the rating; a note
+    saying "mouth loops for the whole segment" is worth much less if the segment cannot be
+    rewatched.
+    """
+    result = await db.execute(
+        select(Segment)
+        .join(Job, Segment.job_id == Job.id)
+        .where(Segment.id == segment_id, Job.user_id == user.id)
+    )
+    segment = result.scalar_one_or_none()
+    if segment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Segment not found")
+    if segment.discarded:
+        return segment
+    if segment.status not in (SegmentStatus.FAILED, SegmentStatus.COMPLETED):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Only failed or completed segments can be discarded (current: "
+                f"'{segment.status}'). Cancel a running segment first."
+            ),
+        )
+
+    segment.discarded = True
+    await db.commit()
+    await db.refresh(segment)
+    return segment
+
+
 @router.delete("/segments/{segment_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_segment(
     segment_id: UUID,

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -143,6 +143,8 @@ class SegmentResponse(BaseModel):
     negative_prompt: Optional[str] = None
     auto_finalize: bool
     transition: Optional[str]
+    # Soft-deleted: kept for its rating, tags and notes, excluded from the video.
+    discarded: bool = False
     notes: Optional[str] = None
     rating: Optional[int] = None
     observation_tags: Optional[str] = None
@@ -313,6 +315,8 @@ class SegmentClipResponse(BaseModel):
 
 
 class SegmentTrimUpdate(BaseModel):
+    # Soft-deleted: kept for its rating, tags and notes, excluded from the video.
+    discarded: bool = False
     notes: Optional[str] = None
     rating: Optional[int] = None
     observation_tags: Optional[str] = None

--- a/app/stitch.py
+++ b/app/stitch.py
@@ -172,10 +172,16 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
             job.status = JobStatus.FINALIZING
             await db.commit()
 
-            # Fetch completed segments ordered by index
+            # Completed and NOT discarded, ordered by index. Discarded segments keep their
+            # status and their index -- the row is a record, not a deletion -- so the filter has
+            # to be explicit or the segment being removed still ends up in the cut.
             result = await db.execute(
                 select(Segment)
-                .where(Segment.job_id == job_id, Segment.status == SegmentStatus.COMPLETED)
+                .where(
+                    Segment.job_id == job_id,
+                    Segment.status == SegmentStatus.COMPLETED,
+                    Segment.discarded.is_(False),
+                )
                 .order_by(Segment.index)
             )
             segments = result.scalars().all()

--- a/tests/test_discard_segment.py
+++ b/tests/test_discard_segment.py
@@ -1,0 +1,55 @@
+"""Discarding keeps the record and removes the segment from the video.
+
+Deleting destroyed the row and with it the rating, tags and notes. That was tolerable when a
+segment was only output. It is not now that annotations are the primary evidence in every
+experiment -- a bad segment is frequently the MOST informative one, and throwing away the
+observation in order to get it out of the cut is exactly backwards.
+"""
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://x/y")
+os.environ.setdefault("JWT_SECRET", "x" * 32)
+
+from app.models import Segment
+
+
+class TestSchema:
+    def test_segments_carry_a_discarded_flag(self):
+        assert "discarded" in Segment.__table__.c
+
+    def test_it_defaults_to_live(self):
+        # A column defaulting the other way would hide every existing segment on deploy.
+        assert Segment.__table__.c.discarded.server_default.arg.lower() == "false"
+
+    def test_the_unique_index_is_partial(self):
+        """This is what lets a discarded segment 2 and its replacement both be 'segment 2'.
+
+        The discarded row keeps its index so the record reads correctly; the regenerated one
+        takes the same position in the video. Under a full constraint the replacement would have
+        to be appended at the end and would play out of order.
+        """
+        idx = next(i for i in Segment.__table__.indexes
+                   if i.name == "uq_segments_job_index_live")
+        assert idx.unique
+        assert [c.name for c in idx.columns] == ["job_id", "index"]
+        where = idx.dialect_options["postgresql"].get("where")
+        assert where is not None and "discarded" in str(where)
+
+    def test_the_old_full_constraint_is_gone(self):
+        # Leaving it would defeat the partial index entirely.
+        names = {c.name for c in Segment.__table__.constraints if c.name}
+        assert "uq_segments_job_index" not in names
+
+
+class TestVideoExcludesDiscarded:
+    def test_stitch_filters_on_discarded(self):
+        # The filter has to be explicit: a discarded segment keeps status COMPLETED and its
+        # index, so selecting on status alone would still put it in the cut -- the exact thing
+        # the user asked to remove.
+        import inspect
+
+        from app import stitch
+
+        src = inspect.getsource(stitch)
+        assert "Segment.discarded.is_(False)" in src


### PR DESCRIPTION
Deleting a segment destroyed the row — and with it the rating, tags and notes recorded against it.

That was tolerable when a segment was only output. **It is not now that annotations are the primary evidence in every experiment.** A bad segment is frequently the *most* informative one, so throwing away the observation in order to get it out of the video is exactly backwards.

`POST /segments/{id}/discard` marks the row and leaves everything else alone.

## The part that makes it work rather than just hide things

The unique constraint on `(job_id, index)` becomes **partial**, covering live rows only:

```sql
CREATE UNIQUE INDEX uq_segments_job_index_live
  ON segments (job_id, index) WHERE NOT discarded;
```

So a discarded segment 2 keeps its index — the record reads as "the discarded version of segment 2" — and **a regenerated segment can take the same position in the video**. Under the full constraint the replacement would have to be appended at the end and would play out of order, which would make the feature useless for its actual purpose.

## Decisions worth reviewing

**Output files are deliberately not removed.** The clip is the evidence behind the rating; a note saying "mouth loops for the whole segment" is worth much less if the segment can't be rewatched. Delete still exists for when the intent really is to destroy.

**Stitching filters on `discarded` explicitly.** A discarded segment keeps status `COMPLETED` and its index, so selecting on status alone would leave the very segment being removed in the cut.

**Job progress excludes discarded from both halves** — a job whose one bad segment was discarded reads 4/4, not 5/5 with one missing. **Run-time totals deliberately still include it**: that GPU time was genuinely spent, and hiding it would understate what a job cost.

471 passing, 5 new — including one asserting the partial index has its `WHERE`, since a full unique index there would silently break regeneration.

Console side not included: a Discard action on the segment row, and discarded segments shown collapsed with their annotations still readable.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct