### PR TITLE
Drop motion_keywords: the field that rewrote the prompt

### DIFF
--- a/alembic/versions/064_drop_motion_keywords.py
+++ b/alembic/versions/064_drop_motion_keywords.py
@@ -1,0 +1,39 @@
+"""Drop segments.motion_keywords
+
+Revision ID: 064
+Revises: 063
+Create Date: 2026-08-13
+
+These were never measured. The daemon derived them by substring-matching the PROMPT against a
+fixed table -- the function took the video bytes and ignored them -- and the table was loose
+enough that "move" read as dancing, "pace" as walking, "hand" as a wave. A clip of none of those
+things was logged as "Motion detected: walking, dancing, falling".
+
+The column mattered because it did not stay still: this API handed it back as
+previous_motion_keywords when the next segment was claimed, and the daemon appended canned
+phrases from it and REPLACED the prompt before building the workflow. Removing the injection
+(wanly-gpu-daemon#141) leaves this column with no reader and no writer, holding values that only
+ever described the prompt they were parsed from.
+
+Dropped rather than kept, because keeping it invites reading it as evidence of what a clip
+contains, which is the one thing it never was. motion_magnitude stays -- that is real optical
+flow over actual frames.
+
+Irreversible in practice: the downgrade restores the column but not its contents, which is the
+correct trade here since the contents were noise.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "064"
+down_revision = "063"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("segments", "motion_keywords")
+
+
+def downgrade() -> None:
+    op.add_column("segments", sa.Column("motion_keywords", sa.JSON(), nullable=True))

--- a/app/models.py
+++ b/app/models.py
@@ -146,7 +146,6 @@ class Segment(Base):
     observation_tags = mapped_column(String(500), nullable=True)
     trim_start_frames = mapped_column(Integer, nullable=False, default=0)
     trim_end_frames = mapped_column(Integer, nullable=False, default=0)
-    motion_keywords = mapped_column(JSON, nullable=True)
     motion_magnitude = mapped_column(Float, nullable=True)
     # Identity scoring, measured inline when the segment finishes generating. Two means:
     # _mean_cos is vs the START FRAME (drift of this generation), _mean_cos_ref is vs the

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -329,7 +329,6 @@ async def claim_next_segment(
     # Resolve start_image
     resolved_start_image = segment.start_image
     previous_segment = None
-    previous_motion_keywords = None
     previous_motion_magnitude = None
     reference_frames = []
     if resolved_start_image is None:
@@ -344,7 +343,6 @@ async def claim_next_segment(
             if prev_segment is not None:
                 resolved_start_image = prev_segment.last_frame_path
                 previous_segment = prev_segment
-                previous_motion_keywords = prev_segment.motion_keywords
                 previous_motion_magnitude = prev_segment.motion_magnitude
                 if prev_segment.reference_frames:
                     reference_frames = prev_segment.reference_frames.copy()
@@ -454,8 +452,6 @@ async def claim_next_segment(
         # Ground truth for identity scoring is always segment 0's start frame. No override:
         # "her" is defined by where the job began, not by a separate reference image.
         identity_ground_truth=job.starting_image,
-        motion_keywords=segment.motion_keywords,
-        previous_motion_keywords=previous_motion_keywords,
         previous_motion_magnitude=previous_motion_magnitude,
         reference_frames=reference_frames if reference_frames else None,
         lightx2v_strength_high=vsettings.lightx2v_strength_high,
@@ -532,8 +528,6 @@ async def update_segment(
         segment.error_message = body.error_message
     if body.progress_log is not None:
         segment.progress_log = body.progress_log
-    if body.motion_keywords is not None:
-        segment.motion_keywords = body.motion_keywords
     if body.motion_magnitude is not None:
         segment.motion_magnitude = body.motion_magnitude
     # Identity scores measured by the daemon at generation time. Measurement only -

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -150,7 +150,6 @@ class SegmentResponse(BaseModel):
     observation_tags: Optional[str] = None
     trim_start_frames: int
     trim_end_frames: int
-    motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
     identity_mean_cos: Optional[float] = None
     identity_mean_cos_ref: Optional[float] = None
@@ -224,9 +223,7 @@ class SegmentClaimResponse(BaseModel):
     # and is overridable, which would silently swap what "her" means mid-measurement.
     # Every segment scores against this same frame, so the numbers chain across the job.
     identity_ground_truth: Optional[str] = None
-    motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
-    previous_motion_keywords: Optional[list[str]] = None
     previous_motion_magnitude: Optional[float] = None
     reference_frames: Optional[list[str]] = None
     lightx2v_strength_high: Optional[float] = None
@@ -365,7 +362,6 @@ class SegmentStatusUpdate(BaseModel):
     last_frame_path: Optional[str] = None
     error_message: Optional[str] = None
     progress_log: Optional[str] = None
-    motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
     identity_mean_cos: Optional[float] = None
     identity_mean_cos_ref: Optional[float] = None


### PR DESCRIPTION
Companion to **wanly-gpu-daemon#141**, which removes the injection itself. This removes the field it travelled on, so nothing can revive it.

Refs DavidJBarnes/wanly-console#285

## Why

The daemon never measured these. It substring-matched the **prompt** against a fixed table — the function took the video bytes and ignored them — loosely enough that "move" read as `dancing`, "pace" as `walking`, "hand" as `hand_wave`. So a clip containing none of it was logged as `Motion detected: walking, dancing, falling`.

This API is what made that consequential: `routes/segments.py` handed the previous segment's keywords back as `previous_motion_keywords` at claim time, and the daemon appended canned phrases from them and **replaced the prompt** before building the workflow. Segment 1 of a chain ran a different prompt than the one written.

## Removed

- `segments.motion_keywords` column — migration **064**
- the ORM attribute on `Segment`
- all three schema fields (`SegmentResponse`, the claim payload, the daemon update body)
- the claim-time propagation (`previous_motion_keywords`)
- the update branch that persisted it

`motion_magnitude` / `previous_motion_magnitude` are **untouched** — real optical flow over actual frames, feeding motion matching rather than the prompt.

Dropping the column rather than leaving it dormant is deliberate: kept, it invites being read as evidence of what a clip contains, which is the one thing it never was. The downgrade restores the column but not its contents — correct here, since the contents only ever described the prompt they were parsed from.

## Verification
- `pytest` — 471 passed, 17 skipped
- `alembic heads` — single head at `064`, chain `063 -> 064`
- `grep -rn motion_keywords app/` — no matches

## Deploy order
Merge/deploy **wanly-gpu-daemon#141 to the 3090 first**. An old daemon posting `motion_keywords` after this ships is harmless (the API ignores unknown fields), but it would keep writing values nothing reads until it is updated.