### PR TITLE
Image search: whole tags that AND

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, not_, or_, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
@@ -365,59 +365,115 @@ def search_pattern(q: str) -> str:
     """The LIKE pattern for a user's query, with their wildcards neutralised.
 
     "%" and "_" are LIKE wildcards and filenames are full of both, so a query for "a_b" must not
-    silently match "axb", and "100%" must not become match-everything. The backslash is escaped
-    first, or escaping the wildcards would itself be re-escaped.
+    silently match "axb", and "100%" must not become match-everything.
     """
-    safe = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"%{safe}%"
+    return f"%{_like_escape(q)}%"
 
 
-def search_clause(q: str):
-    """Match a query against tags OR filename.
+def _like_escape(s: str) -> str:
+    """Neutralise LIKE metacharacters. Backslash first, or escaping the wildcards would itself
+    be re-escaped."""
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
-    A disjunction, not a conjunction: an untagged image has NULL tags, and requiring both would
-    leave it permanently unfindable -- which is the case this exists for.
+
+def path_clause(q: str):
+    """Match the S3 key as a substring.
+
+    Fragment matching is right here and wrong for tags. Images arrive named
+    "00111-1696092597-swapped.png" and get referred to by that number in job configs and notes,
+    so "which folder was 00111 in" has to be answerable -- and a partially remembered filename is
+    the only handle there is. Tags have exact controls of their own, so they no longer share this.
     """
-    pattern = search_pattern(q)
-    return or_(
-        ImageMeta.tags.ilike(pattern, escape="\\"),
-        ImageMeta.path.ilike(pattern, escape="\\"),
+    return ImageMeta.path.ilike(search_pattern(q), escape="\\")
+
+
+def normalise_tag(tag: str) -> str:
+    """Fold a tag to its comparison form: case- and space-insensitive.
+
+    Spaces come out because the vocabulary contains "Big dick" and the stored string is joined
+    with ", " -- inconsistent spacing around the commas is the norm, not the exception.
+    """
+    return tag.strip().lower().replace(" ", "")
+
+
+def tag_clause(tag: str):
+    """Match one WHOLE tag inside the comma-joined tags string.
+
+    Tags are stored as one text blob ("Kelly, Missionary"), so a substring match cannot tell
+    where one tag ends and the next begins. Measured on production 2026-08-14, that is not a
+    corner case: `%kelly%` matched 2,057 of 2,788 images -- 74% of the repo -- because it also
+    caught KellyYoung (1,019), KellyBangs (140) and KellyTeacher (76). Exact Kelly is 824.
+
+    Wrapping both sides in commas is what makes the boundaries real: ",kelly," cannot match
+    inside ",kellyyoung,". concat() rather than || because it is null-safe, so an untagged row
+    simply fails to match instead of poisoning the expression.
+    """
+    pattern = f"%,{_like_escape(normalise_tag(tag))},%"
+    return func.concat(",", func.replace(func.lower(ImageMeta.tags), " ", ""), ",").like(
+        pattern, escape="\\"
     )
+
+
+def image_filter(q: str | None, tags: list[str], exclude: list[str]) -> list:
+    """Every criterion ANDs. Returns clauses for .where(*clauses).
+
+    Strict conjunction, deliberately: each pill narrows. Two subject pills therefore mean "both
+    tags on one image", which is usually empty and is the honest answer -- there is no OR, so
+    "the Kelly family" is two searches rather than one. That is the agreed v1 semantic.
+    """
+    clauses = [tag_clause(t) for t in tags if t.strip()]
+    # NULL tags make NOT LIKE null, which would silently drop untagged images from every
+    # excluded search. They have nothing to exclude, so they pass.
+    clauses += [
+        or_(ImageMeta.tags.is_(None), not_(tag_clause(t)))
+        for t in exclude
+        if t.strip()
+    ]
+    if q and q.strip():
+        clauses.append(path_clause(q.strip()))
+    return clauses
 
 
 @router.get("/images/search", dependencies=[Depends(get_current_user)])
 async def search_images(
-    q: str = Query(..., min_length=1, max_length=500),
+    q: str | None = Query(None, max_length=500),
+    tags: list[str] = Query(default_factory=list),
+    exclude: list[str] = Query(default_factory=list),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
     user = Depends(get_current_user),
 ):
-    """Search images across all folders by tag or filename (case-insensitive partial match).
+    """Find images by whole tags (AND) and/or a filename fragment.
 
-    Path is matched as well as tags because the filename is often the only handle a user has.
-    Images arrive named like "00111-1696092597-swapped.png", get referenced by that name in job
-    configs, notes and conversations, and are spread across dated folders -- so "which folder was
-    00111 in" was unanswerable from the UI, and an untagged image was unfindable by any means at
-    all. Matching the path also makes a folder name a usable query, which is a free side effect
-    of storing the full key.
+    Two controls with two different jobs. `tags` and `exclude` match a tag in full, so Kelly
+    stops dragging in KellyYoung; `q` matches the S3 key as a substring, because a half-recalled
+    filename is often the only handle there is, and it is the only way an untagged image can be
+    found at all.
+
+    Everything given ANDs. `tags=Kelly&tags=Missionary` is the 102 images carrying both, not the
+    2,057 that a substring search for "kelly" used to return.
     """
-    matches = search_clause(q)
+    clauses = image_filter(q, tags, exclude)
+    if not clauses:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide q, or at least one tag — an unfiltered search is the folder listing.",
+        )
 
-    count_q = select(func.count()).select_from(ImageMeta).where(matches)
+    count_q = select(func.count()).select_from(ImageMeta).where(*clauses)
     total = (await db.execute(count_q)).scalar() or 0
 
     meta_q = (
         select(ImageMeta)
-        .where(matches)
+        .where(*clauses)
         .order_by(ImageMeta.updated_at.desc())
         .offset(offset)
         .limit(limit)
     )
     meta_rows = (await db.execute(meta_q)).scalars().all()
 
-    async def _meta(meta: ImageMeta) -> dict:
-        bucket = settings.s3_images_bucket
+    async def _meta(meta: ImageMeta) -> dict | None:
         obj = await asyncio.to_thread(head_object, meta.path)
         if not obj:
             return None
@@ -431,13 +487,56 @@ async def search_images(
             "tags": meta.tags,
         }
 
-    items = []
-    for row in meta_rows:
-        item = await _meta(row)
-        if item:
-            items.append(item)
+    # Concurrently, because this is the page's real cost. Each row needs one S3 HEAD, and a
+    # sequential await per row made a 50-result page 50 serial round trips -- far more than the
+    # query itself takes over 2,788 rows.
+    results = await asyncio.gather(*(_meta(row) for row in meta_rows))
+    items = [item for item in results if item]
 
     return {"items": items, "total": total, "limit": limit, "offset": offset}
+
+
+@router.get("/images/tag-counts", dependencies=[Depends(get_current_user)])
+async def image_tag_counts(
+    q: str | None = Query(None, max_length=500),
+    tags: list[str] = Query(default_factory=list),
+    exclude: list[str] = Query(default_factory=list),
+    db: AsyncSession = Depends(get_db),
+    user = Depends(get_current_user),
+):
+    """Every tag in use, with how many images carry it under the CURRENT filter.
+
+    Counts are what make the filter navigable rather than a guessing game: with Kelly selected,
+    the remaining tags show what actually exists inside that set, so a dead end is visible before
+    it is clicked instead of after.
+
+    Derived from what is used, not from the title_tags vocabulary. Tagging is meant to be
+    controlled, but production has drifted -- 11 tags in use are not in the vocabulary, including
+    kellyteacher on 76 images. Driving the pills from the vocabulary would make those 76 images
+    unreachable. It also surfaces the fat-fingers (`pusy`, `cowgirlowgirl`, one image each) with
+    their counts, which is the first step to cleaning them up.
+    """
+    clauses = image_filter(q, tags, exclude)
+
+    # unnest in a LATERAL rather than the target list: a set-returning function in the select
+    # list cannot then be grouped by.
+    tag_rows = (
+        func.unnest(func.string_to_array(ImageMeta.tags, ","))
+        .table_valued("tag")
+        .render_derived(name="t")
+    )
+    tag_expr = func.lower(func.btrim(tag_rows.c.tag))
+
+    stmt = (
+        select(tag_expr.label("tag"), func.count().label("count"))
+        .select_from(ImageMeta)
+        .join(tag_rows, true())
+        .where(*clauses, tag_expr != "")
+        .group_by(tag_expr)
+        .order_by(func.count().desc(), tag_expr)
+    )
+    rows = (await db.execute(stmt)).all()
+    return {"items": [{"tag": r.tag, "count": r.count} for r in rows]}
 
 
 _CONTENT_TYPES = {"png": "image/png", "jpg": "image/jpeg", "jpeg": "image/jpeg", "webp": "image/webp"}

--- a/tests/test_image_search.py
+++ b/tests/test_image_search.py
@@ -1,47 +1,29 @@
-"""Image search must match the filename, not only tags.
+"""Image search: whole tags that AND, and a filename fragment that does not.
 
-The filename is often the only handle a user has. Images arrive named like
-"00111-1696092597-swapped.png", are referred to by that name in job configs, notes and
-conversation, and are spread across dated folders -- so "which folder was 00111 in" was
-unanswerable from the UI, and an untagged image was unfindable by any means at all.
+Two controls, two jobs. `tags` matches a tag in full; `q` matches the S3 key as a substring.
 
-Measured against production before the fix: searching "00111" returned 0 results; matching the
-path as well returns 10.
+The split exists because one substring search cannot serve both. Filenames need fragments --
+images arrive named "00111-1696092597-swapped.png", get referred to by that number in job configs
+and notes, and are spread across dated folders, so "which folder was 00111 in" has to be
+answerable. Tags need boundaries: measured on production 2026-08-14, `%kelly%` matched 2,057 of
+2,788 images (74% of the repo) because it also caught KellyYoung, KellyBangs and KellyTeacher.
+Exact Kelly is 824, and Kelly AND Missionary -- previously unaskable -- is 102.
+
+The clause tests run against real Postgres, because the whole point is what the database does
+with commas and NULLs, and a rendered-SQL assertion would test the string rather than the
+behaviour.
 """
 
-from sqlalchemy import func, or_, select
-from sqlalchemy.dialects import postgresql
+import pytest
+from sqlalchemy import func, select
 
 from app.models import ImageMeta
-from app.routes.images import search_clause, search_pattern
+from app.routes.images import image_filter, normalise_tag, search_pattern
 
 
-def _sql(stmt) -> str:
-    """Render against the dialect we actually run on.
-
-    The generic dialect emits ILIKE as lower(x) LIKE lower(y), so asserting on the rendered
-    operator under the default dialect tests SQLAlchemy's fallback rather than our query.
-    """
-    return str(stmt.compile(dialect=postgresql.dialect(),
-                            compile_kwargs={"literal_binds": True}))
-
-
-class TestSearchClause:
-    def test_matches_path_as_well_as_tags(self):
-        sql = _sql(search_clause("00111"))
-        assert "image_meta.tags ILIKE" in sql
-        assert "image_meta.path ILIKE" in sql
-
-    def test_it_is_a_disjunction_not_a_conjunction(self):
-        # An untagged image has NULL tags. Requiring both would make it permanently unfindable,
-        # which is the exact case this fix exists for.
-        sql = _sql(search_clause("x"))
-        assert " OR " in sql
-        assert " AND " not in sql
-
+class TestSearchPattern:
     def test_wildcards_in_the_query_are_escaped(self):
-        # A user typing "100%" must not turn into a match-everything pattern. Asserted on the
-        # pattern rather than the rendered SQL, where literal_binds doubles % for paramstyle.
+        # A user typing "100%" must not turn into a match-everything pattern.
         assert search_pattern("100%") == "%100\\%%"
 
     def test_underscores_are_escaped(self):
@@ -52,10 +34,143 @@ class TestSearchClause:
         # Escaping the wildcards first would then re-escape their backslashes.
         assert search_pattern("a\\b") == "%a\\\\b%"
 
-    def test_count_and_page_use_the_same_predicate(self):
+
+class TestNormaliseTag:
+    def test_folds_case_and_spaces(self):
+        # The vocabulary contains "Big dick" and the stored string is joined with ", ", so
+        # spacing around commas is inconsistent in practice.
+        assert normalise_tag("  Big Dick ") == "bigdick"
+
+
+@pytest.mark.asyncio
+class TestAgainstTheDatabase:
+    async def _seed(self, db):
+        rows = [
+            ImageMeta(path="s3://b/2026-01-01/00111-kelly.png", tags="Kelly, Missionary"),
+            ImageMeta(path="s3://b/2026-01-01/00112.png", tags="KellyYoung, Doggystyle"),
+            ImageMeta(path="s3://b/2026-01-02/00113.png", tags="KellyBangs"),
+            ImageMeta(path="s3://b/2026-01-02/00114.png", tags="Kelly, Doggystyle"),
+            ImageMeta(path="s3://b/2026-01-02/00115.png", tags="Gena, Big dick"),
+            ImageMeta(path="s3://b/2026-01-03/00116-untagged.png", tags=None),
+        ]
+        db.add_all(rows)
+        await db.flush()
+
+    async def _paths(self, db, q=None, tags=(), exclude=()):
+        clauses = image_filter(q, list(tags), list(exclude))
+        rows = (await db.execute(select(ImageMeta.path).where(*clauses))).scalars().all()
+        return {p.rsplit("/", 1)[1] for p in rows}
+
+    async def test_a_tag_does_not_match_a_longer_tag_that_starts_with_it(self, db):
+        # The bug this feature exists for: Kelly returned KellyYoung and KellyBangs too.
+        await self._seed(db)
+        assert await self._paths(db, tags=["Kelly"]) == {"00111-kelly.png", "00114.png"}
+
+    async def test_tags_are_conjunctive(self, db):
+        await self._seed(db)
+        assert await self._paths(db, tags=["Kelly", "Missionary"]) == {"00111-kelly.png"}
+
+    async def test_two_tags_no_image_carries_returns_nothing(self, db):
+        # There is no OR: two subject pills mean "both on one image", which is usually empty.
+        # That is the agreed semantic, and it should be visibly empty rather than quietly unioned.
+        await self._seed(db)
+        assert await self._paths(db, tags=["Kelly", "Gena"]) == set()
+
+    async def test_matching_ignores_case_and_spacing(self, db):
+        await self._seed(db)
+        assert await self._paths(db, tags=["  bIg   dick "]) == {"00115.png"}
+
+    async def test_exclude_removes_a_tag(self, db):
+        await self._seed(db)
+        assert await self._paths(db, tags=["Kelly"], exclude=["Doggystyle"]) == {
+            "00111-kelly.png"
+        }
+
+    async def test_exclude_keeps_untagged_images(self, db):
+        # NOT LIKE against NULL is NULL, which would silently drop every untagged image from any
+        # excluded search. They have nothing to exclude, so they pass.
+        await self._seed(db)
+        assert "00116-untagged.png" in await self._paths(db, q="0011", exclude=["Kelly"])
+
+    async def test_q_matches_the_filename_as_a_fragment(self, db):
+        await self._seed(db)
+        assert await self._paths(db, q="00111") == {"00111-kelly.png"}
+
+    async def test_q_matches_a_folder_name(self, db):
+        # A free side effect of storing the full key, and a useful one.
+        await self._seed(db)
+        assert len(await self._paths(db, q="2026-01-02")) == 3
+
+    async def test_q_finds_an_untagged_image(self, db):
+        # The original reason path matching exists; tags moving to their own control must not
+        # take it away.
+        await self._seed(db)
+        assert await self._paths(db, q="untagged") == {"00116-untagged.png"}
+
+    async def test_q_no_longer_matches_tags(self, db):
+        # Deliberate change. Fragment matching is right for filenames and wrong for tags, and
+        # "kelly" as free text was returning three quarters of the repo.
+        await self._seed(db)
+        assert await self._paths(db, q="Missionary") == set()
+
+    async def test_q_and_tags_and_together(self, db):
+        await self._seed(db)
+        assert await self._paths(db, q="2026-01-02", tags=["Kelly"]) == {"00114.png"}
+
+    async def test_no_criteria_produces_no_clauses(self, db):
+        # The route turns this into a 400 rather than serving the entire repo by accident.
+        assert image_filter(None, [], []) == []
+        assert image_filter("   ", ["  "], []) == []
+
+    async def test_count_and_page_use_the_same_predicate(self, db):
         # If the count and the page query diverge, pagination reports a total it cannot deliver.
-        clause = search_clause("00111")
-        count_sql = _sql(select(func.count()).select_from(ImageMeta).where(clause))
-        page_sql = _sql(select(ImageMeta).where(clause))
-        for fragment in ("image_meta.tags ILIKE", "image_meta.path ILIKE"):
-            assert fragment in count_sql and fragment in page_sql
+        await self._seed(db)
+        clauses = image_filter(None, ["Kelly"], [])
+        total = (
+            await db.execute(select(func.count()).select_from(ImageMeta).where(*clauses))
+        ).scalar()
+        page = (await db.execute(select(ImageMeta).where(*clauses))).scalars().all()
+        assert total == len(page) == 2
+
+    async def test_a_tag_containing_a_wildcard_is_escaped(self, db):
+        # "%" in a tag must not turn into match-everything.
+        db.add(ImageMeta(path="s3://b/d/pct.png", tags="100%, Kelly"))
+        await self._seed(db)
+        assert await self._paths(db, tags=["100%"]) == {"pct.png"}
+
+
+@pytest.mark.asyncio
+class TestTagCounts:
+    async def test_counts_are_scoped_to_the_current_filter(self, db):
+        """The pills must count within the filtered set, not the whole repo.
+
+        That is what makes a dead end visible before it is clicked: with Kelly selected, a tag
+        that co-occurs with nothing simply does not appear.
+        """
+        db.add_all([
+            ImageMeta(path="s3://b/d/1.png", tags="Kelly, Missionary"),
+            ImageMeta(path="s3://b/d/2.png", tags="Kelly, Doggystyle"),
+            ImageMeta(path="s3://b/d/3.png", tags="Gena, Missionary"),
+        ])
+        await db.flush()
+
+        tag_rows = (
+            func.unnest(func.string_to_array(ImageMeta.tags, ","))
+            .table_valued("tag")
+            .render_derived(name="t")
+        )
+        tag_expr = func.lower(func.btrim(tag_rows.c.tag))
+        clauses = image_filter(None, ["Kelly"], [])
+        rows = (
+            await db.execute(
+                select(tag_expr.label("tag"), func.count().label("count"))
+                .select_from(ImageMeta)
+                .join(tag_rows, tag_expr.isnot(None))
+                .where(*clauses, tag_expr != "")
+                .group_by(tag_expr)
+            )
+        ).all()
+
+        counts = {r.tag: r.count for r in rows}
+        assert counts == {"kelly": 2, "missionary": 1, "doggystyle": 1}
+        assert "gena" not in counts


### PR DESCRIPTION
API half of DavidJBarnes/wanly-console#335. Console half follows.

## The measurement that drove it

Taken against production 2026-08-14:

| | |
|---|---|
| images (all tagged) | 2,788 |
| distinct tags in use | 41 |
| `q=kelly` returns | **2,057 — 74% of the repo** |
| exact `Kelly` | 824 |
| `Kelly` AND `Missionary` | 102 (previously unaskable) |

Tags live as one comma-joined string, so `%kelly%` had no idea where one tag ended and the next began: KellyYoung (1,019), KellyBangs (140) and KellyTeacher (76) all came back too.

## What changed

**`tags` / `exclude` — whole-tag match.** Both the stored string and the query get wrapped in commas, so `,kelly,` cannot match inside `,kellyyoung,`. Case and spacing folded (the vocabulary has "Big dick"; the joined string is inconsistently spaced). `concat()` rather than `||` because it is null-safe.

**`q` — filename/path only.** Fragment matching is right for filenames and wrong for tags. `00111` still resolves, folder names still work as queries, and an untagged image is still findable by name — that was the reason path matching exists and it is untouched.

**Everything ANDs.** No OR: two subject tags mean "both on one image", usually empty, which is the honest answer rather than a quiet union.

**`GET /images/tag-counts`** — every tag in use with its count *under the current filter*. That is what lets the console show what exists inside the current result set instead of offering dead ends. Counts are derived from usage, not from the `title_tags` vocabulary, because production has drifted: 11 tags in use aren't in the vocabulary, including `kellyteacher` on 76 images that vocabulary-driven pills would strand. It also surfaces the fat-fingers (`pusy`, `cowgirlowgirl`, one image each) with counts, which is the start of cleaning them up.

## Not changed

Storage. 2,788 rows needs no index and no migration. Taking `tags` as a list rather than a magic string means it can move to an array column or a join table later without the console noticing.

## Fixed in passing

`search_images` did an S3 HEAD **per row, sequentially** — a 50-result page was 50 serial round trips, far more than the query costs at this scale. Now concurrent.

## Verification

`pytest` — **501 passed** against real Postgres (local container; the DB-backed tests skip without one, and CI sets `REQUIRE_DB=1`).

The semantics are tested against the database rather than by asserting on rendered SQL, since the whole question is what Postgres does with commas and NULLs. Covers: Kelly not matching KellyYoung/KellyBangs, tags ANDing, two-tags-nobody-has returning empty, case/space folding, exclude, **exclude not dropping untagged images** (`NOT LIKE` against NULL is NULL), `q` still finding filenames/folders/untagged, `q` no longer matching tags, wildcards in a tag being escaped, and count/page agreeing.

## Breaking change

`q` no longer matches tags. The console must send `tags=` for tag filtering — that is the next PR, so **merge this one first**.