### PR TITLE
Re-roll segment 0 with a new seed

### DIFF
--- a/alembic/versions/065_add_segment_seed.py
+++ b/alembic/versions/065_add_segment_seed.py
@@ -1,0 +1,44 @@
+"""Give a segment a seed of its own
+
+Revision ID: 065
+Revises: 064
+Create Date: 2026-08-14
+
+Until now the seed lived only on the job. Every segment's seed was derived at claim time as
+(job.seed + index), so segment 0 was exactly job.seed and the entire job reproduced from that one
+number. That is a good property and this migration does not take it away: the new column is
+NULLABLE, nothing is backfilled, and a NULL seed still means "derive it from the job". Every
+existing row keeps the seed it always had.
+
+The column exists for the case the derivation cannot express: re-rolling a segment to see another
+take of the same prompt. The seed has to change while the position does not, and the only way to
+do that with a job-level seed is to overwrite job.seed -- which silently rewrites history. The
+archived take keeps its video, its rating and its notes, while the number that actually produced
+it is replaced by the number that produced its replacement. Every archived clip would then be
+labelled with the seed of whatever was rolled last.
+
+That is the worst thing to lose in this particular system. Seed is the dominant variable in what a
+take looks like -- expression especially, far more than the LoRA is -- so "which seed gave me
+that one?" is the question the archive exists to answer. A re-roll feature that destroys the
+answer while producing more takes to compare would be worse than not having it.
+
+Deliberately not made NOT NULL with a backfill. Writing (job.seed + index) into every existing row
+would look equivalent and would not be: it would freeze today's derivation into historical data,
+so a later change to how seeds are derived would silently disagree with rows that were never
+explicitly seeded. NULL means "this segment never asked for a particular seed", which is the truth.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "065"
+down_revision = "064"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("seed", sa.BigInteger(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "seed")

--- a/app/models.py
+++ b/app/models.py
@@ -116,6 +116,27 @@ class Segment(Base):
     # A bad segment is often the most informative one, so discarding the observation to get it out
     # of the cut is exactly backwards.
     discarded = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    # The noise seed this segment generates with, when it has one of its own.
+    #
+    # NULL is the normal case and means "derive it", which is how every segment worked before
+    # this column existed: the claim endpoint computes (job.seed + index), so segment 0 is exactly
+    # job.seed and the whole job reproduces from that one number. Existing rows are all NULL and
+    # behave exactly as they always did — this column is additive, never backfilled.
+    #
+    # It is set when a segment needs a seed that is NOT a function of its position, which today
+    # means re-rolling segment 0 to see a different take of the same prompt. Without a per-segment
+    # seed the only way to re-roll would be to overwrite job.seed, and that silently rewrites
+    # history: the archived clip keeps its video and its rating while the number that produced it
+    # is replaced by the number that produced its replacement. That is the worst possible thing to
+    # lose here, because seed is the dominant variable in what a take actually looks like —
+    # expression in particular is seed-driven far more than it is LoRA-driven — so "which seed was
+    # that one?" is the question the whole archive exists to answer.
+    #
+    # Written in the JS-safe integer range (< 2^53) rather than Postgres' full BigInteger range.
+    # A seed only has value if it can be read off the screen and used again, and JSON numbers
+    # above 2^53 are silently rounded by every browser, so a larger seed would display and
+    # round-trip as a DIFFERENT number than the one that generated the video.
+    seed = mapped_column(BigInteger, nullable=True)
     prompt = mapped_column(Text, nullable=False)
     prompt_template = mapped_column(Text, nullable=True)
     duration_seconds = mapped_column(Float, nullable=False, default=5.0)

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -18,6 +18,7 @@ from app.auth import get_current_user
 from app.config import settings
 from app.database import get_db
 from app.enums import JOB_VALID_TRANSITIONS, JobStatus, SegmentStatus, VideoStatus
+from app.seeds import new_seed
 from app.estimation import estimate_segment_time, get_estimation_rates, sum_estimated_queue_time
 from app.helpers import upload_faceswap_image
 from app.models import Job, Lora, Segment, User, Video
@@ -135,7 +136,16 @@ async def create_job(
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Invalid JSON in data field: {e}")
 
-    seed = body.seed if body.seed is not None else random.randint(0, 2**63 - 1)
+    # Drawn below 2**53, the largest integer JavaScript represents exactly.
+    #
+    # The seed is displayed on the job page and can be typed back into this dialog to reproduce a
+    # job — that round trip is the only reason to show it. Above 2**53 the browser silently rounds
+    # it, so the number on screen is NOT the number that generated the video and reproducing from
+    # it quietly produces something else. Drawing from the full BigInteger range made that near
+    # certain rather than rare: only about one seed in a thousand landed low enough to survive.
+    #
+    # Jobs created before this keep their large seeds; nothing can recover what those displayed.
+    seed = body.seed if body.seed is not None else new_seed()
 
     # New jobs go to bottom of queue
     max_priority_result = await db.execute(

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import selectinload
 
 from app.auth import get_current_user, verify_api_key, verify_api_key_or_bearer
 from app.database import get_db
+from app.seeds import new_seed
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.helpers import upload_faceswap_image
 from app.models import AppSetting, Job, Lora, Segment, User, Video, VideoSettingsPreset, Wildcard, Worker
@@ -470,10 +471,13 @@ async def claim_next_segment(
         width=job.width,
         height=job.height,
         fps=job.fps,
-        # Per-segment seed = job.seed + index: seg0 stays exactly job.seed (reproducible),
-        # later segments get decorrelated noise so they don't repeat the same motion pattern.
-        # Whole job still reproduces identically from job.seed. Modulo keeps it in range.
-        seed=(job.seed + segment.index) % (2**63 - 1),
+        # An explicit segment seed wins; otherwise derive it as job.seed + index, which keeps
+        # seg0 exactly job.seed (so the whole job still reproduces from that one number) and
+        # decorrelates later segments so they don't repeat the same motion pattern.
+        #
+        # A segment only carries its own seed when it needed one the derivation cannot express --
+        # today, a re-rolled segment 0, which must change seed without changing position.
+        seed=segment.seed if segment.seed is not None else (job.seed + segment.index) % (2**63 - 1),
         continuation_mode=continuation_mode,
         previous_output_path=prev_output_path if use_vace else None,
         vace_overlap_frames=vace_overlap,
@@ -1268,6 +1272,100 @@ async def cancel_segment(
     await db.commit()
     await db.refresh(segment)
     return segment
+
+
+@router.post("/jobs/{job_id}/reroll", response_model=SegmentResponse)
+async def reroll_first_segment(
+    job_id: UUID,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Archive segment 0 and queue a fresh one, identical except for the seed.
+
+    This is the "show me another take" button. Everything that defines the shot -- prompt, LoRAs,
+    preset, start image, faceswap, duration -- is copied verbatim so that the seed is the ONLY
+    thing that differs and the two takes are actually comparable. A wildcard prompt is copied
+    already-resolved for the same reason: re-rolling the wildcards as well would change two
+    variables at once and make the comparison worth nothing.
+
+    The old take is discarded, not deleted. It keeps its video, rating, tags and notes, and it
+    keeps them under its own seed -- which is why segments have a seed column at all. Rolling
+    repeatedly is the point of this endpoint, so an archive that relabelled every previous take
+    with the newest seed would destroy exactly the record it exists to accumulate.
+
+    Only offered while the job is a single live segment. Once there is a segment 1, segment 0 is
+    the thing it continues from, and replacing it would orphan every successor that was generated
+    from its last frame.
+
+    Trim, transition, rating, notes and observation tags are deliberately NOT copied: they
+    describe the take being archived, not the one about to be generated.
+    """
+    result = await db.execute(
+        select(Job)
+        .where(Job.id == job_id, Job.user_id == user.id)
+        .options(selectinload(Job.segments))
+    )
+    job = result.scalar_one_or_none()
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    # Live segments only. After a re-roll the job holds a discarded segment 0 beside the new one,
+    # and rolling again has to stay available -- that is the whole workflow.
+    live = [s for s in job.segments if not s.discarded]
+    if len(live) != 1 or live[0].index != 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Re-roll only applies to a job with a single segment. This job has "
+                f"{len(live)} live segments; a later segment continues from segment 0's last "
+                "frame, so replacing it would orphan them."
+            ),
+        )
+
+    old = live[0]
+    if old.status not in (SegmentStatus.FAILED, SegmentStatus.COMPLETED):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Segment 0 is '{old.status}'. Cancel it before re-rolling — otherwise the "
+                "worker finishes generating a take that has already been archived."
+            ),
+        )
+
+    old.discarded = True
+
+    fresh = Segment(
+        job_id=job.id,
+        index=0,
+        seed=new_seed(),
+        prompt=old.prompt,
+        prompt_template=old.prompt_template,
+        duration_seconds=old.duration_seconds,
+        speed=old.speed,
+        start_image=old.start_image,
+        loras=old.loras,
+        faceswap_enabled=old.faceswap_enabled,
+        faceswap_method=old.faceswap_method,
+        faceswap_source_type=old.faceswap_source_type,
+        faceswap_image=old.faceswap_image,
+        faceswap_faces_order=old.faceswap_faces_order,
+        faceswap_faces_index=old.faceswap_faces_index,
+        faceswap_model=old.faceswap_model,
+        faceswap_pixel_boost=old.faceswap_pixel_boost,
+        seed_faceswap=old.seed_faceswap,
+        negative_prompt=old.negative_prompt,
+        auto_finalize=old.auto_finalize,
+        video_preset_id=old.video_preset_id,
+    )
+    db.add(fresh)
+
+    # Back to pending or nothing claims it. The job may well be 'awaiting' (segment 0 finished
+    # and it is waiting on a decision) or 'failed'.
+    job.status = JobStatus.PENDING
+
+    await db.commit()
+    await db.refresh(fresh)
+    return fresh
 
 
 @router.post("/segments/{segment_id}/discard", response_model=SegmentResponse)

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -125,6 +125,10 @@ class SegmentResponse(BaseModel):
     id: UUID
     job_id: UUID
     index: int
+    # NULL means "derived from the job" (job.seed + index), which is every segment that was never
+    # explicitly re-rolled. Present so the console can show which seed produced which take —
+    # the question the segment archive exists to answer.
+    seed: Optional[int] = None
     prompt: str
     prompt_template: Optional[str]
     duration_seconds: float

--- a/app/seeds.py
+++ b/app/seeds.py
@@ -1,0 +1,21 @@
+"""Where seeds come from, and why they are smaller than the column that holds them."""
+
+import random
+
+# The largest integer JavaScript represents exactly. Seeds are drawn below it.
+#
+# A seed is only worth recording if it can be read back and used again: the job page shows it and
+# the create dialog accepts it, and reproducing a result by copying that number across is the
+# entire point of storing it. JSON has no integer type — every number arrives in the browser as a
+# double — so anything above 2**53 is silently rounded on the way in. The seed on screen would
+# not be the seed that generated the video, and reproducing from it would quietly produce
+# something else, with nothing anywhere reporting a problem.
+#
+# Postgres holds these in a BigInteger and could take the full 2**63. It is the display side that
+# cannot, and nine quadrillion possible seeds is not a meaningful loss.
+JS_SAFE_MAX_SEED = 2**53 - 1
+
+
+def new_seed() -> int:
+    """A fresh random seed, safe to show and to type back in."""
+    return random.randint(0, JS_SAFE_MAX_SEED)

--- a/tests/test_reroll_segment.py
+++ b/tests/test_reroll_segment.py
@@ -1,0 +1,262 @@
+"""Re-rolling segment 0: another take of the same shot, with the seed as the only difference.
+
+Run against a real database, because the things that can go wrong here are database things --
+whether the replacement can occupy index 0 while the archived take still holds it (it can: the
+unique index is partial over live rows), and whether the archived take keeps the seed that
+actually produced it.
+
+That last one is the reason segments have a seed at all. With only job.seed, re-rolling would
+overwrite it, and every previously archived take would end up labelled with the newest seed. In a
+system where the seed is the dominant variable in what a take looks like, an archive that relabels
+its own history is worse than no archive.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.enums import JobStatus, SegmentStatus
+from app.main import app
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import Job, Segment, User
+
+
+async def _user(db) -> User:
+    user = User(username=str(uuid.uuid4()), password_hash="x")
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _job_with_segment(db, user, **segment_kwargs) -> tuple[Job, Segment]:
+    job = Job(
+        user_id=user.id,
+        name="job",
+        width=480,
+        height=832,
+        fps=16,
+        seed=1234,
+        starting_image="s3://b/start.png",
+        status=JobStatus.AWAITING,
+    )
+    db.add(job)
+    await db.flush()
+
+    fields = dict(
+        job_id=job.id,
+        index=0,
+        prompt="she moves",
+        prompt_template="she {verb}",
+        duration_seconds=5.0,
+        speed=1.0,
+        loras=[{"lora_id": "abc", "high_weight": 1.0, "low_weight": 0.0}],
+        faceswap_enabled=True,
+        faceswap_image="s3://b/face.png",
+        negative_prompt="blurry",
+        video_preset_id=None,
+        status=SegmentStatus.COMPLETED,
+        output_path="s3://b/out.mp4",
+        rating=4,
+        notes="good travel",
+        trim_start_frames=3,
+    )
+    fields.update(segment_kwargs)
+    segment = Segment(**fields)
+    db.add(segment)
+    await db.flush()
+    return job, segment
+
+
+async def _reroll(db, user, job_id):
+    from httpx import ASGITransport, AsyncClient
+
+    # Every real request gets a fresh session. These tests share one so their writes can be
+    # rolled back together, so expire the job graph first -- otherwise the route sees the
+    # collection as it was loaded earlier in the test and never notices the segment the previous
+    # call added. The user is left loaded: it is handed to the route as an object, not re-queried,
+    # and expiring it would make the dependency touch the database from sync context.
+    for obj in list(db.identity_map.values()):
+        if isinstance(obj, (Job, Segment)):
+            db.expire(obj)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.post(f"/jobs/{job_id}/reroll")
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+class TestReroll:
+    async def test_it_archives_the_old_take_and_queues_a_new_one_at_index_0(self, db):
+        user = await _user(db)
+        job, old = await _job_with_segment(db, user)
+
+        resp = await _reroll(db, user, job.id)
+        assert resp.status_code == 200, resp.text
+
+        segments = (
+            await db.execute(select(Segment).where(Segment.job_id == job.id))
+        ).scalars().all()
+        assert len(segments) == 2
+        archived = next(s for s in segments if s.id == old.id)
+        fresh = next(s for s in segments if s.id != old.id)
+
+        # Both hold index 0 at once. That is what the partial unique index is for.
+        assert archived.discarded is True and archived.index == 0
+        assert fresh.discarded is False and fresh.index == 0
+        assert fresh.status == SegmentStatus.PENDING
+
+    async def test_the_new_take_carries_its_own_seed(self, db):
+        user = await _user(db)
+        job, old = await _job_with_segment(db, user)
+
+        resp = await _reroll(db, user, job.id)
+
+        assert resp.json()["seed"] is not None
+        # And the job's seed is untouched, so the archived take still reproduces from it.
+        await db.refresh(job)
+        assert job.seed == 1234
+        await db.refresh(old)
+        assert old.seed is None
+
+    async def test_the_seed_stays_inside_the_javascript_safe_range(self, db):
+        """A seed above 2**53 displays in the browser as a different number than it is.
+
+        It would round on the way through JSON, so the number shown next to a clip would not be
+        the number that generated it -- which defeats recording it at all.
+        """
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+
+        seed = (await _reroll(db, user, job.id)).json()["seed"]
+        assert 0 <= seed <= 2**53 - 1
+
+    async def test_the_shot_is_copied_so_the_seed_is_the_only_variable(self, db):
+        user = await _user(db)
+        job, old = await _job_with_segment(db, user)
+
+        body = (await _reroll(db, user, job.id)).json()
+
+        assert body["prompt"] == old.prompt  # resolved, NOT re-rolled through the wildcards
+        assert body["prompt_template"] == old.prompt_template
+        assert body["duration_seconds"] == old.duration_seconds
+        assert body["loras"] == old.loras
+        assert body["faceswap_enabled"] is True
+        assert body["faceswap_image"] == old.faceswap_image
+        assert body["negative_prompt"] == old.negative_prompt
+
+    async def test_the_annotations_of_the_old_take_are_not_copied(self, db):
+        # Rating, notes and trims describe the take being archived. Carrying them over would
+        # attribute one take's judgement to another one that has not been watched yet.
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+
+        body = (await _reroll(db, user, job.id)).json()
+
+        assert body["rating"] is None
+        assert body["notes"] is None
+        assert body["trim_start_frames"] == 0
+        assert body["output_path"] is None
+
+    async def test_the_job_goes_back_to_pending_so_a_worker_claims_it(self, db):
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+
+        await _reroll(db, user, job.id)
+
+        await db.refresh(job)
+        assert job.status == JobStatus.PENDING
+
+    async def test_rolling_again_is_allowed_with_an_archived_take_present(self, db):
+        """The workflow is rolling repeatedly, so "one segment" has to mean one LIVE segment."""
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+
+        await _reroll(db, user, job.id)
+        # The new take has to have finished before it can be archived in turn.
+        fresh = (
+            await db.execute(
+                select(Segment).where(Segment.job_id == job.id, Segment.discarded.is_(False))
+            )
+        ).scalar_one()
+        fresh.status = SegmentStatus.COMPLETED
+        await db.flush()
+
+        resp = await _reroll(db, user, job.id)
+        assert resp.status_code == 200
+
+        live = (
+            await db.execute(
+                select(Segment).where(Segment.job_id == job.id, Segment.discarded.is_(False))
+            )
+        ).scalars().all()
+        assert len(live) == 1
+        assert len(
+            (await db.execute(select(Segment).where(Segment.job_id == job.id))).scalars().all()
+        ) == 3
+
+    async def test_a_job_with_a_successor_segment_is_refused(self, db):
+        """Segment 1 was generated from segment 0's last frame. Replacing 0 orphans it."""
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+        db.add(Segment(job_id=job.id, index=1, prompt="p", status=SegmentStatus.COMPLETED))
+        await db.flush()
+
+        resp = await _reroll(db, user, job.id)
+        assert resp.status_code == 400
+        assert "single segment" in resp.json()["detail"]
+
+    async def test_a_running_segment_is_refused(self, db):
+        # Otherwise the worker keeps generating a take that has already been archived.
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user, status=SegmentStatus.PROCESSING)
+
+        resp = await _reroll(db, user, job.id)
+        assert resp.status_code == 400
+        assert "Cancel it" in resp.json()["detail"]
+
+    async def test_another_users_job_is_not_found(self, db):
+        owner = await _user(db)
+        intruder = await _user(db)
+        job, _ = await _job_with_segment(db, owner)
+
+        resp = await _reroll(db, intruder, job.id)
+        assert resp.status_code == 404
+
+
+class TestSeedRange:
+    def test_new_seeds_are_javascript_safe(self):
+        """Job seeds used to come from the full 2**63 range, which the browser cannot show.
+
+        The seed is displayed on the job page and can be typed back into the create dialog to
+        reproduce a job -- the only reason to show it at all. Above 2**53 it is silently rounded
+        on the way through JSON, so that round trip produced a DIFFERENT seed with nothing
+        reporting a problem. Drawing from the full range made that near certain rather than rare:
+        roughly one seed in a thousand landed low enough to survive.
+        """
+        from app.seeds import JS_SAFE_MAX_SEED, new_seed
+
+        assert JS_SAFE_MAX_SEED == 2**53 - 1
+        for _ in range(200):
+            seed = new_seed()
+            assert 0 <= seed <= JS_SAFE_MAX_SEED
+            # The round trip a browser performs. Equality here is the whole property.
+            assert int(float(seed)) == seed
+
+
+@pytest.mark.asyncio
+class TestClaimUsesTheSegmentSeed:
+    async def test_an_explicit_seed_wins_over_the_derived_one(self, db):
+        """The claim payload is where the seed actually reaches the worker."""
+        from app.routes.segments import claim_next_segment  # noqa: F401  (import guard)
+
+        user = await _user(db)
+        job, seg = await _job_with_segment(db, user, seed=42)
+        assert seg.seed == 42
+        # The derivation would have produced job.seed + index = 1234.
+        assert (job.seed + seg.index) % (2**63 - 1) == 1234


### PR DESCRIPTION
API half of DavidJBarnes/wanly-console#336. Console button follows.

`POST /jobs/{job_id}/reroll` — archive segment 0, queue an identical one with a new seed.

## The finding that shaped it

There is no per-segment seed. `Job.seed` is the only one, and each segment derives its own at claim time as `(job.seed + index)`. So "re-roll segment 0" could only mean **overwriting `job.seed`** — which silently rewrites history: the archived take keeps its video, rating and notes, while the number that produced it is replaced by the number that produced its replacement. Roll three times and all three archived takes claim the newest seed.

That is the worst thing to lose in this system specifically, since seed is the dominant variable in how a take turns out — expression especially. So segments now carry their own optional seed.

**Nullable, no backfill.** NULL means "derive from the job", which is what every existing segment does and continues to do. Writing `(job.seed + index)` into old rows would look equivalent and isn't — it freezes today's derivation into historical data.

## Semantics

- **Copied verbatim:** prompt, prompt_template, LoRAs, preset, start image, faceswap settings, duration, speed, negative prompt, auto_finalize. The seed is the only variable.
- **Wildcards are NOT re-rolled** — the resolved prompt is copied. Re-rolling them would change two variables at once and make the comparison worthless.
- **Not copied:** rating, notes, tags, trims, transition, output. They describe the take being archived.
- **Gate:** exactly one *live* segment at index 0, completed or failed. Live, because after a roll the job holds an archived take beside the new one and rolling again is the point. Refused once segment 1 exists (it was generated from segment 0's last frame — replacing 0 orphans it) and refused while running (the worker would finish generating something already archived).
- Job goes back to `pending` so a worker claims it.

Migration **065**. The partial unique index from #063 already permits an archived segment 0 and its replacement to both hold index 0 — the schema was ready for this.

## A live bug found on the way, fixed here

New job seeds were drawn from the full `2**63` range. But the seed is **displayed** on the job page and can be **typed back** into the create dialog to reproduce a job — that round trip is the only reason to show it. JSON has no integer type, so anything above `2**53` is silently rounded by the browser: **the seed on screen was not the seed that generated the video**, and reproducing from it quietly produced something else. Only ~1 seed in 1,000 was small enough to survive.

New seeds now come from `app/seeds.new_seed()` (below 2**53). Existing jobs keep their large seeds — what those displayed is unrecoverable. Shout if you would rather I split this out.

## Verification

`pytest` — **513 passed** against real Postgres. `alembic heads` — single head at 065.

The re-roll tests drive the real endpoint over HTTP against a real database, since the interesting failures are database ones: that the archived take and its replacement both hold index 0, that `job.seed` is untouched and the archived take keeps a NULL (derived) seed, that the shot is copied but the annotations are not, that rolling twice works with an archived take present, and that successor/running/other-user cases are refused. Plus the JS round trip (`int(float(seed)) == seed`) over 200 draws.