### PR TITLE
Record the archived take's seed; send seeds as strings

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -1332,6 +1332,14 @@ async def reroll_first_segment(
             ),
         )
 
+    # Stamp the outgoing take with the seed it actually ran on, if it was relying on the
+    # derivation. NULL means "derive from the job", which is unambiguous while a job has one take
+    # and stops being so the moment it has several: the archive exists to answer "which seed gave
+    # me that one", and an archived clip whose seed has to be recomputed from context is a worse
+    # answer than a recorded number. Same value the worker used -- this records it, it does not
+    # change it.
+    if old.seed is None:
+        old.seed = (job.seed + old.index) % (2**63 - 1)
     old.discarded = True
 
     fresh = Segment(

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class SegmentCreate(BaseModel):
@@ -125,10 +125,25 @@ class SegmentResponse(BaseModel):
     id: UUID
     job_id: UUID
     index: int
-    # NULL means "derived from the job" (job.seed + index), which is every segment that was never
-    # explicitly re-rolled. Present so the console can show which seed produced which take —
-    # the question the segment archive exists to answer.
-    seed: Optional[int] = None
+    # A STRING, not a number, and the type is the point.
+    #
+    # Seeds are identifiers: their only use is being read off the screen and used again. They are
+    # stored as BigInteger and 95% of existing jobs (1,645 of 1,724, measured 2026-08-14) have a
+    # seed above 2**53, which is the largest integer JSON survives intact — every browser silently
+    # rounds anything larger. Sent as a number, the seed displayed beside a clip would not be the
+    # seed that generated it, and nothing anywhere would report a problem. Sent as a string it is
+    # exact for every value, and no client does arithmetic on it anyway.
+    #
+    # NULL means "derived from the job" (job.seed + index) — a segment that never asked for a
+    # particular seed. Archiving a take stamps the derived value in, so anything in the archive
+    # carries its own answer.
+    seed: Optional[str] = None
+
+    @field_validator("seed", mode="before")
+    @classmethod
+    def _seed_to_string(cls, v: object) -> Optional[str]:
+        """The column is an integer; the wire format is not."""
+        return None if v is None else str(v)
     prompt: str
     prompt_template: Optional[str]
     duration_seconds: float

--- a/tests/test_reroll_segment.py
+++ b/tests/test_reroll_segment.py
@@ -118,11 +118,9 @@ class TestReroll:
         resp = await _reroll(db, user, job.id)
 
         assert resp.json()["seed"] is not None
-        # And the job's seed is untouched, so the archived take still reproduces from it.
+        # And the job's seed is untouched.
         await db.refresh(job)
         assert job.seed == 1234
-        await db.refresh(old)
-        assert old.seed is None
 
     async def test_the_seed_stays_inside_the_javascript_safe_range(self, db):
         """A seed above 2**53 displays in the browser as a different number than it is.
@@ -134,7 +132,8 @@ class TestReroll:
         job, _ = await _job_with_segment(db, user)
 
         seed = (await _reroll(db, user, job.id)).json()["seed"]
-        assert 0 <= seed <= 2**53 - 1
+        assert isinstance(seed, str), "seeds go over the wire as strings; see the schema"
+        assert 0 <= int(seed) <= 2**53 - 1
 
     async def test_the_shot_is_copied_so_the_seed_is_the_only_variable(self, db):
         user = await _user(db)
@@ -162,6 +161,42 @@ class TestReroll:
         assert body["notes"] is None
         assert body["trim_start_frames"] == 0
         assert body["output_path"] is None
+
+    async def test_the_archived_take_is_stamped_with_the_seed_it_ran_on(self, db):
+        """A NULL seed means "derive from the job", which stops being unambiguous once a job has
+        several takes. Archiving records the number rather than leaving it to be recomputed."""
+        user = await _user(db)
+        job, old = await _job_with_segment(db, user)
+        assert old.seed is None
+
+        await _reroll(db, user, job.id)
+
+        await db.refresh(old)
+        # Exactly what the worker was handed: job.seed + index.
+        assert old.seed == 1234
+
+    async def test_an_already_stamped_seed_is_not_overwritten(self, db):
+        # Re-rolling a take that was itself a re-roll must not relabel it.
+        user = await _user(db)
+        job, old = await _job_with_segment(db, user, seed=99)
+
+        await _reroll(db, user, job.id)
+
+        await db.refresh(old)
+        assert old.seed == 99
+
+    async def test_a_large_seed_survives_the_wire_exactly(self, db):
+        """95% of existing jobs have a seed above 2**53. As a JSON number it would round."""
+        user = await _user(db)
+        job, old = await _job_with_segment(db, user, seed=9223372036854775801)
+
+        body = (await _reroll(db, user, job.id)).json()
+        assert body["seed"] is not None
+
+        await db.refresh(old)
+        assert old.seed == 9223372036854775801
+        # The value a client reads back has to equal the value stored, digit for digit.
+        assert str(old.seed) == "9223372036854775801"
 
     async def test_the_job_goes_back_to_pending_so_a_worker_claims_it(self, db):
         user = await _user(db)


### PR DESCRIPTION
Follow-up to #193, from testing the re-roll on a real job. Both fixes serve the same question — *which seed produced that clip?* — which the archive exists to answer and currently cannot.

## 1. Archiving stamps the seed

A NULL seed means "derive from the job" (`job.seed + index`). That is unambiguous while a job has one take, and stops being so the moment it has several: the archived clip keeps its video, rating and notes, but its seed has to be recomputed from context — so the console showed a seed on the new take and nothing on the old one.

Re-roll now writes the derived value onto the outgoing take. It is exactly what the worker was handed; this records it rather than changing it. A take that already carries its own seed is left alone, so re-rolling a re-roll does not relabel history.

## 2. Seeds are strings on the wire

Measured against production today:

| | |
|---|---|
| jobs | 1,724 |
| **jobs whose seed exceeds 2^53** | **1,645 (95%)** |

2^53 is the largest integer JSON survives intact — every browser silently rounds anything larger. Sent as a number, the seed shown next to a clip is **not the seed that generated it**, and nothing reports a problem. Stamping archived takes would have put that wrong number on 95% of them.

So `SegmentResponse.seed` is now a string. It is exact for every value, and no client does arithmetic on a seed — it is an identifier, not a quantity.

Only the console-facing schema changes. The worker's claim payload keeps an integer: it feeds the sampler, and Python has no precision problem.

## Note on the JS-safe range

#193 made *new* seeds small enough to survive a round trip, which is still worth having for `job.seed` (typed back into the create dialog). This is the complementary half: it makes the 95% of **existing** seeds displayable correctly, which no range change can retroactively do.

## Verification

`pytest` — **516 passed** against real Postgres, including: the archived take is stamped with `job.seed + index`, an already-stamped seed is not overwritten, and a 19-digit seed survives the wire digit for digit.

Console PR follows — it collapses archived takes under their live segment and reads seeds as strings.