### PR TITLE
Backfill the seed on takes archived before seeds were recorded

### DIFF
--- a/alembic/versions/066_backfill_archived_take_seeds.py
+++ b/alembic/versions/066_backfill_archived_take_seeds.py
@@ -1,0 +1,50 @@
+"""Record the seed on takes that were archived before seeds were recorded
+
+Revision ID: 066
+Revises: 065
+Create Date: 2026-08-14
+
+Re-roll stamps the outgoing take with the seed it ran on, but that only started when the endpoint
+learned to do it. Takes archived before then still carry NULL, which means "derive it from the
+job" -- a statement that was unambiguous when a job had one take and stops being so once it has
+several. In the collapsed list of previous takes they show no seed at all, which is precisely the
+question that view exists to answer.
+
+The value is not a guess. Until a segment carried its own seed, the worker was handed
+(job.seed + index) at claim time, so this writes down what actually generated those clips.
+
+Live segments are deliberately left NULL. Their seed is still derived, and it is still
+unambiguous while they hold their position -- and NULL there keeps meaning "never asked for a
+particular seed", which is the honest record. They get stamped if and when they are archived.
+
+The arithmetic runs in `numeric`, not `bigint`. A job seed can be within a few of 2**63-1 (95% of
+them were drawn from the full range), so `job.seed + index` can overflow bigint and abort the
+whole migration before the modulo ever brings it back into range. Postgres does not wrap on
+overflow, it raises.
+"""
+from alembic import op
+
+revision = "066"
+down_revision = "065"
+branch_labels = None
+depends_on = None
+
+# One source of truth for the expression, so the test can execute exactly what ships.
+BACKFILL_SQL = """
+UPDATE segments AS s
+SET seed = ((j.seed::numeric + s.index) % 9223372036854775807)::bigint
+FROM jobs AS j
+WHERE j.id = s.job_id
+  AND s.discarded
+  AND s.seed IS NULL
+"""
+
+
+def upgrade() -> None:
+    op.execute(BACKFILL_SQL)
+
+
+def downgrade() -> None:
+    # Not reversible: which archived takes were stamped by this and which were stamped on archive
+    # is not recorded, and clearing both would lose provenance that was correct.
+    pass

--- a/tests/test_backfill_archived_seeds.py
+++ b/tests/test_backfill_archived_seeds.py
@@ -1,0 +1,143 @@
+"""Migration 066: archived takes that predate seed recording get the seed they ran on.
+
+Executed against a real database rather than asserted as a string, because the two things that
+can go wrong are both database behaviours: bigint overflow on a large job seed, and touching rows
+the migration is supposed to leave alone.
+"""
+
+import importlib.util
+import pathlib
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+
+from app.enums import JobStatus, SegmentStatus
+from app.models import Job, Segment, User
+
+_spec = importlib.util.spec_from_file_location(
+    "migration_066",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "alembic/versions/066_backfill_archived_take_seeds.py",
+)
+_migration = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_migration)
+BACKFILL_SQL = _migration.BACKFILL_SQL
+
+
+async def _job(db, seed: int) -> Job:
+    user = User(username=str(uuid.uuid4()), password_hash="x")
+    db.add(user)
+    await db.flush()
+    job = Job(
+        user_id=user.id, name="j", width=480, height=832, fps=16, seed=seed,
+        status=JobStatus.AWAITING,
+    )
+    db.add(job)
+    await db.flush()
+    return job
+
+
+async def _segment(db, job, index: int, discarded: bool, seed: int | None = None) -> Segment:
+    seg = Segment(
+        job_id=job.id, index=index, prompt="p", status=SegmentStatus.COMPLETED,
+        discarded=discarded, seed=seed,
+    )
+    db.add(seg)
+    await db.flush()
+    return seg
+
+
+@pytest.mark.asyncio
+class TestBackfill:
+    async def test_an_archived_take_gets_the_seed_it_ran_on(self, db):
+        # Until a segment carried its own seed, the worker was handed job.seed + index.
+        job = await _job(db, 1000)
+        seg = await _segment(db, job, index=2, discarded=True)
+
+        await db.execute(text(BACKFILL_SQL))
+
+        await db.refresh(seg)
+        assert seg.seed == 1002
+
+    async def test_a_live_segment_is_left_alone(self, db):
+        """Live segments keep deriving. NULL there means "never asked for a particular seed",
+        which is the honest record while the segment still holds its position."""
+        job = await _job(db, 1000)
+        seg = await _segment(db, job, index=0, discarded=False)
+
+        await db.execute(text(BACKFILL_SQL))
+
+        await db.refresh(seg)
+        assert seg.seed is None
+
+    async def test_an_already_recorded_seed_is_not_overwritten(self, db):
+        # A take archived after stamping shipped already carries the truth.
+        job = await _job(db, 1000)
+        seg = await _segment(db, job, index=0, discarded=True, seed=150488800771430)
+
+        await db.execute(text(BACKFILL_SQL))
+
+        await db.refresh(seg)
+        assert seg.seed == 150488800771430
+
+    async def test_a_seed_at_the_top_of_the_range_does_not_overflow(self, db):
+        """95% of job seeds came from the full 2**63 range, so job.seed + index can exceed what
+        bigint holds. Postgres raises on overflow rather than wrapping, which would abort the
+        entire migration — hence the numeric cast."""
+        job = await _job(db, 9223372036854775800)
+        seg = await _segment(db, job, index=7, discarded=True)
+
+        await db.execute(text(BACKFILL_SQL))
+
+        await db.refresh(seg)
+        # (9223372036854775800 + 7) % (2**63 - 1) == 0
+        assert seg.seed == (9223372036854775800 + 7) % (2**63 - 1)
+
+    async def test_it_matches_what_the_reroll_endpoint_writes(self, db):
+        # Two code paths, one meaning. If they diverge, the same clip gets two different answers.
+        job = await _job(db, 4611686018427387904)
+        seg = await _segment(db, job, index=3, discarded=True)
+
+        await db.execute(text(BACKFILL_SQL))
+
+        await db.refresh(seg)
+        assert seg.seed == (job.seed + seg.index) % (2**63 - 1)
+
+    async def test_it_does_not_reach_across_jobs(self, db):
+        job_a = await _job(db, 100)
+        job_b = await _job(db, 999999)
+        seg = await _segment(db, job_a, index=1, discarded=True)
+        await _segment(db, job_b, index=1, discarded=True)
+
+        await db.execute(text(BACKFILL_SQL))
+
+        await db.refresh(seg)
+        assert seg.seed == 101
+
+    async def test_running_it_twice_changes_nothing(self, db):
+        # Alembic will not, but a hand re-run during a repair might.
+        job = await _job(db, 1000)
+        seg = await _segment(db, job, index=0, discarded=True)
+
+        await db.execute(text(BACKFILL_SQL))
+        await db.refresh(seg)
+        first = seg.seed
+        await db.execute(text(BACKFILL_SQL))
+        await db.refresh(seg)
+
+        assert seg.seed == first == 1000
+
+    async def test_every_archived_take_ends_up_with_a_seed(self, db):
+        job = await _job(db, 1000)
+        for i in range(3):
+            await _segment(db, job, index=i, discarded=True)
+
+        await db.execute(text(BACKFILL_SQL))
+
+        rows = (
+            await db.execute(
+                select(Segment.seed).where(Segment.job_id == job.id, Segment.discarded)
+            )
+        ).scalars().all()
+        assert all(s is not None for s in rows)


### PR DESCRIPTION
David hit this straight after #194 shipped: the first re-roll's archived take shows no seed.

## Why

Stamping only started when the re-roll endpoint learned to do it. Anything archived before that still carries NULL — which means "derive from the job", a statement that was unambiguous when a job had one take and stops being so once it has several. Measured on production just now: **4 of 5 archived takes have no seed**.

Migration **066** backfills them.

The value is not a guess: until a segment could carry its own seed, the worker was handed `(job.seed + index)` at claim time. This writes down what actually generated those clips, and it is the same expression the endpoint writes today — there is a test asserting the two agree, because two code paths giving one clip two different answers would be worse than the gap.

## Live segments stay NULL

Deliberately. Their seed is still derived and still unambiguous while they hold their position, and NULL there keeps meaning "this segment never asked for a particular seed". They get stamped if and when they are archived.

## The bit that would have bitten

The arithmetic runs in `numeric`, not `bigint`. 95% of job seeds came from the full 2^63 range, so `job.seed + index` can exceed what bigint holds — and Postgres **raises on overflow rather than wrapping**, which in a migration means aborting the whole thing before the modulo brings the value back into range. There is a test with a job seed 7 below the ceiling.

## Verification

`pytest` — **524 passed** against real Postgres, 8 of them driving the migration's actual SQL (imported from the migration module, so the test executes exactly what ships): stamping, live rows untouched, already-recorded seeds untouched, top-of-range without overflow, agreement with the endpoint, no cross-job leakage, and idempotence.