### PR TITLE
Cover the claim endpoint end-to-end; fix discarded segments being claimable

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -274,14 +274,21 @@ async def claim_next_segment(
     #   kind="hologram" -> CPU-only reprocess carriers: holograms + smashcut (claimable even on
     #                      FINALIZED/FINALIZING jobs)
     #   kind=None       -> either (legacy combined behavior)
+    #
+    # Every branch excludes discarded segments. Status alone does not: a discarded segment keeps
+    # the status it was discarded in, and retrying a failed one puts it back to PENDING — at
+    # which point the worker regenerates a take the operator has already archived, silently
+    # spending GPU time on a clip nobody asked for.
     if kind == "hologram":
         where = (
             Segment.status == SegmentStatus.PENDING,
+            Segment.discarded.is_(False),
             Segment.reprocess_type.in_(_CPU_REPROCESS_TYPES),
         )
     elif kind == "gpu":
         where = (
             Segment.status == SegmentStatus.PENDING,
+            Segment.discarded.is_(False),
             Job.status.in_([JobStatus.PENDING, JobStatus.PROCESSING]),
             # real generations (reprocess_type NULL) + GPU reprocess (faceswap); exclude CPU carriers.
             # NULL NOT IN (...) is NULL (excludes), so OR the NULL case in explicitly.
@@ -293,6 +300,7 @@ async def claim_next_segment(
     else:
         where = (
             Segment.status == SegmentStatus.PENDING,
+            Segment.discarded.is_(False),
             or_(
                 Job.status.in_([JobStatus.PENDING, JobStatus.PROCESSING]),
                 Segment.reprocess_type.in_(_CPU_REPROCESS_TYPES),
@@ -861,6 +869,14 @@ async def retry_segment(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Only failed segments can be retried (current: '{segment.status}')",
+        )
+    # Retrying an archived take asks for a clip that was deliberately thrown away. Claiming
+    # already refuses to hand one out, so without this the retry would look like it worked and
+    # then sit PENDING forever.
+    if segment.discarded:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="This take was discarded. Restore it before retrying, or re-roll instead.",
         )
 
     segment.status = SegmentStatus.PENDING

--- a/tests/test_claim_endpoint.py
+++ b/tests/test_claim_endpoint.py
@@ -1,0 +1,301 @@
+"""End-to-end coverage for GET /segments/next — the only door into the system.
+
+Written after this endpoint returned 500 in production for every claim against a re-rolled job
+(#196) and stopped the 3090 dead. The bug was one missing predicate, and nothing caught it because
+nothing here called the endpoint: the existing tests covered its auth, and its stale-reclaim WHERE
+clause rebuilt separately in a test file. A 296-line function that every generation passes through
+had no test that ran it.
+
+What makes this endpoint different from the rest of the API is the failure mode. A 500 anywhere
+else is a broken page. Here the daemon polls, gets a 500, and the queue stops — no work runs and
+nothing raises an alarm except a human noticing the GPU is idle. So these tests are deliberately
+about the shapes that make it throw or return the wrong row, not about response formatting.
+
+They drive the real route over HTTP against a real database, because the failure was a database
+result-cardinality error that no amount of mocking would have produced.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.auth import get_current_user, verify_api_key
+from app.database import get_db
+from app.enums import JobStatus, SegmentStatus
+from app.main import app
+from app.models import Job, Segment, User, Worker
+
+WORKER_ID = uuid.UUID("95d5dffe-881b-46a6-bd5f-8930b9a66b75")
+
+
+async def _user(db) -> User:
+    user = User(username=str(uuid.uuid4()), password_hash="x")
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _job(db, user=None, *, seed=1000, priority=0, status=JobStatus.PENDING,
+               starting_image="s3://b/start.png") -> Job:
+    user = user or await _user(db)
+    job = Job(
+        user_id=user.id, name="j", width=480, height=832, fps=16, seed=seed,
+        priority=priority, status=status, starting_image=starting_image,
+    )
+    db.add(job)
+    await db.flush()
+    return job
+
+
+async def _segment(db, job, index=0, *, status=SegmentStatus.PENDING, discarded=False,
+                   last_frame=None, seed=None, start_image=None, reprocess_type=None,
+                   created_at=None) -> Segment:
+    seg = Segment(
+        job_id=job.id, index=index, prompt="p", status=status, discarded=discarded,
+        last_frame_path=last_frame, seed=seed, start_image=start_image,
+        reprocess_type=reprocess_type,
+    )
+    if created_at is not None:
+        seg.created_at = created_at
+    db.add(seg)
+    await db.flush()
+    return seg
+
+
+async def _claim(db, kind="gpu"):
+    """Call the endpoint exactly as the daemon does."""
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[verify_api_key] = lambda: None
+    try:
+        # Every real request gets a fresh session; these share one so writes roll back together.
+        for obj in list(db.identity_map.values()):
+            if isinstance(obj, (Job, Segment, Worker)):
+                db.expire(obj)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.get(
+                "/segments/next",
+                params={"worker_id": str(WORKER_ID), "worker_name": "3090.zero", "kind": kind},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+class TestTheIncident:
+    async def test_a_re_rolled_job_with_a_successor_can_still_be_claimed(self, db):
+        """The production 500 (#196), from the outside.
+
+        A re-roll archives a take and puts its replacement at the same index, so a job rolled six
+        times has seven rows at index 0. Resolving "the previous segment" by index alone then
+        raises MultipleResultsFound — on the claim path, which stops the queue rather than
+        degrading.
+        """
+        job = await _job(db)
+        for _ in range(6):
+            await _segment(db, job, 0, status=SegmentStatus.COMPLETED, discarded=True,
+                           last_frame="s3://b/thrown-away.png")
+        await _segment(db, job, 0, status=SegmentStatus.COMPLETED, last_frame="s3://b/kept.png")
+        await _segment(db, job, 1)
+
+        resp = await _claim(db)
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() is not None
+
+    async def test_the_successor_starts_from_the_live_take_not_an_archived_one(self, db):
+        # Getting one row is not enough — it has to be the right one. Continuing from a frame
+        # that was thrown away would generate silently wrong video.
+        job = await _job(db)
+        await _segment(db, job, 0, status=SegmentStatus.COMPLETED, discarded=True,
+                       last_frame="s3://b/thrown-away.png")
+        await _segment(db, job, 0, status=SegmentStatus.COMPLETED, last_frame="s3://b/kept.png")
+        await _segment(db, job, 1)
+
+        body = (await _claim(db)).json()
+
+        assert body["start_image"] == "s3://b/kept.png"
+
+
+@pytest.mark.asyncio
+class TestWhatGetsClaimed:
+    async def test_a_pending_segment_is_claimed_and_marked(self, db):
+        job = await _job(db)
+        seg = await _segment(db, job, 0)
+
+        body = (await _claim(db)).json()
+
+        assert body["id"] == str(seg.id)
+        await db.refresh(seg)
+        assert seg.status == SegmentStatus.CLAIMED
+        assert seg.worker_id == WORKER_ID
+        assert seg.worker_name == "3090.zero"
+        assert seg.claimed_at is not None
+
+    async def test_nothing_to_do_returns_no_segment(self, db):
+        await _job(db)
+        resp = await _claim(db)
+        assert resp.status_code == 200
+        assert resp.json() is None
+
+    async def test_a_discarded_segment_is_never_claimed(self, db):
+        # An archived take is evidence, not work. Claiming one would regenerate a clip the
+        # operator has already thrown away.
+        job = await _job(db)
+        await _segment(db, job, 0, discarded=True)
+
+        assert (await _claim(db)).json() is None
+
+    async def test_an_already_claimed_segment_is_not_handed_out_twice(self, db):
+        job = await _job(db)
+        await _segment(db, job, 0, status=SegmentStatus.CLAIMED)
+
+        assert (await _claim(db)).json() is None
+
+    async def test_the_job_moves_to_processing(self, db):
+        job = await _job(db, status=JobStatus.PENDING)
+        await _segment(db, job, 0)
+
+        await _claim(db)
+
+        await db.refresh(job)
+        assert job.status == JobStatus.PROCESSING
+
+    async def test_lower_priority_number_goes_first(self, db):
+        user = await _user(db)
+        later = await _job(db, user, priority=5)
+        first = await _job(db, user, priority=1)
+        await _segment(db, later, 0)
+        wanted = await _segment(db, first, 0)
+
+        body = (await _claim(db)).json()
+
+        assert body["id"] == str(wanted.id)
+
+
+@pytest.mark.asyncio
+class TestStartImageResolution:
+    async def test_segment_zero_starts_from_the_job_image(self, db):
+        job = await _job(db, starting_image="s3://b/job-start.png")
+        await _segment(db, job, 0)
+
+        assert (await _claim(db)).json()["start_image"] == "s3://b/job-start.png"
+
+    async def test_a_later_segment_starts_from_the_previous_last_frame(self, db):
+        job = await _job(db)
+        await _segment(db, job, 0, status=SegmentStatus.COMPLETED, last_frame="s3://b/0-last.png")
+        await _segment(db, job, 1)
+
+        assert (await _claim(db)).json()["start_image"] == "s3://b/0-last.png"
+
+    async def test_an_explicit_start_image_wins(self, db):
+        job = await _job(db)
+        await _segment(db, job, 0, start_image="s3://b/chosen.png")
+
+        assert (await _claim(db)).json()["start_image"] == "s3://b/chosen.png"
+
+
+@pytest.mark.asyncio
+class TestSeed:
+    async def test_it_derives_from_the_job_when_the_segment_has_none(self, db):
+        # seg0 is exactly job.seed, so the whole job reproduces from that one number.
+        job = await _job(db, seed=1000)
+        await _segment(db, job, 0)
+
+        assert (await _claim(db)).json()["seed"] == 1000
+
+    async def test_a_later_segment_is_decorrelated_by_its_index(self, db):
+        job = await _job(db, seed=1000)
+        await _segment(db, job, 0, status=SegmentStatus.COMPLETED, last_frame="s3://b/0.png")
+        await _segment(db, job, 1)
+
+        assert (await _claim(db)).json()["seed"] == 1001
+
+    async def test_a_segments_own_seed_wins(self, db):
+        # What a re-roll writes: same position, different seed.
+        job = await _job(db, seed=1000)
+        await _segment(db, job, 0, seed=150488800771430)
+
+        assert (await _claim(db)).json()["seed"] == 150488800771430
+
+    async def test_the_worker_gets_an_integer_not_a_string(self, db):
+        # The console's schema sends seeds as strings for display precision. This payload feeds
+        # the sampler, and it must not inherit that.
+        job = await _job(db, seed=1000)
+        await _segment(db, job, 0)
+
+        assert isinstance((await _claim(db)).json()["seed"], int)
+
+
+@pytest.mark.asyncio
+class TestKindRouting:
+    async def test_gpu_does_not_claim_cpu_reprocess_carriers(self, db):
+        # The CPU track runs concurrently with generation; a GPU worker taking a hologram
+        # carrier would idle the GPU on CPU work.
+        job = await _job(db)
+        await _segment(db, job, 1000, reprocess_type="ar_hologram")
+
+        assert (await _claim(db, kind="gpu")).json() is None
+
+    async def test_hologram_claims_only_carriers(self, db):
+        job = await _job(db)
+        await _segment(db, job, 0)
+        carrier = await _segment(db, job, 1000, reprocess_type="ar_hologram")
+
+        body = (await _claim(db, kind="hologram")).json()
+
+        assert body is not None and body["id"] == str(carrier.id)
+
+    async def test_gpu_ignores_a_paused_job(self, db):
+        job = await _job(db, status=JobStatus.PAUSED)
+        await _segment(db, job, 0)
+
+        assert (await _claim(db, kind="gpu")).json() is None
+
+
+@pytest.mark.asyncio
+class TestStaleReclaim:
+    async def test_work_orphaned_by_a_dead_worker_comes_back(self, db):
+        """A crashed worker's segment must not sit CLAIMED forever — it is the only thing
+        standing between a lost machine and a job that never finishes."""
+        job = await _job(db, status=JobStatus.PROCESSING)
+        stale = await _segment(db, job, 0, status=SegmentStatus.CLAIMED)
+        stale.claimed_at = datetime.now(timezone.utc) - timedelta(minutes=45)
+        stale.worker_id = uuid.uuid4()
+        await db.flush()
+
+        body = (await _claim(db)).json()
+
+        # Reclaimed and handed straight back out to the asking worker.
+        assert body is not None and body["id"] == str(stale.id)
+        await db.refresh(stale)
+        assert stale.worker_id == WORKER_ID
+
+
+@pytest.mark.asyncio
+class TestRetryCannotResurrectAnArchivedTake:
+    async def test_retrying_a_discarded_segment_is_refused(self, db):
+        """Retry is how a discarded segment could become PENDING again.
+
+        Claiming refuses to hand out a discarded segment, so without this the retry would look
+        like it worked and then sit PENDING forever — the worst of both: no clip, no error.
+        """
+        owner = await _user(db)
+        job = await _job(db, owner)
+        seg = await _segment(db, job, 0, status=SegmentStatus.FAILED, discarded=True)
+
+        app.dependency_overrides[get_db] = lambda: db
+        app.dependency_overrides[get_current_user] = lambda: owner
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(f"/segments/{seg.id}/retry")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 400
+        assert "discarded" in resp.json()["detail"].lower()
+        await db.refresh(seg)
+        assert seg.status == SegmentStatus.FAILED

--- a/tests/test_reroll_segment.py
+++ b/tests/test_reroll_segment.py
@@ -282,16 +282,3 @@ class TestSeedRange:
             assert 0 <= seed <= JS_SAFE_MAX_SEED
             # The round trip a browser performs. Equality here is the whole property.
             assert int(float(seed)) == seed
-
-
-@pytest.mark.asyncio
-class TestClaimUsesTheSegmentSeed:
-    async def test_an_explicit_seed_wins_over_the_derived_one(self, db):
-        """The claim payload is where the seed actually reaches the worker."""
-        from app.routes.segments import claim_next_segment  # noqa: F401  (import guard)
-
-        user = await _user(db)
-        job, seg = await _job_with_segment(db, user, seed=42)
-        assert seg.seed == 42
-        # The derivation would have produced job.seed + index = 1234.
-        assert (job.seed + seg.index) % (2**63 - 1) == 1234


### PR DESCRIPTION
Closes #198 (the two bugs). Also the coverage David asked for after #196.

## The gap

`GET /segments/next` — the only door into the system — **had no test that called it**:

| what existed | what it actually covered |
|---|---|
| `test_daemon_route_auth.py` | that it requires an API key |
| `test_stale_claim_reaper.py` | a reclaim WHERE clause *rebuilt separately in the test* |
| `test_reroll_segment.py` | a test of mine that imported the function without calling it |

A 296-line function every generation passes through, never executed. That is how #196 shipped: one missing predicate, 500 on every claim, queue stopped.

The failure mode is what makes this endpoint different. A 500 elsewhere is a broken page; here the daemon polls, gets a 500, and **nothing runs**, with no alarm except a human noticing the GPU is idle. So these tests are about the shapes that make it throw or return the wrong row, and they drive the real route over HTTP against a real database — the bug was a result-cardinality error no mock would have produced.

## The fixes (#198)

**1 — the claim query never excluded discarded segments.** Status does not stand in for it: a discarded segment keeps whatever status it was discarded in, and `retry` puts a failed one back to PENDING. A worker then regenerates a take that was deliberately archived. `Segment.discarded.is_(False)` added to all three `kind` branches.

**2 — retry accepted a discarded segment.** Wrong on its own terms, and it is the entry point for bug 1. It also gets *worse* once 1 is fixed: the retry would return 200, flip the segment to PENDING, and nothing would ever claim it — no clip, no error, stuck forever. Now refused with a message saying to restore it or re-roll.

Both are the same class as #196: code assuming a discarded row is inert.

## Coverage added

- **The incident from the outside**: six archived takes plus a successor claims cleanly, and the successor starts from the *live* take's last frame, not a thrown-away one.
- **What gets claimed**: marked with worker and timestamp; nothing pending returns no segment; no double hand-out; job moves PENDING → PROCESSING; lower priority first; **discarded never claimed**.
- **Start image**: segment 0 from the job image, later segments from the previous last frame, explicit start image winning.
- **Seed**: derived from the job, decorrelated by index, a segment's own seed winning, and the worker payload staying an **integer** — the console schema sends strings for display precision and this one feeds the sampler.
- **Kind routing**: GPU not taking CPU carriers, hologram taking only those, paused jobs ignored.
- **Stale reclaim**: work orphaned by a dead worker comes back and is handed straight out.
- **Retry**: refused on a discarded take, status untouched.

## Removed

The test of mine that imported `claim_next_segment` without calling it. It read as coverage of the claim path and was not.

## Verification

`pytest` — **547 passed** against real Postgres (20 new).