### PR TITLE
The job seed follows the live take

### DIFF
--- a/alembic/versions/067_job_seed_follows_the_live_take.py
+++ b/alembic/versions/067_job_seed_follows_the_live_take.py
@@ -1,0 +1,68 @@
+"""Move a re-rolled take's seed onto the job
+
+Revision ID: 067
+Revises: 066
+Create Date: 2026-08-14
+
+Re-roll used to write the new seed onto the segment and leave job.seed alone. That left a
+re-rolled job showing TWO seeds — one on the job header and a different one on segment 0 — where
+the job's was the seed of a take that had already been archived. Two numbers, and the more
+prominent one wrong.
+
+There is one live take, so there is one answer, and it belongs on the job: that is where the
+header shows it and where the create dialog accepts it back to reproduce the job. Segment 0 then
+derives from it like every other segment and needs no seed of its own.
+
+So for each live segment carrying its own seed: move that seed to the job and clear it on the
+segment. Four jobs on production, all re-rolls.
+
+Nothing is lost. Migration 066 stamped every archived take with the seed it ran on, so the job
+seed being replaced here is already recorded on the row that actually produced it. The EXISTS
+guard enforces that rather than assuming it: a live segment with its own seed but no archived
+sibling would be a shape this has not seen, and it is left alone instead of having the old job
+seed silently dropped.
+"""
+from alembic import op
+
+revision = "067"
+down_revision = "066"
+branch_labels = None
+depends_on = None
+
+MOVE_SEED_TO_JOB = """
+UPDATE jobs AS j
+SET seed = s.seed
+FROM segments AS s
+WHERE s.job_id = j.id
+  AND NOT s.discarded
+  AND s.seed IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM segments AS archived
+    WHERE archived.job_id = j.id
+      AND archived.discarded
+      AND archived.seed IS NOT NULL
+  )
+"""
+
+CLEAR_SEED_ON_LIVE_SEGMENTS = """
+UPDATE segments AS s
+SET seed = NULL
+FROM jobs AS j
+WHERE s.job_id = j.id
+  AND NOT s.discarded
+  AND s.seed IS NOT NULL
+  AND j.seed = s.seed
+"""
+
+
+def upgrade() -> None:
+    # Order matters: the clear keys on the job already holding the value, so a failure between
+    # the two leaves the seed recorded twice rather than nowhere.
+    op.execute(MOVE_SEED_TO_JOB)
+    op.execute(CLEAR_SEED_ON_LIVE_SEGMENTS)
+
+
+def downgrade() -> None:
+    # Not reversible: which job seeds came from a live segment is not recorded, and the previous
+    # job seed lives on an archived take that this did not touch.
+    pass

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -1369,10 +1369,28 @@ async def reroll_first_segment(
         old.seed = (job.seed + old.index) % (2**63 - 1)
     old.discarded = True
 
+    # The job's seed becomes the new take's seed, and the new take derives from it like any
+    # other segment.
+    #
+    # There is one live take, so there should be one answer to "what seed is this?" — and it
+    # belongs on the job, where the header shows it and the create dialog accepts it back. The
+    # alternative, a job seed frozen at whatever the first take used, means the number on the job
+    # and the number that generated what is on screen disagree from the first re-roll onward.
+    #
+    # This is only safe because the outgoing take was just stamped above: the seed being replaced
+    # here is still recorded, on the row it actually produced. Overwriting job.seed WITHOUT that
+    # would relabel the archived clip with a seed that never generated it.
+    #
+    # Re-roll requires a single live segment, so nothing else is deriving from the old value.
+    job.seed = new_seed()
+
     fresh = Segment(
         job_id=job.id,
         index=0,
-        seed=new_seed(),
+        # NULL: derive from the job like every other segment. The job seed WAS just set to this
+        # take's seed, so a second copy on the segment would be the same number in two places,
+        # free to drift.
+        seed=None,
         prompt=old.prompt,
         prompt_template=old.prompt_template,
         duration_seconds=old.duration_seconds,

--- a/tests/test_job_seed_follows_live_take.py
+++ b/tests/test_job_seed_follows_live_take.py
@@ -1,0 +1,222 @@
+"""One live take, one seed, and it lives on the job.
+
+Re-roll used to write the new seed onto the segment and leave job.seed alone, so a re-rolled job
+displayed two seeds — the job header showing the seed of a take that had already been archived,
+and segment 0 showing the one actually in use. Two numbers, the more prominent one wrong.
+
+The job is where the seed belongs: the header shows it and the create dialog accepts it back to
+reproduce a job. Segment 0 derives from it like every other segment.
+
+This is only safe because archiving stamps the outgoing take with the seed it ran on. Overwriting
+job.seed without that would relabel an archived clip with a seed that never generated it — which
+is why that stamping and this move cannot be separated.
+"""
+
+import importlib.util
+import pathlib
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.enums import JobStatus, SegmentStatus
+from app.main import app
+from app.models import Job, Segment, User
+
+_spec = importlib.util.spec_from_file_location(
+    "migration_067",
+    pathlib.Path(__file__).resolve().parents[1]
+    / "alembic/versions/067_job_seed_follows_the_live_take.py",
+)
+_migration = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_migration)
+
+
+async def _run_migration(db):
+    await db.execute(text(_migration.MOVE_SEED_TO_JOB))
+    await db.execute(text(_migration.CLEAR_SEED_ON_LIVE_SEGMENTS))
+
+
+async def _user(db) -> User:
+    user = User(username=str(uuid.uuid4()), password_hash="x")
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _job(db, user=None, *, seed=1000) -> Job:
+    user = user or await _user(db)
+    job = Job(
+        user_id=user.id, name="j", width=480, height=832, fps=16, seed=seed,
+        starting_image="s3://b/start.png", status=JobStatus.AWAITING,
+    )
+    db.add(job)
+    await db.flush()
+    return job
+
+
+async def _segment(db, job, *, index=0, discarded=False, seed=None,
+                   status=SegmentStatus.COMPLETED) -> Segment:
+    seg = Segment(job_id=job.id, index=index, prompt="p", status=status,
+                  discarded=discarded, seed=seed)
+    db.add(seg)
+    await db.flush()
+    return seg
+
+
+async def _reroll(db, user, job_id):
+    from httpx import ASGITransport, AsyncClient
+
+    for obj in list(db.identity_map.values()):
+        if isinstance(obj, (Job, Segment)):
+            db.expire(obj)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.post(f"/jobs/{job_id}/reroll")
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+class TestRerollMovesTheSeedToTheJob:
+    async def test_the_job_gets_the_new_seed(self, db):
+        user = await _user(db)
+        job = await _job(db, user, seed=1000)
+        await _segment(db, job)
+
+        await _reroll(db, user, job.id)
+
+        await db.refresh(job)
+        assert job.seed != 1000
+
+    async def test_the_new_take_carries_no_seed_of_its_own(self, db):
+        # One number, one place. A copy on the segment is the same value twice, free to drift.
+        user = await _user(db)
+        job = await _job(db, user, seed=1000)
+        await _segment(db, job)
+
+        body = (await _reroll(db, user, job.id)).json()
+
+        assert body["seed"] is None
+
+    async def test_the_archived_take_keeps_the_seed_it_ran_on(self, db):
+        # The whole reason overwriting job.seed is safe.
+        user = await _user(db)
+        job = await _job(db, user, seed=1000)
+        old = await _segment(db, job)
+
+        await _reroll(db, user, job.id)
+
+        await db.refresh(old)
+        assert old.seed == 1000
+
+    async def test_the_new_take_claims_the_seed_now_on_the_job(self, db):
+        """End to end: what the worker is handed must be the number the header shows."""
+        user = await _user(db)
+        job = await _job(db, user, seed=1000)
+        await _segment(db, job)
+
+        await _reroll(db, user, job.id)
+        await db.refresh(job)
+
+        fresh = (
+            await db.execute(
+                select(Segment).where(Segment.job_id == job.id, Segment.discarded.is_(False))
+            )
+        ).scalar_one()
+        # The claim derivation for a NULL-seed segment at index 0.
+        assert fresh.seed is None
+        assert (job.seed + fresh.index) % (2**63 - 1) == job.seed
+
+    async def test_rolling_twice_leaves_two_distinct_archived_seeds(self, db):
+        # Each archived take answers for itself; the job answers for the live one.
+        user = await _user(db)
+        job = await _job(db, user, seed=1000)
+        await _segment(db, job)
+
+        await _reroll(db, user, job.id)
+        await db.refresh(job)
+        second_seed = job.seed
+        live = (
+            await db.execute(
+                select(Segment).where(Segment.job_id == job.id, Segment.discarded.is_(False))
+            )
+        ).scalar_one()
+        live.status = SegmentStatus.COMPLETED
+        await db.flush()
+
+        await _reroll(db, user, job.id)
+        await db.refresh(job)
+
+        archived = (
+            await db.execute(
+                select(Segment.seed).where(Segment.job_id == job.id, Segment.discarded)
+            )
+        ).scalars().all()
+        assert sorted(archived) == sorted([1000, second_seed])
+        assert job.seed not in archived
+
+
+@pytest.mark.asyncio
+class TestMigration067:
+    async def test_it_moves_a_live_segments_seed_onto_the_job(self, db):
+        job = await _job(db, seed=7189671993964474770)          # the old take's seed
+        live = await _segment(db, job, seed=5699167371037795)   # the take actually in use
+        await _segment(db, job, discarded=True, seed=7189671993964474770)
+
+        await _run_migration(db)
+
+        await db.refresh(job)
+        await db.refresh(live)
+        assert job.seed == 5699167371037795
+        assert live.seed is None
+
+    async def test_the_archived_take_is_untouched(self, db):
+        job = await _job(db, seed=1000)
+        await _segment(db, job, seed=2000)
+        archived = await _segment(db, job, discarded=True, seed=1000)
+
+        await _run_migration(db)
+
+        await db.refresh(archived)
+        assert archived.seed == 1000
+
+    async def test_a_job_that_was_never_re_rolled_is_untouched(self, db):
+        job = await _job(db, seed=1000)
+        live = await _segment(db, job)
+
+        await _run_migration(db)
+
+        await db.refresh(job)
+        await db.refresh(live)
+        assert job.seed == 1000 and live.seed is None
+
+    async def test_a_live_seed_with_no_archived_sibling_is_left_alone(self, db):
+        """A shape this has not seen. Moving the seed there would drop the old job seed with
+        nothing else recording it, so it is left for a human rather than guessed at."""
+        job = await _job(db, seed=1000)
+        live = await _segment(db, job, seed=2000)
+
+        await _run_migration(db)
+
+        await db.refresh(job)
+        await db.refresh(live)
+        assert job.seed == 1000
+        assert live.seed == 2000
+
+    async def test_running_it_twice_changes_nothing(self, db):
+        job = await _job(db, seed=1000)
+        live = await _segment(db, job, seed=2000)
+        await _segment(db, job, discarded=True, seed=1000)
+
+        await _run_migration(db)
+        await _run_migration(db)
+
+        await db.refresh(job)
+        await db.refresh(live)
+        assert job.seed == 2000 and live.seed is None

--- a/tests/test_reroll_segment.py
+++ b/tests/test_reroll_segment.py
@@ -111,16 +111,17 @@ class TestReroll:
         assert fresh.discarded is False and fresh.index == 0
         assert fresh.status == SegmentStatus.PENDING
 
-    async def test_the_new_take_carries_its_own_seed(self, db):
+    async def test_the_new_seed_lands_on_the_job_not_the_segment(self, db):
+        # One live take, one seed, and it lives where the header shows it and the create dialog
+        # takes it back. See test_job_seed_follows_live_take.py for the full model.
         user = await _user(db)
         job, old = await _job_with_segment(db, user)
 
         resp = await _reroll(db, user, job.id)
 
-        assert resp.json()["seed"] is not None
-        # And the job's seed is untouched.
+        assert resp.json()["seed"] is None
         await db.refresh(job)
-        assert job.seed == 1234
+        assert job.seed != 1234
 
     async def test_the_seed_stays_inside_the_javascript_safe_range(self, db):
         """A seed above 2**53 displays in the browser as a different number than it is.
@@ -131,9 +132,10 @@ class TestReroll:
         user = await _user(db)
         job, _ = await _job_with_segment(db, user)
 
-        seed = (await _reroll(db, user, job.id)).json()["seed"]
-        assert isinstance(seed, str), "seeds go over the wire as strings; see the schema"
-        assert 0 <= int(seed) <= 2**53 - 1
+        await _reroll(db, user, job.id)
+
+        await db.refresh(job)
+        assert 0 <= job.seed <= 2**53 - 1
 
     async def test_the_shot_is_copied_so_the_seed_is_the_only_variable(self, db):
         user = await _user(db)
@@ -190,8 +192,7 @@ class TestReroll:
         user = await _user(db)
         job, old = await _job_with_segment(db, user, seed=9223372036854775801)
 
-        body = (await _reroll(db, user, job.id)).json()
-        assert body["seed"] is not None
+        await _reroll(db, user, job.id)
 
         await db.refresh(old)
         assert old.seed == 9223372036854775801


### PR DESCRIPTION
David, from using it: *"I see a seed on the job and I see a seed on seg0 … the seed kept from the re-roll should be the new job seed. No need to display the seed on seg0 — it will always be the job seed."*

Right, and simpler than what I built.

## The problem

A re-rolled job showed **two seeds**: the job header, and a different one on segment 0. The job's was the seed of a take that had already been archived — so the more prominent number was the wrong one. Four jobs on production are in that state right now.

## The model

One live take, one answer, and it belongs on the **job** — that is where the header shows it and where the create dialog accepts it back to reproduce a job.

- Re-roll writes the new seed to `job.seed`.
- The new segment's seed stays **NULL** and derives like every other segment, so segment 0 is always the job seed and needs nothing displayed.
- Archived takes keep their own stamped seed, so each one still answers for itself.

## Why this is only safe now

Overwriting `job.seed` was exactly what I argued against when building #193 — it relabels the archived clip with a seed that never generated it. That objection is answered by #194, which stamps the outgoing take with the seed it ran on **before** the job seed moves. The stamping and this change cannot be separated; with them together, nothing is lost.

Re-roll also requires a single live segment, so nothing else is deriving from the old value at the moment it changes.

## Migration 067

Moves the four existing re-rolled jobs into the same shape: the live segment's seed becomes the job seed and clears on the segment.

Guarded by an `EXISTS` on an archived sibling carrying a seed. A live segment with its own seed and *no* archived take is a shape this has not seen, and moving the seed there would drop the old job seed with nothing else recording it — so it is left alone for a human rather than guessed at. The two statements are ordered so a failure between them leaves the seed recorded twice rather than nowhere.

## Verification

`pytest` — **557 passed** against real Postgres, single head at 067. Covers: the job taking the new seed, the take carrying none, the archived take keeping what it ran on, the claim derivation handing the worker the number the header shows, two rolls leaving two distinct archived seeds, and for the migration — the move, the archived take untouched, a never-re-rolled job untouched, the unguarded shape left alone, and idempotence.

Console PR follows to drop the now-redundant seed chip from segment 0.