### PR TITLE
"Re-roll until": rule-driven re-roll loop

### DIFF
--- a/alembic/versions/068_reroll_until_rule.py
+++ b/alembic/versions/068_reroll_until_rule.py
@@ -1,0 +1,43 @@
+"""Re-roll until: a take can carry the rule that judges it
+
+Revision ID: 068
+Revises: 067
+Create Date: 2026-08-14
+
+Re-rolling (065) made "show me another take" a button. This makes it a loop: when the user
+re-rolls they can attach a rule — one of the four quality axes and a threshold — and when the
+take finishes generating, the API judges it against that rule. A take that misses the rule is
+archived and re-rolled again automatically, up to a global per-job cap (app setting
+"max_rerolls_per_job", default 3). A take that meets the rule, or exhausts the cap, sits and
+waits for the user exactly as before.
+
+The rule lives ON THE SEGMENT, not the job, for the same reason the seed does: each take is
+judged by the rule it was generated under. Changing the rule mid-chain must not relabel the
+takes already archived, and an archived take's record should say what bar it was asked to clear.
+
+reroll_count is the take's position in its chain — 1 for the user-initiated roll, incremented by
+each automatic one — so the cap is enforced from the take itself rather than by counting
+archived rows, which would conflate rule-driven rolls with plain manual ones.
+
+All three columns are nullable and nothing is backfilled: NULL means "no rule", which is every
+take that exists today and every plain re-roll from now on.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "068"
+down_revision = "067"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("reroll_rule_metric", sa.String(length=16), nullable=True))
+    op.add_column("segments", sa.Column("reroll_rule_threshold", sa.Float(), nullable=True))
+    op.add_column("segments", sa.Column("reroll_count", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "reroll_count")
+    op.drop_column("segments", "reroll_rule_threshold")
+    op.drop_column("segments", "reroll_rule_metric")

--- a/app/models.py
+++ b/app/models.py
@@ -167,6 +167,17 @@ class Segment(Base):
     observation_tags = mapped_column(String(500), nullable=True)
     trim_start_frames = mapped_column(Integer, nullable=False, default=0)
     trim_end_frames = mapped_column(Integer, nullable=False, default=0)
+    # "Re-roll until": the rule this take was generated under, judged by the API when the take
+    # completes. Metric is one of identity/expression/motion/detail; the comparison is >= against
+    # the MEAN of the matching series in identity_metrics — the same number the console's chips
+    # show, so the value that gates is the value the user can read off the screen. A take that
+    # misses the rule is archived and re-rolled again automatically, capped by the
+    # "max_rerolls_per_job" app setting. reroll_count is this take's position in its chain
+    # (1 = the user-initiated roll). NULL throughout means "no rule" — every plain re-roll, and
+    # every take that predates the feature.
+    reroll_rule_metric = mapped_column(String(16), nullable=True)
+    reroll_rule_threshold = mapped_column(Float, nullable=True)
+    reroll_count = mapped_column(Integer, nullable=True)
     motion_magnitude = mapped_column(Float, nullable=True)
     # Identity scoring, measured inline when the segment finishes generating. Two means:
     # _mean_cos is vs the START FRAME (drift of this generation), _mean_cos_ref is vs the

--- a/app/routes/app_settings.py
+++ b/app/routes/app_settings.py
@@ -23,6 +23,7 @@ _DEFAULTS = {
     "negative_prompt": "",
     "continuation_mode": "traditional",
     "vace_overlap_frames": "12",
+    "max_rerolls_per_job": "3",
 }
 
 
@@ -44,6 +45,7 @@ def _to_response(settings: dict[str, str]) -> AppSettingsResponse:
         negative_prompt=settings["negative_prompt"],
         continuation_mode=settings.get("continuation_mode", "traditional"),
         vace_overlap_frames=int(settings.get("vace_overlap_frames", "12")),
+        max_rerolls_per_job=int(settings.get("max_rerolls_per_job", "3")),
     )
 
 

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import logging
+import math
 import random
 import re
 import subprocess
@@ -30,6 +31,7 @@ from app.schemas.segments import (
     FramePreview,
     FramePreviewResponse,
     HologramRequest,
+    RerollRequest,
     SegmentClaimResponse,
     SegmentClipResponse,
     SegmentCreate,
@@ -594,6 +596,19 @@ async def update_segment(
         )
 
     await db.flush()
+
+    # "Re-roll until": judge a completed take against its rule now, while the metrics ride the
+    # same PATCH (the daemon uploads output first — which flips status to COMPLETED — then sends
+    # this PATCH with status + scores together). If the take misses, this archives it and adds a
+    # fresh pending segment-0, which the status block below then counts as active — so the job
+    # stays PENDING instead of falling to AWAITING/FINALIZED. auto_finalize composes for free:
+    # the job finalizes only once a take clears the rule (or the chain gives up).
+    if (
+        body.status == SegmentStatus.COMPLETED
+        and segment.reroll_rule_metric is not None
+        and not segment.discarded
+    ):
+        await _judge_reroll_rule(db, segment)
 
     # Check if job needs status update. Hologram carriers are exempt — they don't affect the
     # source job's status (a failed hologram must not flip a finalized job to FAILED).
@@ -1301,9 +1316,175 @@ async def cancel_segment(
     return segment
 
 
+# --- "Re-roll until" (#342) --------------------------------------------------------------------
+#
+# A re-roll may carry a rule: one of the four quality axes and a threshold, judged >= when the
+# take finishes generating. The rule gates on the MEAN of the matching per-frame series in
+# identity_metrics — the same number the console's metric chips display — so what drives the loop
+# is exactly the value the user can read off the screen. The nearby scalar columns
+# (identity_mean_cos_ref, motion_magnitude) are close cousins but not the displayed number, and
+# two subtly different values behind one decision is how trust in a metric dies.
+REROLL_RULE_SERIES = {
+    "identity": "series",
+    "expression": "series_expression",
+    "motion": "series_motion",
+    "detail": "series_detail",
+}
+
+# Mirrors the console's MIN_POINTS: below this the chip doesn't render, so the user could never
+# see the number that gated. An unevaluable rule stops the loop instead of burning GPU blind.
+REROLL_RULE_MIN_POINTS = 8
+
+DEFAULT_MAX_REROLLS = 3
+
+
+def _reroll_rule_mean(metrics: dict | None, metric: str) -> float | None:
+    series = (metrics or {}).get(REROLL_RULE_SERIES[metric])
+    if not isinstance(series, list):
+        return None
+    values = [v for v in series if isinstance(v, (int, float)) and math.isfinite(v)]
+    if len(values) < REROLL_RULE_MIN_POINTS:
+        return None
+    return sum(values) / len(values)
+
+
+def _roll_new_take(
+    job: Job,
+    old: Segment,
+    *,
+    rule_metric: str | None = None,
+    rule_threshold: float | None = None,
+    reroll_count: int | None = None,
+) -> Segment:
+    """Archive `old` and build its replacement — the mechanics shared by a user-initiated
+    re-roll and an automatic rule-driven one. The caller adds the returned segment to the
+    session; commit is the caller's too.
+
+    Stamp the outgoing take with the seed it actually ran on, if it was relying on the
+    derivation. NULL means "derive from the job", which is unambiguous while a job has one take
+    and stops being so the moment it has several: the archive exists to answer "which seed gave
+    me that one", and an archived clip whose seed has to be recomputed from context is a worse
+    answer than a recorded number. Same value the worker used -- this records it, it does not
+    change it.
+
+    The job's seed then becomes the new take's seed, and the new take derives from it like any
+    other segment. This is only safe because the outgoing take was just stamped: the seed being
+    replaced is still recorded, on the row it actually produced. See #199 for the full model.
+    """
+    if old.seed is None:
+        old.seed = (job.seed + old.index) % (2**63 - 1)
+    old.discarded = True
+    job.seed = new_seed()
+
+    fresh = Segment(
+        job_id=job.id,
+        index=0,
+        # NULL: derive from the job like every other segment. The job seed WAS just set to this
+        # take's seed, so a second copy on the segment would be the same number in two places,
+        # free to drift.
+        seed=None,
+        prompt=old.prompt,
+        prompt_template=old.prompt_template,
+        duration_seconds=old.duration_seconds,
+        speed=old.speed,
+        start_image=old.start_image,
+        loras=old.loras,
+        faceswap_enabled=old.faceswap_enabled,
+        faceswap_method=old.faceswap_method,
+        faceswap_source_type=old.faceswap_source_type,
+        faceswap_image=old.faceswap_image,
+        faceswap_faces_order=old.faceswap_faces_order,
+        faceswap_faces_index=old.faceswap_faces_index,
+        faceswap_model=old.faceswap_model,
+        faceswap_pixel_boost=old.faceswap_pixel_boost,
+        seed_faceswap=old.seed_faceswap,
+        negative_prompt=old.negative_prompt,
+        auto_finalize=old.auto_finalize,
+        video_preset_id=old.video_preset_id,
+        reroll_rule_metric=rule_metric,
+        reroll_rule_threshold=rule_threshold,
+        reroll_count=reroll_count,
+    )
+
+    # Back to pending or nothing claims it. The job may well be 'awaiting' (segment 0 finished
+    # and it is waiting on a decision) or 'failed'.
+    job.status = JobStatus.PENDING
+    return fresh
+
+
+async def _judge_reroll_rule(db: AsyncSession, segment: Segment) -> None:
+    """Judge a freshly completed take against the rule it was generated under.
+
+    Called from the completion PATCH, while the metrics are in hand. Three quiet exits — rule
+    met, cap reached, rule unevaluable — all leave the take live and the job to fall through to
+    AWAITING exactly as if no rule existed ("sit idle", per the ticket). Only a measured miss
+    with budget remaining rolls again.
+
+    A failed generation never reaches here (judged on COMPLETED only): a crash is not a metric
+    miss, and looping on one would burn the whole budget re-running a broken setup.
+    """
+    metric = segment.reroll_rule_metric
+    threshold = segment.reroll_rule_threshold
+    used = segment.reroll_count or 1
+
+    mean = _reroll_rule_mean(segment.identity_metrics, metric)
+    if mean is None:
+        logger.warning(
+            "segment %s: re-roll rule %s >= %s is unevaluable (no %s series in metrics) — sitting idle",
+            segment.id, metric, threshold, REROLL_RULE_SERIES[metric],
+        )
+        return
+    if mean >= threshold:
+        logger.info(
+            "segment %s: re-roll rule met — %s %.3f >= %.3f on take %d",
+            segment.id, metric, mean, threshold, used,
+        )
+        return
+
+    setting = await db.get(AppSetting, "max_rerolls_per_job")
+    try:
+        cap = int(setting.value) if setting else DEFAULT_MAX_REROLLS
+    except (TypeError, ValueError):
+        cap = DEFAULT_MAX_REROLLS
+    if used >= cap:
+        logger.info(
+            "segment %s: re-roll rule missed (%s %.3f < %.3f) but the cap of %d takes is spent — sitting idle",
+            segment.id, metric, mean, threshold, cap,
+        )
+        return
+
+    # Same gate as the endpoint: re-roll only while this take is the job's single live segment.
+    # It is by construction — a rule only ever rides a segment-0 take — but a successor added
+    # while this take was generating would be orphaned by an automatic roll, so verify.
+    job = await db.get(Job, segment.job_id)
+    others = await db.execute(
+        select(Segment.id).where(
+            Segment.job_id == job.id,
+            Segment.id != segment.id,
+            Segment.discarded.is_(False),
+        )
+    )
+    if others.first() is not None:
+        logger.warning(
+            "segment %s: re-roll rule missed but the job has other live segments — sitting idle",
+            segment.id,
+        )
+        return
+
+    fresh = _roll_new_take(
+        job, segment, rule_metric=metric, rule_threshold=threshold, reroll_count=used + 1,
+    )
+    db.add(fresh)
+    logger.info(
+        "segment %s: re-roll rule missed — %s %.3f < %.3f, rolling take %d/%d",
+        segment.id, metric, mean, threshold, used + 1, cap,
+    )
+
+
 @router.post("/jobs/{job_id}/reroll", response_model=SegmentResponse)
 async def reroll_first_segment(
     job_id: UUID,
+    body: RerollRequest | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1326,7 +1507,31 @@ async def reroll_first_segment(
 
     Trim, transition, rating, notes and observation tags are deliberately NOT copied: they
     describe the take being archived, not the one about to be generated.
+
+    Optionally carries a "re-roll until" rule (metric + threshold, judged >= on completion).
+    A take that misses its rule is archived and re-rolled again automatically, up to the
+    max_rerolls_per_job app setting; see _judge_reroll_rule.
     """
+    rule_metric = body.rule_metric if body else None
+    rule_threshold = body.rule_threshold if body else None
+    if rule_metric is not None:
+        if rule_metric not in REROLL_RULE_SERIES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown re-roll rule metric '{rule_metric}'. "
+                       f"One of: {', '.join(REROLL_RULE_SERIES)}.",
+            )
+        if rule_threshold is None or not math.isfinite(rule_threshold):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A re-roll rule needs a finite threshold.",
+            )
+    elif rule_threshold is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="rule_threshold given without rule_metric.",
+        )
+
     result = await db.execute(
         select(Job)
         .where(Job.id == job_id, Job.user_id == user.id)
@@ -1359,62 +1564,15 @@ async def reroll_first_segment(
             ),
         )
 
-    # Stamp the outgoing take with the seed it actually ran on, if it was relying on the
-    # derivation. NULL means "derive from the job", which is unambiguous while a job has one take
-    # and stops being so the moment it has several: the archive exists to answer "which seed gave
-    # me that one", and an archived clip whose seed has to be recomputed from context is a worse
-    # answer than a recorded number. Same value the worker used -- this records it, it does not
-    # change it.
-    if old.seed is None:
-        old.seed = (job.seed + old.index) % (2**63 - 1)
-    old.discarded = True
-
-    # The job's seed becomes the new take's seed, and the new take derives from it like any
-    # other segment.
-    #
-    # There is one live take, so there should be one answer to "what seed is this?" — and it
-    # belongs on the job, where the header shows it and the create dialog accepts it back. The
-    # alternative, a job seed frozen at whatever the first take used, means the number on the job
-    # and the number that generated what is on screen disagree from the first re-roll onward.
-    #
-    # This is only safe because the outgoing take was just stamped above: the seed being replaced
-    # here is still recorded, on the row it actually produced. Overwriting job.seed WITHOUT that
-    # would relabel the archived clip with a seed that never generated it.
-    #
-    # Re-roll requires a single live segment, so nothing else is deriving from the old value.
-    job.seed = new_seed()
-
-    fresh = Segment(
-        job_id=job.id,
-        index=0,
-        # NULL: derive from the job like every other segment. The job seed WAS just set to this
-        # take's seed, so a second copy on the segment would be the same number in two places,
-        # free to drift.
-        seed=None,
-        prompt=old.prompt,
-        prompt_template=old.prompt_template,
-        duration_seconds=old.duration_seconds,
-        speed=old.speed,
-        start_image=old.start_image,
-        loras=old.loras,
-        faceswap_enabled=old.faceswap_enabled,
-        faceswap_method=old.faceswap_method,
-        faceswap_source_type=old.faceswap_source_type,
-        faceswap_image=old.faceswap_image,
-        faceswap_faces_order=old.faceswap_faces_order,
-        faceswap_faces_index=old.faceswap_faces_index,
-        faceswap_model=old.faceswap_model,
-        faceswap_pixel_boost=old.faceswap_pixel_boost,
-        seed_faceswap=old.seed_faceswap,
-        negative_prompt=old.negative_prompt,
-        auto_finalize=old.auto_finalize,
-        video_preset_id=old.video_preset_id,
+    fresh = _roll_new_take(
+        job,
+        old,
+        rule_metric=rule_metric,
+        rule_threshold=rule_threshold,
+        # The user-initiated roll is the first take charged against the cap.
+        reroll_count=1 if rule_metric is not None else None,
     )
     db.add(fresh)
-
-    # Back to pending or nothing claims it. The job may well be 'awaiting' (segment 0 finished
-    # and it is waiting on a decision) or 'failed'.
-    job.status = JobStatus.PENDING
 
     await db.commit()
     await db.refresh(fresh)

--- a/app/schemas/app_settings.py
+++ b/app/schemas/app_settings.py
@@ -16,6 +16,9 @@ class AppSettingsResponse(BaseModel):
     # or "vace" (video-conditioned continuation). vace_overlap_frames = kept tail length.
     continuation_mode: str = "traditional"
     vace_overlap_frames: int = 12
+    # "Re-roll until": how many takes a rule-driven re-roll chain may generate per job
+    # before it gives up and sits idle (the user-initiated roll counts as the first).
+    max_rerolls_per_job: int = 3
     # Seed re-anchor: faceswap each continuation segment's last frame to the canonical
     # identity before it seeds the next segment (only fires when a successor exists).
 
@@ -31,3 +34,4 @@ class AppSettingsUpdate(BaseModel):
     negative_prompt: Optional[str] = None
     continuation_mode: Optional[str] = None
     vace_overlap_frames: Optional[int] = None
+    max_rerolls_per_job: Optional[int] = None

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -169,6 +169,9 @@ class SegmentResponse(BaseModel):
     observation_tags: Optional[str] = None
     trim_start_frames: int
     trim_end_frames: int
+    reroll_rule_metric: Optional[str] = None
+    reroll_rule_threshold: Optional[float] = None
+    reroll_count: Optional[int] = None
     motion_magnitude: Optional[float] = None
     identity_mean_cos: Optional[float] = None
     identity_mean_cos_ref: Optional[float] = None
@@ -373,6 +376,16 @@ class HologramRequest(BaseModel):
     key_color: Optional[str] = None
     flavor: Optional[str] = None  # "2d_matte" (default) or "2.5d_depth"
     depth_scale_m: Optional[float] = None  # 2.5d relief depth in meters (clamped 0.03..0.60)
+
+
+class RerollRequest(BaseModel):
+    """Optional rule for POST /jobs/{id}/reroll. Omitted entirely = plain one-shot re-roll.
+
+    The comparison is >= by design (per #342); only the metric and the bar are chosen.
+    """
+
+    rule_metric: Optional[str] = None  # identity | expression | motion | detail
+    rule_threshold: Optional[float] = None
 
 
 class SegmentStatusUpdate(BaseModel):

--- a/tests/test_reroll_until.py
+++ b/tests/test_reroll_until.py
@@ -1,0 +1,271 @@
+"""'Re-roll until': the rule-driven re-roll loop (#342, console repo).
+
+The loop is judged in the completion PATCH — the same request that carries the metrics — so
+these tests drive it exactly the way the daemon does: create a take with a rule, PATCH it
+completed with an identity_metrics blob, and look at what the API decided to do.
+
+Run against a real database for the same reason as test_reroll_segment.py: what can go wrong
+is database-shaped (a second live row at index 0, the cap setting read at judge time).
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.enums import JobStatus, SegmentStatus
+from app.main import app
+from app.auth import get_current_user, verify_api_key
+from app.database import get_db
+from app.models import AppSetting, Job, Segment, User
+
+
+# Eight points is the console's chip minimum, mirrored by the judge. Mean 3.0.
+EXPRESSION_LOW = [3.0] * 8
+# Mean 5.0 — clears a threshold of 4.
+EXPRESSION_HIGH = [5.0] * 8
+
+
+async def _user(db) -> User:
+    user = User(username=str(uuid.uuid4()), password_hash="x")
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _job_with_segment(db, user, **segment_kwargs) -> tuple[Job, Segment]:
+    job = Job(
+        user_id=user.id,
+        name="job",
+        width=480,
+        height=832,
+        fps=16,
+        seed=1234,
+        starting_image="s3://b/start.png",
+        status=JobStatus.AWAITING,
+    )
+    db.add(job)
+    await db.flush()
+
+    fields = dict(
+        job_id=job.id,
+        index=0,
+        prompt="she moves",
+        duration_seconds=5.0,
+        speed=1.0,
+        status=SegmentStatus.COMPLETED,
+        output_path="s3://b/out.mp4",
+    )
+    fields.update(segment_kwargs)
+    segment = Segment(**fields)
+    db.add(segment)
+    await db.flush()
+    return job, segment
+
+
+def _expire(db):
+    # Shared session across "requests" — expire so routes reload current rows. See
+    # test_reroll_segment.py for why the user object is left alone.
+    for obj in list(db.identity_map.values()):
+        if isinstance(obj, (Job, Segment)):
+            db.expire(obj)
+
+
+async def _request(db, user, method, url, json=None):
+    from httpx import ASGITransport, AsyncClient
+
+    _expire(db)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[verify_api_key] = lambda: None
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.request(method, url, json=json)
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def _complete_with_metrics(db, user, segment_id, series):
+    return await _request(
+        db, user, "PATCH", f"/segments/{segment_id}",
+        json={"status": "completed", "identity_metrics": {"series_expression": series}},
+    )
+
+
+async def _live_segments(db, job_id):
+    _expire(db)
+    rows = (await db.execute(select(Segment).where(Segment.job_id == job_id))).scalars().all()
+    return [s for s in rows if not s.discarded]
+
+
+@pytest.mark.asyncio
+class TestRerollRuleRequest:
+    async def test_a_rule_rides_the_new_take_with_count_1(self, db):
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+
+        resp = await _request(
+            db, user, "POST", f"/jobs/{job.id}/reroll",
+            json={"rule_metric": "expression", "rule_threshold": 4},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["reroll_rule_metric"] == "expression"
+        assert body["reroll_rule_threshold"] == 4
+        assert body["reroll_count"] == 1
+
+    async def test_a_plain_reroll_carries_no_rule(self, db):
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+
+        body = (await _request(db, user, "POST", f"/jobs/{job.id}/reroll")).json()
+        assert body["reroll_rule_metric"] is None
+        assert body["reroll_count"] is None
+
+    async def test_an_unknown_metric_is_refused(self, db):
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+
+        resp = await _request(
+            db, user, "POST", f"/jobs/{job.id}/reroll",
+            json={"rule_metric": "vibes", "rule_threshold": 4},
+        )
+        assert resp.status_code == 400
+
+    async def test_a_metric_without_a_threshold_is_refused(self, db):
+        user = await _user(db)
+        job, _ = await _job_with_segment(db, user)
+
+        resp = await _request(
+            db, user, "POST", f"/jobs/{job.id}/reroll",
+            json={"rule_metric": "expression"},
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+class TestRerollRuleJudging:
+    async def _ruled_take(self, db, user, count=1, **kwargs):
+        return await _job_with_segment(
+            db, user,
+            status=SegmentStatus.PROCESSING,
+            reroll_rule_metric="expression",
+            reroll_rule_threshold=4.0,
+            reroll_count=count,
+            **kwargs,
+        )
+
+    async def test_a_miss_archives_the_take_and_rolls_the_next_one(self, db):
+        user = await _user(db)
+        job, take = await self._ruled_take(db, user)
+
+        resp = await _complete_with_metrics(db, user, take.id, EXPRESSION_LOW)
+        assert resp.status_code == 200, resp.text
+
+        live = await _live_segments(db, job.id)
+        assert len(live) == 1
+        fresh = live[0]
+        assert fresh.id != take.id and fresh.index == 0
+        assert fresh.status == SegmentStatus.PENDING
+        # The rule travels with the chain, and the count advances.
+        assert fresh.reroll_rule_metric == "expression"
+        assert fresh.reroll_rule_threshold == 4.0
+        assert fresh.reroll_count == 2
+
+        await db.refresh(job)
+        assert job.status == JobStatus.PENDING
+        await db.refresh(take)
+        assert take.discarded is True
+        # The archived take keeps the metrics that condemned it, and its seed (see #199).
+        assert take.identity_metrics == {"series_expression": EXPRESSION_LOW}
+        assert take.seed == 1234
+
+    async def test_a_met_rule_ends_the_loop(self, db):
+        user = await _user(db)
+        job, take = await self._ruled_take(db, user)
+
+        await _complete_with_metrics(db, user, take.id, EXPRESSION_HIGH)
+
+        live = await _live_segments(db, job.id)
+        assert [s.id for s in live] == [take.id]
+        await db.refresh(job)
+        assert job.status == JobStatus.AWAITING
+
+    async def test_the_cap_ends_the_loop(self, db):
+        user = await _user(db)
+        job, take = await self._ruled_take(db, user, count=3)  # default cap
+
+        await _complete_with_metrics(db, user, take.id, EXPRESSION_LOW)
+
+        live = await _live_segments(db, job.id)
+        assert [s.id for s in live] == [take.id]
+        await db.refresh(job)
+        assert job.status == JobStatus.AWAITING
+
+    async def test_the_cap_is_read_from_settings_at_judge_time(self, db):
+        user = await _user(db)
+        db.add(AppSetting(key="max_rerolls_per_job", value="5"))
+        await db.flush()
+        job, take = await self._ruled_take(db, user, count=3)
+
+        await _complete_with_metrics(db, user, take.id, EXPRESSION_LOW)
+
+        live = await _live_segments(db, job.id)
+        assert live[0].reroll_count == 4  # 3 < 5, so it rolled
+
+    async def test_an_unevaluable_rule_sits_idle_instead_of_looping_blind(self, db):
+        user = await _user(db)
+        job, take = await self._ruled_take(db, user)
+
+        # Series too short for the console to even draw a chip: nothing visible could gate.
+        await _complete_with_metrics(db, user, take.id, [3.0] * 4)
+
+        live = await _live_segments(db, job.id)
+        assert [s.id for s in live] == [take.id]
+        await db.refresh(job)
+        assert job.status == JobStatus.AWAITING
+
+    async def test_a_missing_series_sits_idle(self, db):
+        user = await _user(db)
+        job, take = await self._ruled_take(db, user)
+
+        resp = await _request(
+            db, user, "PATCH", f"/segments/{take.id}",
+            json={"status": "completed", "identity_metrics": {"series": [0.9] * 8}},
+        )
+        assert resp.status_code == 200
+
+        live = await _live_segments(db, job.id)
+        assert [s.id for s in live] == [take.id]
+
+    async def test_a_failed_generation_is_not_judged(self, db):
+        user = await _user(db)
+        job, take = await self._ruled_take(db, user)
+
+        await _request(
+            db, user, "PATCH", f"/segments/{take.id}",
+            json={"status": "failed", "error_message": "boom"},
+        )
+
+        live = await _live_segments(db, job.id)
+        assert [s.id for s in live] == [take.id]
+        await db.refresh(job)
+        assert job.status == JobStatus.FAILED
+
+    async def test_a_successor_segment_blocks_the_automatic_roll(self, db):
+        # Cannot happen through the UI today, but an automatic roll that orphaned segment 1
+        # would silently discard the frame it was generated from — so the judge verifies.
+        user = await _user(db)
+        job, take = await self._ruled_take(db, user)
+        db.add(Segment(
+            job_id=job.id, index=1, prompt="and continues",
+            duration_seconds=5.0, speed=1.0, status=SegmentStatus.COMPLETED,
+        ))
+        await db.flush()
+
+        await _complete_with_metrics(db, user, take.id, EXPRESSION_LOW)
+
+        live = await _live_segments(db, job.id)
+        assert {s.index for s in live} == {0, 1}
+        assert all(not s.discarded for s in live)


### PR DESCRIPTION
API half of DavidJBarnes/wanly-console#342 (console PR follows).

A re-roll may now attach a rule — metric (identity/expression/motion/detail) + threshold, judged `>=` when the take completes. A miss archives the take and rolls again automatically, capped by the new `max_rerolls_per_job` app setting (default 3, exposed on GET/PUT `/settings`). A met rule, a spent cap, or an unmeasurable take all sit idle awaiting the user, exactly as today.

**Why it's shaped this way**
- **Gates on the chip number.** The rule compares against the mean of the matching `identity_metrics` series — the same value the console's metric chips display (min 8 points, mirroring the chip threshold). Not the nearby scalar columns: two subtly different values behind one decision is how trust in a metric dies.
- **Rule rides the segment**, like the seed and for the same reason — each archived take records the bar it was asked to clear; changing the rule mid-chain can't relabel history. `reroll_count` is the take's position in its chain (user's roll = 1), so the cap doesn't conflate rule-driven rolls with plain manual ones.
- **Judged in the completion PATCH** — the request that actually carries the metrics. The whole loop is API-side; daemon and GPU image untouched (checked against the wanly-gpu-docker parity table: no dep, node, model, or env change).
- **Failures are not judged.** A crash is not a metric miss; looping on one would burn the budget re-running a broken setup. The retry button still exists.
- Migration 068: three nullable columns, no backfill — NULL is "no rule", which is every existing row and every plain re-roll.

**Verified**: 26 reroll tests pass against a real Postgres (12 new in `test_reroll_until.py`, covering miss→roll, met→stop, cap→stop, settings-read-at-judge-time, unevaluable→idle, failed→not judged, successor→blocked). Flipped the comparison deliberately and watched 3 tests fail, restored. Full suite: 569 passed.