### PR TITLE
Filter jobs by whole tags, and stop `q` matching tags by substring

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -13,6 +13,8 @@ from app.config import settings
 from app.database import get_db
 from app.models import Favorite, ImageMeta, Job, Segment
 from app.schemas.images import ImageTagsUpdate
+from app.tag_filter import like_escape
+from app.tag_filter import tag_clause as _tag_clause
 from app.s3 import (
     delete_object,
     download_bytes,
@@ -367,13 +369,7 @@ def search_pattern(q: str) -> str:
     "%" and "_" are LIKE wildcards and filenames are full of both, so a query for "a_b" must not
     silently match "axb", and "100%" must not become match-everything.
     """
-    return f"%{_like_escape(q)}%"
-
-
-def _like_escape(s: str) -> str:
-    """Neutralise LIKE metacharacters. Backslash first, or escaping the wildcards would itself
-    be re-escaped."""
-    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{like_escape(q)}%"
 
 
 def path_clause(q: str):
@@ -387,31 +383,14 @@ def path_clause(q: str):
     return ImageMeta.path.ilike(search_pattern(q), escape="\\")
 
 
-def normalise_tag(tag: str) -> str:
-    """Fold a tag to its comparison form: case- and space-insensitive.
-
-    Spaces come out because the vocabulary contains "Big dick" and the stored string is joined
-    with ", " -- inconsistent spacing around the commas is the norm, not the exception.
-    """
-    return tag.strip().lower().replace(" ", "")
-
-
 def tag_clause(tag: str):
-    """Match one WHOLE tag inside the comma-joined tags string.
+    """Match one WHOLE tag inside an image's comma-joined tags string.
 
-    Tags are stored as one text blob ("Kelly, Missionary"), so a substring match cannot tell
-    where one tag ends and the next begins. Measured on production 2026-08-14, that is not a
-    corner case: `%kelly%` matched 2,057 of 2,788 images -- 74% of the repo -- because it also
-    caught KellyYoung (1,019), KellyBangs (140) and KellyTeacher (76). Exact Kelly is 824.
-
-    Wrapping both sides in commas is what makes the boundaries real: ",kelly," cannot match
-    inside ",kellyyoung,". concat() rather than || because it is null-safe, so an untagged row
-    simply fails to match instead of poisoning the expression.
+    Measured on production 2026-08-14, boundaries are the whole point: `%kelly%` matched 2,057 of
+    2,788 images -- 74% of the repo -- because it also caught KellyYoung (1,019), KellyBangs (140)
+    and KellyTeacher (76). Exact Kelly is 824. Jobs share the implementation via `app.tag_filter`.
     """
-    pattern = f"%,{_like_escape(normalise_tag(tag))},%"
-    return func.concat(",", func.replace(func.lower(ImageMeta.tags), " ", ""), ",").like(
-        pattern, escape="\\"
-    )
+    return _tag_clause(ImageMeta.tags, tag)
 
 
 def image_filter(q: str | None, tags: list[str], exclude: list[str]) -> list:

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
-from sqlalchemy import case, func, select
+from sqlalchemy import case, func, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -24,6 +24,7 @@ from app.helpers import upload_faceswap_image
 from app.models import Job, Lora, Segment, User, Video
 from app.routes.segments import _resolve_loras, _resolve_wildcards
 from app.s3 import delete_object, delete_prefix, delete_prefix_except, upload_bytes
+from app.tag_filter import like_escape, tag_clause
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _ALLOWED_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
@@ -276,6 +277,52 @@ async def create_job(
     return job
 
 
+def job_filter(
+    *,
+    user_id: UUID,
+    status_filter: str | None = None,
+    name: str | None = None,
+    search: str | None = None,
+    tags: list[str] | None = None,
+    starred: bool | None = None,
+) -> list:
+    """Every criterion ANDs. Returns clauses for .where(*clauses).
+
+    Two controls with two different jobs, the same split the image repo settled on. `tags`
+    matches a tag in FULL, so the AR pill returns AR videos and not every job whose name happens
+    to contain "ar"; `q` matches the job NAME as a fragment, because a half-remembered name is
+    often the only handle there is.
+
+    `q` also matches a whole tag, so typing a tag name still finds it -- but it no longer matches
+    tags by substring, which is what made searching "AR" return jobs tagged `argentina` or
+    `starlight` (#353).
+
+    Tag pills are strictly conjunctive: each one narrows, so two pills mean "both tags on one
+    job". There is no OR.
+    """
+    clauses = [Job.user_id == user_id]
+    if starred:
+        clauses.append(Job.config_starred.is_(True))
+    if name:
+        clauses.append(Job.name.ilike(f"%{like_escape(name)}%", escape="\\"))
+    if search and search.strip():
+        clauses.append(
+            or_(
+                Job.name.ilike(f"%{like_escape(search.strip())}%", escape="\\"),
+                tag_clause(Job.tags, search),
+            )
+        )
+    clauses += [tag_clause(Job.tags, t) for t in (tags or []) if t.strip()]
+    if status_filter:
+        statuses = [s.strip() for s in status_filter.split(",") if s.strip()]
+        clauses.append(Job.status.in_(statuses))
+    elif not starred:
+        # Starred = "successful configs" and those are usually finalized jobs, so the
+        # star filter must see all statuses; only hide finalized/archived otherwise.
+        clauses.append(Job.status.notin_([JobStatus.FINALIZED, JobStatus.FINALIZING, JobStatus.ARCHIVED]))
+    return clauses
+
+
 @router.get("/jobs", response_model=JobListResponse)
 async def list_jobs(
     limit: int = Query(50, ge=1, le=200),
@@ -283,33 +330,22 @@ async def list_jobs(
     status_filter: str | None = Query(None, alias="status"),
     sort: str = Query("created_at_desc"),
     name: str | None = Query(None, min_length=1, max_length=255, description="Filter jobs by name (case-insensitive partial match)"),
-    search: str | None = Query(None, min_length=1, max_length=255, alias="q", description="Search jobs by name or tags (case-insensitive partial match)"),
+    search: str | None = Query(None, min_length=1, max_length=255, alias="q", description="Search jobs by name (partial) or by a whole tag"),
+    tags: list[str] = Query(default_factory=list, description="Only jobs carrying ALL of these tags, matched in full"),
     starred: bool | None = Query(None, description="Only jobs flagged as successful configs"),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    base = select(Job).where(Job.user_id == user.id)
-    if starred:
-        base = base.where(Job.config_starred.is_(True))
-    if name:
-        safe = name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        base = base.where(Job.name.ilike(f"%{safe}%", escape="\\"))
-    if search:
-        safe = search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-        pattern = f"%{safe}%"
-        base = base.where(
-            or_(
-                Job.name.ilike(pattern, escape="\\"),
-                Job.tags.ilike(pattern, escape="\\"),
-            )
+    base = select(Job).where(
+        *job_filter(
+            user_id=user.id,
+            status_filter=status_filter,
+            name=name,
+            search=search,
+            tags=tags,
+            starred=starred,
         )
-    if status_filter:
-        statuses = [s.strip() for s in status_filter.split(",") if s.strip()]
-        base = base.where(Job.status.in_(statuses))
-    elif not starred:
-        # Starred = "successful configs" and those are usually finalized jobs, so the
-        # star filter must see all statuses; only hide finalized/archived otherwise.
-        base = base.where(Job.status.notin_([JobStatus.FINALIZED, JobStatus.FINALIZING, JobStatus.ARCHIVED]))
+    )
 
     total_result = await db.execute(select(func.count()).select_from(base.subquery()))
     total = total_result.scalar_one()
@@ -487,6 +523,58 @@ async def list_jobs(
         )
 
     return JobListResponse(items=response_items, total=total, limit=limit, offset=offset)
+
+
+@router.get("/jobs/tag-counts")
+async def job_tag_counts(
+    status_filter: str | None = Query(None, alias="status"),
+    search: str | None = Query(None, min_length=1, max_length=255, alias="q"),
+    tags: list[str] = Query(default_factory=list),
+    starred: bool | None = Query(None),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Every tag in use, with how many jobs carry it under the CURRENT filter.
+
+    Counts scoped to the filter are what make the pills navigable rather than a guessing game:
+    with `kelly` selected, the tags left standing are the ones that actually co-occur with it, so
+    a dead end is visible before it is clicked instead of after. A selected tag always survives
+    its own filter (its count is the result count), so it can be clicked off again.
+
+    Driven by what is USED, not by the title_tags vocabulary -- the image repo learned that the
+    hard way, where 11 in-use tags were absent from the vocabulary and pills built from it would
+    have stranded them.
+
+    Declared above `/jobs/{job_id}` on purpose: that route takes a UUID, so a path reaching it
+    first would 422 rather than fall through.
+    """
+    clauses = job_filter(
+        user_id=user.id,
+        status_filter=status_filter,
+        search=search,
+        tags=tags,
+        starred=starred,
+    )
+
+    # unnest in a LATERAL rather than the target list: a set-returning function in the select
+    # list cannot then be grouped by.
+    tag_rows = (
+        func.unnest(func.string_to_array(Job.tags, ","))
+        .table_valued("tag")
+        .render_derived(name="t")
+    )
+    tag_expr = func.lower(func.btrim(tag_rows.c.tag))
+
+    stmt = (
+        select(tag_expr.label("tag"), func.count().label("count"))
+        .select_from(Job)
+        .join(tag_rows, true())
+        .where(*clauses, tag_expr != "")
+        .group_by(tag_expr)
+        .order_by(func.count().desc(), tag_expr)
+    )
+    rows = (await db.execute(stmt)).all()
+    return {"items": [{"tag": r.tag, "count": r.count} for r in rows]}
 
 
 @router.put("/jobs/reorder", response_model=list[JobResponse])

--- a/app/tag_filter.py
+++ b/app/tag_filter.py
@@ -1,0 +1,40 @@
+"""Whole-tag matching over a comma-joined tags column.
+
+Tags live as one text blob on both images ("Kelly, Missionary") and jobs ("AR, kelly"), so a
+substring match cannot tell where one tag ends and the next begins. Measured on the image repo
+2026-08-14, that is not a corner case: `%kelly%` matched 2,057 of 2,788 images -- 74% of the
+repo -- because it also caught KellyYoung, KellyBangs and KellyTeacher. Exact Kelly is 824.
+
+This module is the shared implementation, parameterised on the column, so images and jobs agree
+on what "has this tag" means.
+"""
+
+from sqlalchemy import func
+
+
+def like_escape(s: str) -> str:
+    """Neutralise LIKE metacharacters. Backslash first, or escaping the wildcards would itself
+    be re-escaped."""
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def normalise_tag(tag: str) -> str:
+    """Fold a tag to its comparison form: case- and space-insensitive.
+
+    Spaces come out because the vocabulary contains "Big dick" and the stored string is joined
+    with ", " -- inconsistent spacing around the commas is the norm, not the exception.
+    """
+    return tag.strip().lower().replace(" ", "")
+
+
+def tag_clause(column, tag: str):
+    """Match one WHOLE tag inside the comma-joined tags string of `column`.
+
+    Wrapping both sides in commas is what makes the boundaries real: ",kelly," cannot match
+    inside ",kellyyoung,". concat() rather than || because it is null-safe, so an untagged row
+    simply fails to match instead of poisoning the expression.
+    """
+    pattern = f"%,{like_escape(normalise_tag(tag))},%"
+    return func.concat(",", func.replace(func.lower(column), " ", ""), ",").like(
+        pattern, escape="\\"
+    )

--- a/tests/test_image_search.py
+++ b/tests/test_image_search.py
@@ -18,7 +18,8 @@ import pytest
 from sqlalchemy import func, select
 
 from app.models import ImageMeta
-from app.routes.images import image_filter, normalise_tag, search_pattern
+from app.routes.images import image_filter, search_pattern
+from app.tag_filter import normalise_tag
 
 
 class TestSearchPattern:

--- a/tests/test_job_tag_filter.py
+++ b/tests/test_job_tag_filter.py
@@ -1,0 +1,181 @@
+"""Filtering videos (jobs) by whole tags, and the search box that no longer over-matches them.
+
+Two issues, one fix. Videos could only be narrowed by a substring search over name AND tags
+(console#352 asked for the image repo's tag pills; console#353 reported the fallout: searching
+"AR" to find AR videos returned everything whose name or tags merely contained "ar").
+
+So `tags` matches a tag in FULL and every pill ANDs, while `q` keeps matching the job NAME as a
+fragment -- a half-remembered name is often the only handle there is -- but matches tags whole.
+
+These run against real Postgres: the whole point is what the database does with commas and
+NULLs, and a rendered-SQL assertion would test the string rather than the behaviour.
+"""
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.enums import JobStatus
+from app.main import app
+from app.models import Job, User
+from app.routes.jobs import job_filter
+
+
+@pytest.mark.asyncio
+class TestJobFilter:
+    async def _seed(self, db):
+        user = User(username=str(uuid.uuid4()), password_hash="x")
+        db.add(user)
+        await db.flush()
+
+        rows = [
+            # name,                 tags,                status
+            ("driveway ar tier1",   "AR, kelly",         JobStatus.FINALIZED),
+            ("kitchen argentina",   "argentina, kelly",  JobStatus.FINALIZED),
+            ("starlight bar scene", "starlight",         JobStatus.FINALIZED),
+            ("kelly closeup",       "kelly",             JobStatus.FINALIZED),
+            ("ar depth test",       "ar, depth",         JobStatus.PENDING),
+            ("untagged take",       None,                JobStatus.FINALIZED),
+        ]
+        for name, tags, job_status in rows:
+            db.add(Job(
+                user_id=user.id, name=name, tags=tags, status=job_status,
+                width=640, height=640, fps=60, seed=1000,
+            ))
+        await db.flush()
+        return user
+
+    async def _names(self, db, user, **kwargs):
+        clauses = job_filter(user_id=user.id, **kwargs)
+        rows = (await db.execute(select(Job.name).where(*clauses))).scalars().all()
+        return set(rows)
+
+    async def test_a_tag_pill_does_not_match_a_longer_tag_that_starts_with_it(self, db):
+        # console#353: "AR" pulled in argentina and starlight.
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", tags=["AR"]) == {
+            "driveway ar tier1",
+        }
+
+    async def test_tag_pills_are_conjunctive(self, db):
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized,pending", tags=["ar", "depth"]) == {
+            "ar depth test",
+        }
+
+    async def test_two_tags_no_job_carries_returns_nothing(self, db):
+        # There is no OR: two pills mean "both tags on one job", and empty is the honest answer.
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", tags=["AR", "starlight"]) == set()
+
+    async def test_tag_matching_ignores_case_and_spacing(self, db):
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", tags=[" Ar "]) == {
+            "driveway ar tier1",
+        }
+
+    async def test_untagged_jobs_never_match_a_tag(self, db):
+        # concat() is null-safe, so a NULL tags column fails to match rather than poisoning it.
+        user = await self._seed(db)
+        assert "untagged take" not in await self._names(db, user, status_filter="finalized", tags=["kelly"])
+
+    async def test_search_matches_a_whole_tag_not_a_fragment_of_one(self, db):
+        # The #353 fix, tag half: q=AR still finds the AR-*tagged* job, and no longer drags in
+        # the one tagged `argentina` or `starlight` purely on those tags.
+        user = await self._seed(db)
+        matched = await self._names(db, user, status_filter="finalized", search="AR")
+        assert "driveway ar tier1" in matched
+        assert "kelly closeup" not in matched
+
+    async def test_search_still_matches_ar_inside_a_name_which_is_what_the_pill_is_for(self, db):
+        # Deliberate, and the limit of what `q` can do: names are fragment-matched, so "AR" also
+        # returns "kitchen argentina" and "starlight bar scene" on their NAMES. That is the same
+        # property that makes a half-remembered name findable, and it cannot be both.
+        #
+        # The precise control is the tag pill, which returns only the AR-tagged job -- see
+        # test_a_tag_pill_does_not_match_a_longer_tag_that_starts_with_it. If name noise still
+        # bites in practice, word-boundary name matching is the follow-up, not a wider `q`.
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", search="AR") == {
+            "driveway ar tier1",
+            "kitchen argentina",
+            "starlight bar scene",
+        }
+
+    async def test_search_still_matches_a_name_fragment(self, db):
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", search="kitchen") == {
+            "kitchen argentina",
+        }
+
+    async def test_search_and_tags_and_together(self, db):
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", search="driveway", tags=["kelly"]) == {
+            "driveway ar tier1",
+        }
+
+    async def test_status_filter_still_applies_alongside_tags(self, db):
+        # The Videos page only ever asks for finalized work; a pill must not widen that.
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", tags=["ar"]) == {
+            "driveway ar tier1",
+        }
+
+    async def test_blank_tags_are_ignored_rather_than_filtering_nothing(self, db):
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", tags=["  "]) == {
+            "driveway ar tier1", "kitchen argentina", "starlight bar scene",
+            "kelly closeup", "untagged take",
+        }
+
+    async def test_like_wildcards_in_a_tag_are_escaped(self, db):
+        # A tag of "%" must not become match-everything.
+        user = await self._seed(db)
+        assert await self._names(db, user, status_filter="finalized", tags=["%"]) == set()
+
+
+@pytest.mark.asyncio
+class TestTagCountsEndpoint:
+    """`/jobs/tag-counts` — the numbers on the pills.
+
+    Counts are scoped to the CURRENT filter, which is what makes the pill row navigable: with
+    `kelly` selected, the tags left standing are the ones that co-occur with it, so a dead end is
+    visible before it is clicked instead of after.
+    """
+
+    async def _counts(self, db, user, **params):
+        app.dependency_overrides[get_db] = lambda: db
+        app.dependency_overrides[get_current_user] = lambda: user
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                res = await client.get("/jobs/tag-counts", params=params)
+            assert res.status_code == 200, res.text
+            return {row["tag"]: row["count"] for row in res.json()["items"]}
+        finally:
+            app.dependency_overrides.clear()
+
+    async def test_counts_every_tag_in_use_under_the_status_filter(self, db):
+        user = await TestJobFilter()._seed(db)
+        # The Videos page asks for finalized work only, so the pending `depth` job is not counted.
+        assert await self._counts(db, user, status="finalized") == {
+            "ar": 1, "kelly": 3, "argentina": 1, "starlight": 1,
+        }
+
+    async def test_counts_narrow_to_the_selected_tag(self, db):
+        user = await TestJobFilter()._seed(db)
+        # With kelly selected, only what co-occurs with kelly is offered — and kelly itself
+        # survives at the result count, so the pill can be clicked off again.
+        assert await self._counts(db, user, status="finalized", tags=["kelly"]) == {
+            "kelly": 3, "ar": 1, "argentina": 1,
+        }
+
+    async def test_a_route_named_tag_counts_is_not_swallowed_by_jobs_job_id(self, db):
+        # /jobs/{job_id} takes a UUID, so a path reaching it first would 422 rather than fall
+        # through. This is the regression guard for the declaration order.
+        user = await TestJobFilter()._seed(db)
+        assert "ar" in await self._counts(db, user, status="finalized")

--- a/tests/test_job_tag_filter.py
+++ b/tests/test_job_tag_filter.py
@@ -179,3 +179,40 @@ class TestTagCountsEndpoint:
         # through. This is the regression guard for the declaration order.
         user = await TestJobFilter()._seed(db)
         assert "ar" in await self._counts(db, user, status="finalized")
+
+
+@pytest.mark.asyncio
+class TestListJobsEndpoint:
+    """`GET /jobs?tags=` from the outside — the console sends repeated keys.
+
+    Worth an endpoint test rather than only exercising `job_filter`: a `tags` list that does not
+    bind arrives as an absent filter, and an unfiltered list looks like a working page rather
+    than a broken one.
+    """
+
+    async def _get(self, db, user, params):
+        app.dependency_overrides[get_db] = lambda: db
+        app.dependency_overrides[get_current_user] = lambda: user
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                res = await client.get("/jobs", params=params)
+            assert res.status_code == 200, res.text
+            return {j["name"] for j in res.json()["items"]}
+        finally:
+            app.dependency_overrides.clear()
+
+    async def test_a_repeated_tags_key_filters_rather_than_being_dropped(self, db):
+        user = await TestJobFilter()._seed(db)
+        assert await self._get(db, user, [("status", "finalized"), ("tags", "ar")]) == {
+            "driveway ar tier1",
+        }
+
+    async def test_two_repeated_tags_keys_and(self, db):
+        user = await TestJobFilter()._seed(db)
+        params = [("status", "finalized,pending"), ("tags", "ar"), ("tags", "depth")]
+        assert await self._get(db, user, params) == {"ar depth test"}
+
+    async def test_no_tags_returns_the_unfiltered_page(self, db):
+        user = await TestJobFilter()._seed(db)
+        assert len(await self._get(db, user, [("status", "finalized")])) == 5


### PR DESCRIPTION
Backend for [wanly-console#352](https://github.com/DavidJBarnes/wanly-console/issues/352) (Videos needs the image repo's filter) and [wanly-console#353](https://github.com/DavidJBarnes/wanly-console/issues/353) (searching "AR" pulls up non-AR videos).

## The problem

`GET /jobs?q=` was one substring match over `name` OR `tags`. Tags are stored as a single comma-joined blob, so a substring cannot tell where one tag ends and the next begins — searching `AR` matched `argentina` and `starlight`. The image repo hit exactly this in July (`%kelly%` matched 74% of the repo) and fixed it with whole-tag matching plus counted pills; jobs never got the same treatment.

## Changes

- **`GET /jobs` gains `tags`** — matched in full, strictly conjunctive. Two pills mean "both tags on one job"; there is no OR.
- **`GET /jobs/tag-counts`** — every tag in use with how many jobs carry it *under the current filter*, so the pill row shows what actually co-occurs with the current selection rather than offering dead ends. Declared above `/jobs/{job_id}` on purpose (that route takes a UUID and would 422 rather than fall through) — with a regression test on the ordering.
- **`q` no longer matches tags by substring.** It still matches the job **name** as a fragment, and now matches a **whole** tag.
- `app/tag_filter.py` holds the comma-wrapping trick, shared by images and jobs.

## Known limit, deliberately

`q=AR` still returns jobs whose **name** contains "ar" (`kitchen argentina`). Name fragment matching is what makes a half-remembered name findable and it cannot be both things at once — the tag pill is the precise control, and that is what #352 puts on screen. Encoded as a named test rather than left to be rediscovered. If name noise still bites in practice, word-boundary name matching is the follow-up.

## Testing

`574 passed` against real Postgres (REQUIRE_DB=1). 15 new tests in `tests/test_job_tag_filter.py` cover the boundary cases against actual rows — a longer tag that starts with a shorter one, conjunction, NULL tags, case/spacing folding, LIKE wildcard escaping, status interaction, and the counts endpoint.

Console PR follows.