### PR TITLE
Carry LTX recipe parameters on a segment

### DIFF
--- a/alembic/versions/069_ltx_recipe_params.py
+++ b/alembic/versions/069_ltx_recipe_params.py
@@ -1,0 +1,49 @@
+"""LTX recipe parameters on a segment
+
+Revision ID: 069
+Revises: 068
+Create Date: 2026-08-31
+
+LTX 2.3 replaces WAN 2.2 as the engine underneath Wanly. Most of what a render needs is
+already on the segment and means the same thing for either engine — prompt, negative_prompt,
+seed, start_image, output_path — so this adds only what is genuinely new.
+
+What is new is the RECIPE. On the LTX side a render is driven by a validated (character, pose)
+configuration authored in a sheet, and that configuration reduced, across sixteen validated
+recipes, to exactly two variables: the character LoRA and the prompt. Every other field —
+checkpoint, content LoRA, distill, guidance, steps, frames, resolution, negative — had one
+distinct value across all sixteen. So the useful thing to record per segment is which recipe
+ran and which of its defaults were overridden, not a column per parameter.
+
+Hence one JSONB column rather than a dozen nullable ones. The shape:
+
+    {"recipe": "Missionary POV", "character": "k3lly2026",
+     "char_lora": "k3lly2026_v2", "char_s1": 0.8, "char_s2": 1.5,
+     "frames": 241, "graph_sha256": "85649768667ba700..."}
+
+`graph_sha256` is the one field worth calling out. A recipe is value patches on a pinned
+graph, so the hash of the RESOLVED graph detects any change to shared state that alters a
+recipe, at no GPU cost. It is how that project caught a regenerated sheet silently overwriting
+a hand-authored prompt, within minutes, on the day the check was written. Recording it against
+the segment is what makes a render provably the configuration that was signed off, rather than
+something that merely claims to be.
+
+Nullable, nothing backfilled: NULL means "not an LTX recipe render", which is every WAN
+segment that already exists.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "069"
+down_revision = "068"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("segments", sa.Column("ltx_recipe", JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("segments", "ltx_recipe")

--- a/app/models.py
+++ b/app/models.py
@@ -222,6 +222,19 @@ class Segment(Base):
     #  "frames_sampled": n, "frames_with_face": n}
     lynx_identity_scores = mapped_column(JSON, nullable=True)
     negative_prompt = mapped_column(Text, nullable=True)
+    # LTX recipe render: which validated (character, pose) configuration produced this
+    # segment, and any of its defaults the user overrode. One JSONB rather than a column
+    # per parameter, because across sixteen validated recipes every field except the
+    # character LoRA and the prompt had exactly ONE distinct value — a recipe is
+    # (character LoRA, prompt) and the rest is one global configuration.
+    #
+    # graph_sha256 is the regression trail: a recipe is value patches on a pinned graph, so
+    # the hash of the resolved graph detects any change to shared state that alters a recipe,
+    # at no GPU cost. It is what makes a render provably the configuration that was signed
+    # off rather than one that merely claims to be.
+    #
+    # NULL means "not an LTX recipe render" — every WAN segment, and any free-form LTX one.
+    ltx_recipe = mapped_column(JSONB, nullable=True)
     reprocess_type = mapped_column(String(20), nullable=True)
     # Foundry smashcut carrier (reprocess_type="smashcut_concat"): ordered list of source clip
     # output_paths to concatenate + the transition style ("seamless" | "black").

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -268,6 +268,7 @@ async def create_job(
         faceswap_pixel_boost=seg.faceswap_pixel_boost,
         seed_faceswap=seg.seed_faceswap,
         negative_prompt=seg.negative_prompt,
+        ltx_recipe=seg.ltx_recipe,
         auto_finalize=seg.auto_finalize,
         video_preset_id=seg.video_preset_id,
     )

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -214,6 +214,7 @@ async def add_segment(
         faceswap_pixel_boost=body.faceswap_pixel_boost,
         seed_faceswap=body.seed_faceswap,
         negative_prompt=negative_prompt,
+        ltx_recipe=body.ltx_recipe,
         auto_finalize=body.auto_finalize,
         video_preset_id=body.video_preset_id,
     )
@@ -489,6 +490,10 @@ async def claim_next_segment(
         sampler_name=sampler_name,
         scheduler=scheduler,
         negative_prompt=negative_prompt,
+        # Passed through verbatim. The engine must never look a recipe up for itself: an
+        # engine that cannot look one up cannot look up a STALE one, which is the failure
+        # this shape exists to make impossible (see wanly-api#207).
+        ltx_recipe=segment.ltx_recipe,
         reprocess_type=segment.reprocess_type,
         output_path=segment.output_path,
         seed_faceswap=seed_faceswap,

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -23,6 +23,10 @@ class SegmentCreate(BaseModel):
     # segment. Uses faceswap_image, so it only has an effect when faceswap is configured.
     seed_faceswap: bool = False
     negative_prompt: Optional[str] = None
+    # LTX recipe render: which validated (character, pose) configuration this segment ran,
+    # plus any of its defaults the user overrode and the resolved graph hash. NULL means
+    # "not a recipe render". See Segment.ltx_recipe for why this is one field and not a dozen.
+    ltx_recipe: Optional[dict[str, Any]] = None
     auto_finalize: bool = False
     transition: Optional[str] = None
     video_preset_id: Optional[UUID] = None
@@ -160,6 +164,10 @@ class SegmentResponse(BaseModel):
     faceswap_pixel_boost: Optional[str] = None
     seed_faceswap: bool = False
     negative_prompt: Optional[str] = None
+    # LTX recipe render: which validated (character, pose) configuration this segment ran,
+    # plus any of its defaults the user overrode and the resolved graph hash. NULL means
+    # "not a recipe render". See Segment.ltx_recipe for why this is one field and not a dozen.
+    ltx_recipe: Optional[dict[str, Any]] = None
     auto_finalize: bool
     transition: Optional[str]
     # Soft-deleted: kept for its rating, tags and notes, excluded from the video.
@@ -258,6 +266,10 @@ class SegmentClaimResponse(BaseModel):
     sampler_name: Optional[str] = None
     scheduler: Optional[str] = None
     negative_prompt: Optional[str] = None
+    # LTX recipe render: which validated (character, pose) configuration this segment ran,
+    # plus any of its defaults the user overrode and the resolved graph hash. NULL means
+    # "not a recipe render". See Segment.ltx_recipe for why this is one field and not a dozen.
+    ltx_recipe: Optional[dict[str, Any]] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None
     width: int

--- a/tests/test_first_segment_fields.py
+++ b/tests/test_first_segment_fields.py
@@ -43,3 +43,36 @@ def test_the_two_new_tunables_specifically_round_trip():
     from_jobs = _kwargs_passed_to_segment("app/routes/jobs.py")
     assert "faceswap_model" in from_jobs
     assert "faceswap_pixel_boost" in from_jobs
+
+
+def test_job_creation_persists_ltx_recipe():
+    """A recipe render creates its job and segment 0 in one call, so this is THE path it uses.
+
+    Dropped here, the segment would generate with the daemon's defaults instead of the
+    validated recipe -- and would look fine, because a plausible clip comes back either way.
+    The graph hash recorded against it would then describe a configuration that never ran.
+    """
+    from_jobs = _kwargs_passed_to_segment("app/routes/jobs.py")
+    assert "ltx_recipe" in from_jobs, "first_segment silently drops ltx_recipe"
+
+
+def test_every_client_supplied_segment_field_is_wired_into_both_paths():
+    """The general form of the two tests above.
+
+    Both previous failures were the same shape -- a field added to the append path and not to
+    job creation -- caught only after the fact, and only because someone queried the row. The
+    faceswap guard was written for one family of fields and the ltx one for a single field;
+    neither would catch the NEXT field added. This does.
+
+    A field that legitimately never comes from the client on segment 0 goes in
+    _NOT_CLIENT_SUPPLIED above, which makes the exemption a deliberate, reviewable line rather
+    than a silent omission.
+    """
+    from_jobs = _kwargs_passed_to_segment("app/routes/jobs.py")
+    from_segments = _kwargs_passed_to_segment("app/routes/segments.py")
+    client_fields = set(SegmentCreate.model_fields) - _NOT_CLIENT_SUPPLIED
+    missing = (client_fields & from_segments) - from_jobs
+    assert not missing, (
+        "fields wired into the append path but not job creation: "
+        f"{sorted(missing)} -- segment 0 would silently drop them"
+    )


### PR DESCRIPTION
Adds one JSONB column so an LTX recipe render can be created, claimed and recorded through the queue that already exists.

Refs #206

## The queue does not change

This ticket was originally scoped as a parallel LTX track — a `kind="ltx"` claim lane, a narrowed `kind="gpu"`, guards against stitching firing on LTX jobs. That was the wrong shape. LTX **replaces** WAN as the engine underneath Wanly (wanly-gpu-docker#41), so every worker is an LTX worker and every new segment is an LTX segment. There is nothing to discriminate between.

`GET /segments/next` is untouched: same skip-locked claim, heartbeat reclaim, priority ordering, same #203 fix. What changes is what the daemon does with a claimed segment (wanly-gpu-daemon#146).

## One column, not a dozen

Across sixteen validated recipes, every field except the character LoRA and the prompt had **one distinct value**: checkpoint, content LoRA, distill, guidance, steps, frames, resolution, negative. A recipe is `(character LoRA, prompt)` and the rest is one global configuration. So what is worth recording per segment is which recipe ran and which defaults were overridden — a shape, not a schema.

```json
{"recipe": "Missionary POV", "character": "k3lly2026",
 "char_lora": "k3lly2026_v2", "char_s1": 0.8, "char_s2": 1.5,
 "frames": 241, "graph_sha256": "85649768667ba700..."}
```

`graph_sha256` earns its place: the hash of the resolved graph detects any change to shared state that alters a recipe, at no GPU cost. It caught a regenerated sheet silently overwriting a hand-authored prompt within minutes of being written.

Nullable, nothing backfilled — NULL means "not a recipe render", which is every existing WAN segment.

## I walked into the trap this repo already has a test for

`test_first_segment_fields.py` exists because `faceswap_model` and `faceswap_pixel_boost` once shipped into the append path only, so a job created with them in `first_segment` silently fell back to daemon defaults — invisible unless you queried the row.

My first cut wired `routes/segments.py` and not `routes/jobs.py`. That is precisely the path a recipe render uses, because it creates its job and segment 0 in one call. Dropped there, the segment generates on daemon defaults, returns a perfectly plausible clip, and the hash recorded against it describes a configuration that never ran.

So rather than adding a third narrow guard, the general one: **every client-supplied `SegmentCreate` field must be wired into both paths.** The faceswap test covered a prefix and would not have caught this; this catches the next field too. Exemptions live in an explicit list, so an omission has to be argued for rather than happening quietly.

## Verification

- 460 passed, 119 skipped (the skips are DB-backed; no Postgres locally)
- Both new tests proven against broken code: deleted the `routes/jobs.py` wiring, watched them fail with `first_segment silently drops ltx_recipe`, restored it
- Migration `069` parses and is a single additive nullable column

Not exercised end to end — no LTX render has gone through the queue yet, which needs wanly-gpu-daemon#146.