### PR TITLE
wanly-api owns the LTX recipe book

### DIFF
--- a/alembic/versions/070_ltx_recipe_book.py
+++ b/alembic/versions/070_ltx_recipe_book.py
@@ -1,0 +1,53 @@
+"""The LTX recipe book lives in the API
+
+Revision ID: 070
+Revises: 069
+Create Date: 2026-08-31
+
+An LTX render is driven by a validated (character, pose) configuration authored in a
+hand-maintained .ods sheet. Until now that sheet was parsed into a recipes.json which existed
+in TWO copies — the repo's and the engine's — kept in step by a Dockerfile COPY. Switching the
+engine to a bind mount removed the rebuild, and with it the copy. Nothing replaced it. A
+16-render batch then ran against stale prompts, and a finding was drawn from those renders,
+written up as established, and agreed to before being retracted.
+
+The check that missed it called GET /recipes and confirmed it returned 8 recipes with the
+right names. Both were equally true of the stale file. It confirmed facts that had not changed
+instead of content that had.
+
+So: one authority. The API holds the book, the console reads it from here, and the engine
+receives the RESOLVED recipe inside the claim rather than looking one up. An engine that
+cannot look a recipe up cannot look up a stale one — the drift becomes structurally
+impossible rather than something a check has to catch.
+
+A single row, because there is one book. `source_sha256` is over the uploaded .ods bytes and
+`book_sha256` over the parsed content — the second is the one that matters, since a
+re-saved sheet with no edits changes the file bytes but not the book.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "070"
+down_revision = "069"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ltx_recipe_book",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("book", JSONB(), nullable=False),
+        sa.Column("book_sha256", sa.String(length=64), nullable=False),
+        sa.Column("source_sha256", sa.String(length=64), nullable=False),
+        sa.Column("source_filename", sa.Text(), nullable=True),
+        sa.Column("imported_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        # One book. The constraint is the documentation: this is a singleton, not a history.
+        sa.CheckConstraint("id = 1", name="ck_ltx_recipe_book_singleton"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ltx_recipe_book")

--- a/app/ltx_sheet.py
+++ b/app/ltx_sheet.py
@@ -1,0 +1,157 @@
+"""Parse the hand-authored LTX recipe sheet (.ods) into the recipe book.
+
+The sheet is the source of truth for what a recipe IS, and **David authors it by hand**.
+Two consequences that this module exists to respect:
+
+* **Never regenerate the sheet.** Regenerating it from code once silently overwrote a
+  hand-edited prompt; the graph hash caught it within minutes, but only because something
+  was watching. Reading is the only direction.
+* **Parse defensively.** Labels acquire annotations — adding "(hardcoded)" to a column-A
+  label broke the parser once. The sheet now leads with an `id` column precisely so the
+  machine key is separate from the human label, and labels can change freely.
+
+Ported from storyboard's `recipes/sheet_to_yaml.py`. The parsing lives HERE now: wanly-api
+owns the recipe book, and an engine that cannot look a recipe up cannot look up a stale one.
+That is the point — two copies of recipes.json once shipped a 16-render batch against stale
+prompts, and the check that missed it compared counts rather than content.
+"""
+
+import hashlib
+import io
+import re
+import xml.etree.ElementTree as ET
+import zipfile
+from typing import Any
+
+T = "urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+X = "urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+
+# A cell repeated more than this is ODS padding out to the sheet edge, not real data.
+_REPEAT_IS_PADDING = 40
+
+
+class SheetError(ValueError):
+    """The upload is not a recipe sheet we can read."""
+
+
+def _read_sheets(data: bytes) -> dict[str, list[list[str]]]:
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as z:
+            root = ET.fromstring(z.read("content.xml"))
+    except (zipfile.BadZipFile, KeyError, ET.ParseError) as e:
+        raise SheetError(f"not a readable .ods file: {type(e).__name__}: {e}") from e
+
+    sheets: dict[str, list[list[str]]] = {}
+    for sh in root.iter(f"{{{T}}}table"):
+        rows: list[list[str]] = []
+        for row in sh.findall(f".//{{{T}}}table-row"):
+            cells: list[str] = []
+            for c in row.findall(f"{{{T}}}table-cell"):
+                rep = int(c.get(f"{{{T}}}number-columns-repeated", "1"))
+                txt = " ".join(
+                    "".join(p.itertext()).strip() for p in c.findall(f"{{{X}}}p")
+                )
+                if rep > _REPEAT_IS_PADDING:
+                    rep = 1
+                cells.extend([txt.strip()] * rep)
+            while cells and cells[-1] == "":
+                cells.pop()
+            rows.append(cells)
+        sheets[sh.get(f"{{{T}}}name")] = rows
+    return sheets
+
+
+def _one_character(rows: list[list[str]]) -> dict[str, Any]:
+    grid = [r for r in rows if r]
+    if not grid:
+        raise SheetError("character tab is empty")
+    header = grid[0]
+
+    # Leading `id | label | source` columns are the current layout. The legacy layout put
+    # the source in the label as "Checkpoint (hardcoded)" — which is exactly the coupling
+    # that broke the parser, and why the id column exists.
+    has_id = header[0].strip().lower() == "id"
+    off = 3 if has_id else 1
+    names = header[off:]
+
+    params: dict[str, list[str]] = {}
+    sources: dict[str, str] = {}
+    labels: dict[str, str] = {}
+    for r in grid[1:]:
+        if not r or not r[0]:
+            continue
+        if has_id:
+            key = r[0].strip()
+            labels[key] = r[1] if len(r) > 1 else ""
+            sources[key] = r[2] if len(r) > 2 else ""
+        else:
+            m = re.match(r"^(.*?)\s*\(([^)]*)\)\s*$", r[0])
+            key = (m.group(1) if m else r[0]).strip()
+            labels[key] = key
+            sources[key] = m.group(2).strip() if m else ""
+        params[key] = r[off:]
+
+    out: dict[str, Any] = {"sources": sources, "labels": labels, "recipes": {}}
+    for i, name in enumerate(names):
+        def g(key: str, default: str = "") -> str:
+            v = params.get(key, [])
+            return v[i] if i < len(v) else default
+
+        out["recipes"][name] = {
+            "checkpoint": g("checkpoint"),
+            "char_lora": g("char_lora"),
+            "char_s1": g("char_s1"),
+            "char_s2": g("char_s2"),
+            "content_lora": g("content_lora"),
+            "distill": g("distill"),
+            "prompt": g("prompt_positive"),
+            "negative": g("prompt_negative"),
+            "guidance": g("guidance"),
+            "steps": g("steps"),
+            "frames": g("frames"),
+            "resolution": g("resolution"),
+            "test_images": [s.strip() for s in g("input_image").split(",") if s.strip()],
+            "validated": g("validated"),
+        }
+    return out
+
+
+def parse_sheet(data: bytes) -> dict[str, Any]:
+    """Bytes of a .ods -> the recipe book. Pure: reads, never writes."""
+    sheets = _read_sheets(data)
+    if "Prompts" not in sheets:
+        raise SheetError(
+            f"no 'Prompts' tab — found {sorted(sheets)}. That tab holds the shared "
+            "prompt/negative/guidance text every recipe refers to by key."
+        )
+    definitions = {
+        r[0]: r[1] for r in sheets["Prompts"] if len(r) >= 2 and r[0] != "key"
+    }
+    characters = [k for k in sheets if k != "Prompts"]
+    if not characters:
+        raise SheetError("no character tabs — a sheet needs at least one besides 'Prompts'")
+
+    book: dict[str, Any] = {"definitions": definitions, "characters": {}}
+    for ch in characters:
+        book["characters"][ch] = _one_character(sheets[ch])
+
+    # Back-compat: the first character also sits at the top level, which is the shape the
+    # engine served and the console already reads.
+    first = book["characters"][characters[0]]
+    book.update({
+        "character": characters[0],
+        "sources": first["sources"],
+        "labels": first["labels"],
+        "recipes": first["recipes"],
+    })
+    return book
+
+
+def book_sha256(book: dict[str, Any]) -> str:
+    """Content hash of the whole book.
+
+    Compare CONTENT, not counts. A stale book has the right number of everything — that is
+    precisely how a 16-render batch against stale prompts went unnoticed.
+    """
+    import json
+    return hashlib.sha256(json.dumps(book, sort_keys=True).encode()).hexdigest()

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
 from app.reservation_monitor import reservation_monitor
 from app.limiter import limiter
-from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, runpod, segments, stats, tags, video_presets, videos, wildcards, workers
+from app.routes import app_settings, auth, faceswap, favorites, files, images, jobs, loras, ltx_recipes, runpod, segments, stats, tags, video_presets, videos, wildcards, workers
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +66,7 @@ app.include_router(segments.router)
 app.include_router(faceswap.router)
 app.include_router(files.router)
 app.include_router(loras.router)
+app.include_router(ltx_recipes.router)
 app.include_router(tags.router)
 app.include_router(videos.router)
 app.include_router(wildcards.router)

--- a/app/models.py
+++ b/app/models.py
@@ -451,3 +451,24 @@ class GpuReservation(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
+
+
+class LtxRecipeBook(Base):
+    """The parsed LTX recipe sheet. One row — see migration 070 for why the API owns it.
+
+    The console reads recipes from here, and a claim carries the RESOLVED recipe rather than a
+    name for the engine to look up. That is what makes stale-recipe drift structurally
+    impossible instead of something a check has to notice.
+    """
+    __tablename__ = "ltx_recipe_book"
+
+    id = mapped_column(Integer, primary_key=True)
+    book = mapped_column(JSONB, nullable=False)
+    # Over the parsed content. This is the one that matters: re-saving the sheet with no edits
+    # changes the file bytes but not the book.
+    book_sha256 = mapped_column(String(64), nullable=False)
+    # Over the uploaded .ods bytes, so "did this exact file get imported" is answerable.
+    source_sha256 = mapped_column(String(64), nullable=False)
+    source_filename = mapped_column(Text, nullable=True)
+    imported_at = mapped_column(DateTime(timezone=True), nullable=False,
+                                server_default=text("now()"))

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -1,0 +1,111 @@
+"""The LTX recipe book: import the sheet, serve the book.
+
+wanly-api owns the book (migration 070). The console reads recipes from here, and a claim
+carries the RESOLVED recipe rather than a name for the engine to look up — an engine that
+cannot look a recipe up cannot look up a stale one.
+"""
+
+import hashlib
+import logging
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.ltx_sheet import SheetError, book_sha256, parse_sheet
+from app.models import LtxRecipeBook, User
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# The sheet is a few hundred KB of XML in a zip. Anything far larger is not a recipe sheet,
+# and refusing early beats unzipping it to find out.
+MAX_SHEET_BYTES = 8 * 1024 * 1024
+
+
+@router.get("/recipes")
+async def get_recipes(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """The recipe book, in the shape the console already reads.
+
+    404 rather than an empty book when nothing has been imported: an empty book and a missing
+    one look identical downstream, and "the dropdowns are empty" should not be the first sign
+    that no sheet was ever uploaded.
+    """
+    row = (await db.execute(select(LtxRecipeBook).where(LtxRecipeBook.id == 1))).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No recipe book has been imported. POST the sheet to /recipes/import.",
+        )
+    book = dict(row.book)
+    # Provenance travels with the book so a render can be tied back to the exact sheet that
+    # produced it, without a second call.
+    book["book_sha256"] = row.book_sha256
+    book["imported_at"] = row.imported_at.isoformat() if row.imported_at else None
+    return book
+
+
+@router.post("/recipes/import")
+async def import_recipes(
+    file: UploadFile = File(...),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Upload the hand-authored .ods and replace the book.
+
+    Parsing happens HERE rather than in a script that writes a file, so there is exactly one
+    parser and exactly one copy. Two copies of recipes.json once shipped a 16-render batch
+    against stale prompts.
+
+    The sheet itself is never written back. It is authored by hand, and regenerating it from
+    code once silently overwrote a hand-edited prompt.
+    """
+    raw = await file.read()
+    if not raw:
+        raise HTTPException(status_code=400, detail="empty upload")
+    if len(raw) > MAX_SHEET_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"sheet is {len(raw)} bytes, over the {MAX_SHEET_BYTES} limit",
+        )
+    try:
+        book = parse_sheet(raw)
+    except SheetError as e:
+        # The sheet is hand-authored, so a parse failure is usually a human edit rather than a
+        # corrupt file. Say what was wrong, not just that something was.
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    new_hash = book_sha256(book)
+    row = (await db.execute(select(LtxRecipeBook).where(LtxRecipeBook.id == 1))).scalar_one_or_none()
+    previous = row.book_sha256 if row else None
+
+    if row is None:
+        row = LtxRecipeBook(id=1)
+        db.add(row)
+    row.book = book
+    row.book_sha256 = new_hash
+    row.source_sha256 = hashlib.sha256(raw).hexdigest()
+    row.source_filename = file.filename
+    await db.commit()
+    await db.refresh(row)
+
+    characters = {c: len(v.get("recipes", {})) for c, v in book.get("characters", {}).items()}
+    logger.info(
+        "recipe book imported from %s: %s, book_sha256 %s (was %s)",
+        file.filename, characters, new_hash[:16], (previous or "none")[:16],
+    )
+    # `changed` is the useful bit: re-saving the sheet with no edits changes the file bytes
+    # but not the book, and the caller should be able to tell those apart.
+    return {
+        "characters": characters,
+        "definitions": len(book.get("definitions", {})),
+        "book_sha256": new_hash,
+        "previous_book_sha256": previous,
+        "changed": previous != new_hash,
+        "imported_at": row.imported_at.isoformat() if row.imported_at else None,
+    }

--- a/tests/test_ltx_sheet.py
+++ b/tests/test_ltx_sheet.py
@@ -1,0 +1,137 @@
+"""Parsing the hand-authored LTX recipe sheet.
+
+Every failure here is silent: a mis-parsed sheet still yields a book with the right shape and
+the right number of things, and the render that follows looks fine. That is not hypothetical —
+a 16-render batch once ran against stale prompts, and the check that missed it compared counts
+and one field, both identical in the stale data.
+"""
+
+import io
+import zipfile
+
+import pytest
+
+from app.ltx_sheet import SheetError, book_sha256, parse_sheet
+
+REAL_SHEET = "/home/david/projects/storyboard/renders/recipe-sheet.ods"
+
+
+def _ods(sheets: dict[str, list[list[str]]]) -> bytes:
+    """Minimal .ods: just enough content.xml for the parser."""
+    T = "urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+    X = "urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+    parts = [f'<office:document-content xmlns:office="urn:x" xmlns:table="{T}" xmlns:text="{X}">']
+    for name, rows in sheets.items():
+        parts.append(f'<table:table table:name="{name}">')
+        for row in rows:
+            parts.append("<table:table-row>")
+            for cell in row:
+                parts.append(f"<table:table-cell><text:p>{cell}</text:p></table:table-cell>")
+            parts.append("</table:table-row>")
+        parts.append("</table:table>")
+    parts.append("</office:document-content>")
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("content.xml", "".join(parts))
+    return buf.getvalue()
+
+
+BASIC = {
+    "Prompts": [["key", "text"], ["P.A", "a woman walking"], ["N.STD", "blurry, distorted"]],
+    "alice": [
+        ["id", "label", "source", "Pose One", "Pose Two"],
+        ["char_lora", "Char Lora", "ui", "alice_v2", "alice_v2"],
+        ["char_s1", "Stage 1", "ui with defaults", "0.8", "0.8"],
+        ["char_s2", "Stage 2", "ui with defaults", "1.5", "1.5"],
+        ["prompt_positive", "Prompt", "ui with defaults", "P.A", "P.A"],
+        ["prompt_negative", "Negative", "ui with defaults", "N.STD", "N.STD"],
+        ["validated", "Validated", "", "Yes", "No"],
+    ],
+}
+
+
+def test_parses_characters_and_recipes():
+    b = parse_sheet(_ods(BASIC))
+    assert list(b["characters"]) == ["alice"]
+    assert sorted(b["characters"]["alice"]["recipes"]) == ["Pose One", "Pose Two"]
+    assert b["definitions"]["P.A"] == "a woman walking"
+
+
+def test_source_annotations_are_captured_from_their_own_column():
+    """The `id` column exists so the machine key is separate from the human label.
+
+    Before it, the source lived inside the label as "Checkpoint (hardcoded)" — and adding that
+    annotation broke the parser. Labels must be free to change without breaking anything.
+    """
+    b = parse_sheet(_ods(BASIC))
+    assert b["sources"]["char_lora"] == "ui"
+    assert b["sources"]["char_s1"] == "ui with defaults"
+    assert b["labels"]["char_s1"] == "Stage 1"
+
+
+def test_legacy_label_annotation_still_parses():
+    legacy = {
+        "Prompts": [["key", "text"], ["P.A", "x"]],
+        "alice": [["label", "Pose One"], ["char_lora (ui)", "alice_v2"]],
+    }
+    b = parse_sheet(_ods(legacy))
+    assert b["characters"]["alice"]["recipes"]["Pose One"]["char_lora"] == "alice_v2"
+    assert b["sources"]["char_lora"] == "ui"
+
+
+def test_missing_prompts_tab_is_a_named_error_not_a_shrug():
+    with pytest.raises(SheetError, match="Prompts"):
+        parse_sheet(_ods({"alice": [["id", "label", "source", "Pose"]]}))
+
+
+def test_not_an_ods_is_a_named_error():
+    with pytest.raises(SheetError, match="readable"):
+        parse_sheet(b"this is not a zip file")
+
+
+def test_book_hash_tracks_content_not_formatting():
+    """Compare CONTENT, not counts.
+
+    A stale book has the right number of everything, which is exactly how the stale-prompt
+    batch went unnoticed. The hash is what makes 'has this actually changed' answerable.
+    """
+    a = parse_sheet(_ods(BASIC))
+    same = parse_sheet(_ods(BASIC))
+    assert book_sha256(a) == book_sha256(same)
+
+    edited = {k: [r[:] for r in v] for k, v in BASIC.items()}
+    edited["Prompts"][1][1] = "a woman running"      # one word, in shared prompt text
+    assert book_sha256(parse_sheet(_ods(edited))) != book_sha256(a)
+
+
+@pytest.mark.skipif(not __import__("os").path.exists(REAL_SHEET), reason="real sheet not present")
+def test_matches_the_real_sheet_and_the_engines_own_output():
+    """The port must be faithful, not merely plausible.
+
+    Verified 2026-08-31 against the parser this was ported from: byte-identical book,
+    sha256 31dfad3847a8a3f8.
+    """
+    b = parse_sheet(open(REAL_SHEET, "rb").read())
+    assert set(b["characters"]) == {"k3lly2026", "k3llydw", "p@y"}
+    assert all(len(c["recipes"]) == 8 for c in b["characters"].values())
+    r = b["characters"]["k3lly2026"]["recipes"]["Missionary POV"]
+    assert r["char_lora"] == "k3lly2026_v2"
+    assert (r["char_s1"], r["char_s2"]) == ("0.8", "1.5")
+    # content_lora "none" is not incidental: dropping DR34ML4Y is what removed the motion
+    # horror, and it is universal across all sixteen validated recipes.
+    assert r["content_lora"] == "none"
+
+
+def test_first_character_is_mirrored_at_the_top_level():
+    """The console falls back to book.recipes / book.sources when there is no character map.
+
+    Dropping these passed every other test in this file — the parser looked fine, the
+    characters were all there, and the failure would have surfaced as empty dropdowns in the
+    UI against an engine that predates multi-character. Found by deliberately deleting the
+    mirror and watching nothing fail.
+    """
+    b = parse_sheet(_ods(BASIC))
+    assert b["character"] == "alice"
+    assert b["recipes"] == b["characters"]["alice"]["recipes"]
+    assert b["sources"] == b["characters"]["alice"]["sources"]
+    assert b["labels"] == b["characters"]["alice"]["labels"]


### PR DESCRIPTION
One authority for what a recipe is. `POST /recipes/import` takes the hand-authored `.ods`; `GET /recipes` serves the book the console reads.

Refs #207

## Why this is its own change

The sheet was parsed into a `recipes.json` that existed in **two copies** — the repo's and the engine's — kept in step by a Dockerfile `COPY`. Switching the engine to a bind mount removed the rebuild, and with it the copy. Nothing replaced it.

A 16-render batch then ran against **stale prompts**, and a finding was drawn from those renders, written up as established, and agreed to before being retracted.

The check that missed it called `GET /recipes` and confirmed 8 recipes with the right names. Both were equally true of the stale file. **It confirmed facts that had not changed instead of content that had.**

## The shape

```
recipe-sheet.ods ──POST /recipes/import──> wanly-api   (one authority)
console          ──GET /recipes──────────> wanly-api
engine           <── resolved recipe INSIDE the claim
```

An engine that cannot look a recipe up cannot look up a *stale* one. The drift becomes structurally impossible rather than something a check has to notice.

Parsing happens in the API rather than in a script that writes a file, so there is one parser and one copy. **The sheet is never written back** — it is authored by hand, and regenerating it from code once silently overwrote a hand-edited prompt.

## Details worth a look

- **Two hashes per import.** `book_sha256` over the parsed content, `source_sha256` over the uploaded bytes. Re-saving the sheet with no edits changes the file but not the book, and the response's `changed` flag tells those apart.
- **`GET /recipes` 404s when nothing is imported**, rather than returning an empty book. An empty book and a missing one look identical downstream, and "the dropdowns are empty" shouldn't be the first sign that no sheet was ever uploaded.
- **Parse errors are named**, not shrugged at. The sheet is hand-authored, so a parse failure is usually a human edit rather than a corrupt file.

## Verification

**The port is faithful, checked by content not by eye.** Parsing the real sheet produces a book byte-identical to the existing parser's `recipes.json` — sha256 `31dfad3847a8a3f8`, 3 characters, 8 recipes each, 29 definitions.

Every failure this guards is silent: a mis-parsed sheet still yields a book of the right shape with the right number of things. So each test was proven against broken code:

| deliberate break | result |
|---|---|
| source column read one index off | caught |
| `definitions` silently emptied | caught |
| **top-level back-compat mirror dropped** | **passed every test I had written** |

That third one is the reason for doing this rather than admiring a green suite — the console falls back to `book.recipes` when there's no character map, so dropping it would have surfaced as empty dropdowns and nothing else. Now covered.

468 passed, 119 skipped (skips are DB-backed; no local Postgres).

## Not done here

The console still reads `/ltx` from the engine — repointing it at `/api` is the next step and is what makes the Storyboard page work on the deployed site, where nginx has no route to `3090.zero`. Creating queued jobs from that form is console#358.