### PR TITLE
A recipe is a POSE, with a <TRIGGER> placeholder

### DIFF
--- a/alembic/versions/072_recipes_are_poses.py
+++ b/alembic/versions/072_recipes_are_poses.py
@@ -1,0 +1,94 @@
+"""A recipe is a POSE, not a pose-per-character
+
+Revision ID: 072
+Revises: 071
+Create Date: 2026-08-31
+
+071 stored 24 recipes: 8 poses x 3 characters. That was wrong, and it locked new LoRAs out —
+a character with no rows in the table had no recipes at all, so adding one meant duplicating
+eight prompts rather than naming a LoRA and a trigger word.
+
+**Recipes were never meant to be LoRA-specific.** Verified against the seeded data before
+changing it: strip the leading trigger token and all 8 poses are character-agnostic. The only
+"differences" between the three copies of Cowgirl POV and Doggystyle Side were a stray
+trailing space — three copies of one prompt that had already begun to drift, which is the
+argument for this change rather than an objection to it.
+
+So: 8 poses, each carrying a <TRIGGER> placeholder, and a character supplies the LoRA and
+the trigger word that fills it. Adding a character costs a row, and every pose works for it
+immediately.
+
+<TRIGGER> shares syntax with the wildcard resolver (`<([^<>]+)>` in
+app/routes/segments.py::_resolve_wildcards). An unmatched name is left alone, so this is safe
+today — but a Wildcard named TRIGGER would make the resolver swap in a RANDOM option, and the
+render would quietly name the wrong character. The trigger is therefore substituted BEFORE
+wildcard resolution, and the name is reserved so that wildcard cannot be created.
+
+`validated` moves meaning slightly and deliberately. It marks the POSE as proven: the prompt
+produces what it claims. Whether a given CHARACTER renders well is a property of its LoRA, and
+that is what segment ratings and observations already record. p@y's rows were marked
+unvalidated in the sheet because p@y was new, not because the poses were in doubt.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+# Frozen: a migration records what happened, so its data must not be importable and editable.
+_POSES = [{'name': 'Blowjob Other', 'prompt_template': '<TRIGGER>, a woman kneeling beside a nude man seen from the side, she grips his penis with one hand and strokes it top to bottom. She wraps her lips around it and bobs her head all the way down and all the way back up, glancing toward the camera. Her other hand rests on his thigh. Handheld camera at the foot of the bed, slight natural sway, no cuts. Soft even lamplight from the left picks out natural skin tones and texture. Audio: her rhythmic breathing and moaning, the sound of skin against skin.'}, {'name': 'Blowjob POV', 'prompt_template': '<TRIGGER>, a woman kneeling in front of a nude man, she grips his penis with one hand and strokes it top to bottom. She wraps her lips around it and, maintaining eye contact with the viewer, bobs her head all the way down and all the way back up. Her eyes stay locked on the viewer. Her other hand rests on his thigh. Handheld camera at the foot of the bed, slight natural sway, no cuts. Soft even lamplight from the left picks out natural skin tones and texture. Audio: her rhythmic breathing and moaning, the sound of skin against skin.'}, {'name': 'Cowgirl Backside', 'prompt_template': '<TRIGGER>, a woman having reverse cowgirl sex seen from behind, she is on top of a man facing away from the camera, his penis is clearly seen gliding all the way in and all the way back out of her as she rides him, her buttocks and back moving with each stroke. Her face stays in focus the entire time. She looks back over her shoulder toward the camera. Handheld camera at the foot of the bed, slight natural sway, no cuts. Soft even lamplight from the left picks out natural skin tones and texture. Audio: her rhythmic breathing and moaning, the sound of skin against skin.'}, {'name': 'Cowgirl POV', 'prompt_template': '<TRIGGER>, a woman having cowgirl sex, she is on top of a man, his penis is clearly seen smoothly gliding all the way in and all the way back out of her vagina, her breasts bounce and jiggle as she rides and grinds on him. Her facial expressions show intense pleasure and she maintains eye contact with the viewer. Her face stays in focus the entire time.  Handheld camera at the foot of the bed, slight natural sway, no cuts. Soft even lamplight from the left picks out natural skin tones and texture. Audio: her rhythmic breathing and moaning, the sound of skin against skin.'}, {'name': 'Doggystyle Front Facing', 'prompt_template': '<TRIGGER>, a woman on her knees bent over a bed is facing the camera. A man is behind her having doggystyle sex and thrusts into her in a steady, continuous rhythm; his hips meet her behind on every stroke and her breasts and buttocks jiggle with each impact. She maintains steady eye contact with the camera with natural expressions that align with the encounter. Her face stays in focus the entire time. Handheld camera at the foot of the bed, slight natural sway, no cuts. Soft even lamplight from the left picks out natural skin tones and texture. Audio: her rhythmic breathing and moaning, the sound of skin against skin.'}, {'name': 'Doggystyle Side', 'prompt_template': '<TRIGGER>, a woman on her knees bent over a bed seen from the side. A man is behind her having doggystyle sex and thrusts into her in a steady, continuous rhythm; his hips meet her behind on every stroke and her breasts and buttocks jiggle with each impact. Her face is turned toward the camera with natural expressions that align with the encounter. Her face stays in focus the entire time.  Handheld camera at the foot of the bed, slight natural sway, no cuts. Soft even lamplight from the left picks out natural skin tones and texture. Audio: her rhythmic breathing and moaning, the sound of skin against skin.'}, {'name': 'Missionary POV', 'prompt_template': '<TRIGGER>, a woman lies on her back, her legs spread and raised, knees bent. A man is between her thighs and thrusts into her in a steady, continuous rhythm; his hips meet hers on every stroke and her breasts and thighs jiggle with each impact. His penis is clearly seen gliding all the way in and all the way back out of her vagina. She moans with each thrust, she maintains steady eye contact with the camera. Handheld camera at the foot of the bed, slight natural sway, no cuts. Her face stays in focus the entire time. Soft even lamplight from the left picks out natural skin tones and texture. Audio: her rhythmic breathing and moaning, the sound of skin against skin.'}, {'name': 'Missionary Side', 'prompt_template': '<TRIGGER>, a woman lies on her back, her legs spread and raised, knees bent. A man is between her thighs and thrusts into her in a steady, continuous rhythm; his hips meet hers on every stroke and her breasts and thighs jiggle with each impact. His penis is clearly seen gliding all the way in and all the way back out of her vagina. She moans with each thrust, she maintains steady eye contact with the camera. Handheld camera at the foot of the bed, slight natural sway, no cuts. Her face stays in focus the entire time. Soft even lamplight from the left picks out natural skin tones and texture. Audio: her rhythmic breathing and moaning, the sound of skin against skin.'}]
+
+_TRIGGERS = {'k3lly2026': 'k3lly2026', 'k3llydw': 'k3llydw', 'p@y': 'p@y'}
+
+revision = "072"
+down_revision = "071"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # A character supplies the trigger word that fills <TRIGGER>. Seeded from the leading
+    # token of its own prompts, which is where it lived before.
+    op.add_column("ltx_characters", sa.Column("trigger", sa.String(length=64), nullable=True))
+    for name, trig in _TRIGGERS.items():
+        conn.execute(sa.text("UPDATE ltx_characters SET trigger = :t WHERE name = :n"),
+                     {"t": trig, "n": name})
+    # Backfill anything unseeded with its own name, then make it required: a character with
+    # no trigger renders a prompt containing a literal placeholder, which is worse than
+    # failing loudly at creation.
+    conn.execute(sa.text("UPDATE ltx_characters SET trigger = name WHERE trigger IS NULL"))
+    op.alter_column("ltx_characters", "trigger", nullable=False)
+
+    # Poses are no longer per character.
+    op.drop_index("ix_ltx_recipes_character_id", table_name="ltx_recipes")
+    op.drop_constraint("uq_ltx_recipe_character_name", "ltx_recipes", type_="unique")
+    op.drop_column("ltx_recipes", "character_id")
+    op.alter_column("ltx_recipes", "prompt", new_column_name="prompt_template")
+
+    # 24 rows collapse to 8. Replaced rather than deduped in SQL: the templates below are the
+    # authoritative text, and picking a survivor row would preserve whichever copy happened to
+    # carry the stray whitespace.
+    #
+    # DELETE before the unique constraint, not after. The 24 rows are 8 names x 3 characters,
+    # so adding UNIQUE(name) while they are still present fails outright — which it did.
+    conn.execute(sa.text("DELETE FROM ltx_recipes"))
+    import uuid as _uuid
+    for p in _POSES:
+        conn.execute(
+            sa.text("INSERT INTO ltx_recipes (id, name, prompt_template, validated) "
+                    "VALUES (:id, :name, :prompt, true)"),
+            {"id": _uuid.uuid4(), "name": p["name"], "prompt": p["prompt_template"]},
+        )
+
+    # Only once the duplicates are gone.
+    op.create_unique_constraint("uq_ltx_recipe_name", "ltx_recipes", ["name"])
+
+
+def downgrade() -> None:
+    # Not reversible in any useful sense: 8 poses cannot be expanded back into 24 rows without
+    # knowing which characters existed at the time. Restores the shape, not the data.
+    op.drop_constraint("uq_ltx_recipe_name", "ltx_recipes", type_="unique")
+    op.alter_column("ltx_recipes", "prompt_template", new_column_name="prompt")
+    op.add_column("ltx_recipes", sa.Column("character_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_index("ix_ltx_recipes_character_id", "ltx_recipes", ["character_id"])
+    op.drop_column("ltx_characters", "trigger")

--- a/app/models.py
+++ b/app/models.py
@@ -465,6 +465,10 @@ class LtxCharacter(Base):
     id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = mapped_column(String(64), nullable=False, unique=True)
     char_lora = mapped_column(Text, nullable=False)
+    # The token that fills a pose's <TRIGGER> placeholder. "Adding a character costs a LoRA
+    # and a trigger swap" — this is the trigger half, and it is why a new LoRA is never
+    # locked out: every pose works for it the moment the row exists.
+    trigger = mapped_column(String(64), nullable=False)
     # Per-stage, never flat. Stage 1 generates at half size from noise; stage 2 refines the
     # 2x-upscaled latent and is where facial detail resolves. Collapsing them to one number
     # is a different configuration, not a simplification.
@@ -476,39 +480,36 @@ class LtxCharacter(Base):
     # ON DELETE CASCADE. Without it the ORM tries to load every child row to delete them
     # individually — which under asyncpg is a lazy load in the wrong context and raises
     # MissingGreenlet, so deleting a character failed outright. Found by running it.
-    recipes = relationship("LtxRecipe", back_populates="character",
-                           cascade="all, delete-orphan", passive_deletes=True,
-                           order_by="LtxRecipe.name")
 
 
 class LtxRecipe(Base):
-    """A pose for a character: a prompt, and almost nothing else.
+    """A POSE. Not a pose-per-character.
 
-    Measured across all 24 seeded recipes, only char_lora and prompt varied — every other
-    field had exactly one value. Those live once in the global stack (app_settings) rather
-    than being copied per row, because storing a global value 24 times is how it silently
-    stops being global.
+    Recipes are not LoRA-specific and never were: strip the leading trigger token and all 8
+    seeded poses are character-agnostic. Storing them per character locked new LoRAs out —
+    a character with no rows had no recipes — and let three copies of one prompt drift apart,
+    which two of them already had.
+
+    The prompt carries a <TRIGGER> placeholder that the character's own trigger word fills.
     """
     __tablename__ = "ltx_recipes"
     __table_args__ = (
-        UniqueConstraint("character_id", "name", name="uq_ltx_recipe_character_name"),
-        Index("ix_ltx_recipes_character_id", "character_id"),
+        UniqueConstraint("name", name="uq_ltx_recipe_name"),
     )
 
     id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    character_id = mapped_column(UUID(as_uuid=True),
-                                 ForeignKey("ltx_characters.id", ondelete="CASCADE"),
-                                 nullable=False)
     name = mapped_column(String(128), nullable=False)
-    prompt = mapped_column(Text, nullable=False)
+    # Contains <TRIGGER>, filled with the character's trigger word. Substituted BEFORE
+    # wildcard resolution, and the name is reserved in the wildcard routes, so the resolver
+    # can never treat it as a wildcard and swap in something random.
+    prompt_template = mapped_column(Text, nullable=False)
     # NULL means "the stack's negative" — true of all 24 seeded recipes. The override exists
     # because a pose might one day need one, not because any does.
     negative_prompt = mapped_column(Text, nullable=True)
     frames = mapped_column(Integer, nullable=True)
-    # A human watched it and signed it off. NOT a quality score: the automated metrics have
-    # picked the wrong clip before, more than once.
+    # The POSE is proven: this prompt produces what it claims. Whether a given CHARACTER
+    # renders well is a property of its LoRA, and segment ratings already record that.
+    # NOT a quality score: the automated metrics have picked the wrong clip before.
     validated = mapped_column(Boolean, nullable=False, server_default="false", default=False)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), nullable=True)
-
-    character = relationship("LtxCharacter", back_populates="recipes")

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -19,7 +19,6 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.auth import get_current_user
 from app.database import get_db
@@ -44,6 +43,29 @@ async def _character(db: AsyncSession, character_id: uuid.UUID) -> LtxCharacter:
     return c
 
 
+# The placeholder a pose carries and a character's trigger fills.
+#
+# This shares syntax with the wildcard resolver (`<([^<>]+)>` in
+# app/routes/segments.py::_resolve_wildcards), which matters: a Wildcard named TRIGGER would
+# make the resolver substitute a RANDOM option here, and the render would quietly name the
+# wrong character or none at all.
+#
+# Two things close that. The trigger is substituted BEFORE wildcard resolution runs, so a
+# correctly-built prompt never reaches the resolver carrying this. And the name is reserved
+# in the wildcard routes, so the shadowing wildcard cannot be created in the first place.
+TRIGGER_PLACEHOLDER = "<TRIGGER>"
+
+
+def render_prompt(template: str, trigger: str) -> str:
+    """Fill a pose's placeholder with a character's trigger word.
+
+    A template with no placeholder is returned unchanged rather than rejected — a pose whose
+    prompt genuinely does not name the character is unusual but not wrong, and failing here
+    would block a render for a stylistic choice.
+    """
+    return template.replace(TRIGGER_PLACEHOLDER, trigger)
+
+
 @router.get("/recipes")
 async def get_recipe_book(
     user: User = Depends(get_current_user),
@@ -55,35 +77,39 @@ async def get_recipe_book(
     stack is returned alongside so the page can SHOW what a recipe pins without each recipe
     carrying a copy of it.
     """
-    rows = (
-        await db.execute(
-            select(LtxCharacter).options(selectinload(LtxCharacter.recipes))
-            .order_by(LtxCharacter.name)
-        )
-    ).scalars().all()
+    chars = (await db.execute(
+        select(LtxCharacter).order_by(LtxCharacter.name)
+    )).scalars().all()
+    poses = (await db.execute(
+        select(LtxRecipe).order_by(LtxRecipe.name)
+    )).scalars().all()
 
+    # Poses are character-agnostic, so EVERY pose is offered for EVERY character. That is the
+    # point: a new LoRA is never locked out for want of rows in a table — add the character
+    # and all of them work immediately.
     return {
         "stack": LTX_STACK,
+        "poses": [
+            {
+                "id": str(r.id),
+                "name": r.name,
+                "prompt_template": r.prompt_template,
+                "negative_prompt": r.negative_prompt or LTX_STACK["negative"],
+                "frames": r.frames or LTX_STACK["frames"],
+                "validated": r.validated,
+            }
+            for r in poses
+        ],
         "characters": [
             {
                 "id": str(c.id),
                 "name": c.name,
                 "char_lora": c.char_lora,
+                "trigger": c.trigger,
                 "strength_stage_1": c.strength_stage_1,
                 "strength_stage_2": c.strength_stage_2,
-                "recipes": [
-                    {
-                        "id": str(r.id),
-                        "name": r.name,
-                        "prompt": r.prompt,
-                        "negative_prompt": r.negative_prompt or LTX_STACK["negative"],
-                        "frames": r.frames or LTX_STACK["frames"],
-                        "validated": r.validated,
-                    }
-                    for r in c.recipes
-                ],
             }
-            for c in rows
+            for c in chars
         ],
     }
 
@@ -94,7 +120,11 @@ async def create_character(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    c = LtxCharacter(**body.model_dump())
+    data = body.model_dump()
+    # A character without a trigger renders a prompt containing a literal "<TRIGGER>", which
+    # is worse than any default. The name is what all three seeded characters use.
+    data["trigger"] = data.get("trigger") or data["name"]
+    c = LtxCharacter(**data)
     db.add(c)
     try:
         await db.commit()
@@ -129,16 +159,14 @@ async def delete_character(
     await db.commit()
 
 
-@router.post("/ltx/characters/{character_id}/recipes",
-             response_model=LtxRecipeResponse, status_code=201)
+@router.post("/ltx/recipes", response_model=LtxRecipeResponse, status_code=201)
 async def create_recipe(
-    character_id: uuid.UUID,
     body: LtxRecipeCreate,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    await _character(db, character_id)
-    r = LtxRecipe(character_id=character_id, **body.model_dump())
+    """Create a pose. Not attached to a character — every character gets it."""
+    r = LtxRecipe(**body.model_dump())
     db.add(r)
     try:
         await db.commit()
@@ -146,7 +174,7 @@ async def create_recipe(
         await db.rollback()
         raise HTTPException(
             status_code=409,
-            detail=f"Recipe {body.name!r} already exists for this character",
+            detail=f"A pose named {body.name!r} already exists",
         )
     await db.refresh(r)
     return r

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -21,7 +21,7 @@ from app.database import get_db
 from app.seeds import new_seed
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.helpers import upload_faceswap_image
-from app.models import AppSetting, Job, Lora, Segment, User, Video, VideoSettingsPreset, Wildcard, Worker
+from app.models import AppSetting, Job, Lora, LtxCharacter, Segment, User, Video, VideoSettingsPreset, Wildcard, Worker
 from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
     EXCLUSIVE_TAG_GROUPS,
@@ -99,6 +99,32 @@ async def _resolve_loras(db: AsyncSession, loras_input: list | None) -> list | N
             # Backward compat: raw filename format
             resolved.append(item)
     return resolved
+
+
+async def _resolve_trigger(db: AsyncSession, prompt: str, ltx_recipe: dict | None) -> str:
+    """Fill a pose's <TRIGGER> with the character's trigger word.
+
+    Runs BEFORE _resolve_wildcards, and that order is the safeguard: <TRIGGER> shares syntax
+    with wildcards, so a Wildcard named TRIGGER would otherwise substitute a random option and
+    the render would quietly name the wrong character. Doing it first means the resolver never
+    sees the placeholder. (The name is also reserved in the wildcard routes, so both ends are
+    covered.)
+
+    The console normally substitutes at creation time; this catches a prompt that reaches the
+    API still carrying the placeholder — an edited prompt, or any caller that is not the
+    console.
+    """
+    if "<TRIGGER>" not in prompt:
+        return prompt
+    name = (ltx_recipe or {}).get("character")
+    if not name:
+        # Leave it. Rendering the literal text "<TRIGGER>" is bad, but silently dropping the
+        # token that anchors the character LoRA is worse and much harder to notice.
+        return prompt
+    row = (await db.execute(
+        select(LtxCharacter).where(LtxCharacter.name == name)
+    )).scalar_one_or_none()
+    return prompt.replace("<TRIGGER>", row.trigger) if row else prompt
 
 
 async def _resolve_wildcards(db: AsyncSession, prompt: str) -> tuple[str, str | None]:
@@ -186,7 +212,8 @@ async def add_segment(
     next_index = max((s.index for s in job.segments), default=-1) + 1
 
     resolved_loras = await _resolve_loras(db, body.loras)
-    resolved_prompt, prompt_template = await _resolve_wildcards(db, body.prompt)
+    prompt = await _resolve_trigger(db, body.prompt, body.ltx_recipe)
+    resolved_prompt, prompt_template = await _resolve_wildcards(db, prompt)
 
     # Inherit negative_prompt from prior segment if not explicitly set.
     # Segments are eagerly loaded and ordered by index via the relationship,

--- a/app/routes/wildcards.py
+++ b/app/routes/wildcards.py
@@ -11,6 +11,15 @@ from app.schemas.wildcards import WildcardCreate, WildcardResponse, WildcardUpda
 
 router = APIRouter()
 
+# LTX poses carry <TRIGGER>, which the character's trigger word fills. It shares syntax with
+# wildcards, so a wildcard by this name would make the resolver substitute a RANDOM option --
+# the render would name the wrong character, or none, and nothing would report a problem.
+#
+# The trigger is already substituted before wildcard resolution runs, so this is the second of
+# two guards rather than the only one. Reserving the name means the collision cannot be created
+# by hand in the first place, which is cheaper than reasoning about ordering later.
+RESERVED_WILDCARD_NAMES = {"TRIGGER"}
+
 
 @router.get("/wildcards", response_model=list[WildcardResponse])
 async def list_wildcards(
@@ -27,6 +36,12 @@ async def create_wildcard(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
+    if body.name.strip().upper() in RESERVED_WILDCARD_NAMES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"'{body.name}' is reserved: LTX poses use <TRIGGER> for the character "
+                   "trigger word, and a wildcard by that name would randomly replace it.",
+        )
     existing = await db.execute(select(Wildcard).where(Wildcard.name == body.name))
     if existing.scalar_one_or_none():
         raise HTTPException(
@@ -63,6 +78,13 @@ async def update_wildcard(
     if wildcard is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Wildcard not found")
     if body.name is not None:
+        # Renaming into the reserved name is the same collision by another route.
+        if body.name.strip().upper() in RESERVED_WILDCARD_NAMES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"'{body.name}' is reserved: LTX poses use <TRIGGER> for the character "
+                       "trigger word, and a wildcard by that name would randomly replace it.",
+            )
         wildcard.name = body.name
     if body.options is not None:
         wildcard.options = body.options

--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -10,6 +10,9 @@ from pydantic import BaseModel, ConfigDict, Field
 class LtxCharacterCreate(BaseModel):
     name: str = Field(min_length=1, max_length=64)
     char_lora: str = Field(min_length=1)
+    # Fills every pose's <TRIGGER> placeholder. Defaults to the character's own name, which
+    # is what all three seeded characters use.
+    trigger: Optional[str] = Field(default=None, max_length=64)
     # Per-stage, never flat — stage 1 decides the body, stage 2 resolves the face.
     strength_stage_1: float = 0.8
     strength_stage_2: float = 1.5
@@ -21,13 +24,16 @@ class LtxCharacterResponse(BaseModel):
     id: uuid.UUID
     name: str
     char_lora: str
+    trigger: str
     strength_stage_1: float
     strength_stage_2: float
 
 
 class LtxRecipeCreate(BaseModel):
+    """A pose. Character-agnostic: the prompt carries <TRIGGER>, not a name."""
+
     name: str = Field(min_length=1, max_length=128)
-    prompt: str = Field(min_length=1)
+    prompt_template: str = Field(min_length=1)
     # NULL means the global stack's negative, which is true of every seeded recipe.
     negative_prompt: Optional[str] = None
     frames: Optional[int] = Field(default=None, gt=0)
@@ -36,7 +42,7 @@ class LtxRecipeCreate(BaseModel):
 
 class LtxRecipeUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=128)
-    prompt: Optional[str] = Field(default=None, min_length=1)
+    prompt_template: Optional[str] = Field(default=None, min_length=1)
     negative_prompt: Optional[str] = None
     frames: Optional[int] = Field(default=None, gt=0)
     validated: Optional[bool] = None
@@ -46,9 +52,8 @@ class LtxRecipeResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    character_id: uuid.UUID
     name: str
-    prompt: str
+    prompt_template: str
     negative_prompt: Optional[str]
     frames: Optional[int]
     validated: bool

--- a/tests/test_ltx_recipes.py
+++ b/tests/test_ltx_recipes.py
@@ -95,3 +95,73 @@ def test_migration_data_is_inlined_not_imported():
 def test_the_sheet_parser_is_gone():
     """The harness does not come with us. Leaving it would invite a second source of truth."""
     assert not Path("app/ltx_sheet.py").exists()
+
+
+# --- 072: a recipe is a POSE, not a pose-per-character ------------------------------------
+
+POSES_MIGRATION = Path("alembic/versions/072_recipes_are_poses.py")
+
+
+def _poses_const(name: str):
+    tree = ast.parse(POSES_MIGRATION.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", None) == name:
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"{name} not found in {POSES_MIGRATION}")
+
+
+def test_twenty_four_rows_collapse_to_eight_poses():
+    """8 poses x 3 characters was 24 rows of which 16 were duplicates.
+
+    Verified against the seeded data before the change: strip the leading trigger token and
+    all 8 poses are character-agnostic.
+    """
+    assert len(_poses_const("_POSES")) == 8
+
+
+def test_every_pose_carries_the_trigger_placeholder():
+    """Without it the prompt names no character and the LoRA has nothing to anchor to."""
+    for p in _poses_const("_POSES"):
+        assert "<TRIGGER>" in p["prompt_template"], p["name"]
+
+
+def test_no_pose_hardcodes_a_character_name():
+    """The bug this migration fixes.
+
+    A pose naming k3lly2026 in its text is a pose only k3lly2026 can use, which is how new
+    LoRAs got locked out.
+    """
+    for p in _poses_const("_POSES"):
+        for character in ("k3lly2026", "k3llydw", "p@y"):
+            assert character not in p["prompt_template"], f"{p['name']} hardcodes {character}"
+
+
+def test_placeholder_is_braces_not_angle_brackets():
+    """`<...>` is the wildcard resolver's syntax (segments.py::_resolve_wildcards).
+
+    A trigger in angle brackets would be treated as a wildcard and randomly substituted —
+    the render would silently name a different character, or nothing at all.
+    """
+    for p in _poses_const("_POSES"):
+        assert "<trigger>" not in p["prompt_template"]
+
+
+def test_render_prompt_substitutes_the_trigger():
+    from app.routes.ltx_recipes import render_prompt
+    assert render_prompt("<TRIGGER>, a woman walks", "k3lly2026") == "k3lly2026, a woman walks"
+    # A template without the placeholder is returned unchanged rather than rejected.
+    assert render_prompt("a woman walks", "k3lly2026") == "a woman walks"
+
+
+def test_a_new_character_gets_every_pose_without_adding_rows():
+    """The whole point. Adding a character is a row, not eight prompt copies.
+
+    Poses are returned for every character because they are not attached to one, so this is a
+    property of the schema rather than something the API has to remember to do.
+    """
+    import inspect
+    from app.routes import ltx_recipes
+    src = inspect.getsource(ltx_recipes.get_recipe_book)
+    assert '"poses"' in src
+    # Poses must NOT be nested inside characters — that is the shape that locked LoRAs out.
+    assert "c.recipes" not in src


### PR DESCRIPTION
Recipes were never meant to be LoRA-specific. #211 made them so, and that locked new LoRAs out.

## The bug

071 stored **24 recipes: 8 poses × 3 characters**. A character with no rows had no recipes at all, so adding a LoRA meant duplicating eight prompts rather than naming a LoRA and a trigger word.

**Verified against the seeded data before changing it:** strip the leading trigger token and all 8 poses are character-agnostic. The only differences among the three copies of `Cowgirl POV` and `Doggystyle Side` were **a stray trailing space** — three copies of one prompt that had already begun to drift. That's the argument for this change, not an objection to it.

## The shape

8 poses carrying `<TRIGGER>`; a character supplies the LoRA and the word that fills it.

```
ltx_recipes   name, prompt_template ("<TRIGGER>, a woman ..."), validated
ltx_characters name, char_lora, trigger, s1, s2
```

Adding a character is **one row**, and every pose works for it immediately. That's "adding a character costs a LoRA and a trigger swap" made structural instead of aspirational.

## `<TRIGGER>` shares syntax with wildcards — guarded at both ends

The wildcard resolver matches `<([^<>]+)>`. A `Wildcard` named `TRIGGER` would make it substitute a **random option**, and the render would quietly name the wrong character with nothing reporting a problem.

1. **The trigger is substituted before wildcard resolution**, so a well-formed prompt never reaches the resolver carrying the placeholder.
2. **The name is reserved** on wildcard create *and* rename, so the colliding wildcard can't be made by hand.

A prompt that arrives still carrying `<TRIGGER>` with no resolvable character is **left alone**, not stripped. Rendering the literal text is bad; silently dropping the token that anchors the character LoRA is worse and far harder to notice.

## `validated` shifts meaning, deliberately

It now marks the **pose** as proven — the prompt produces what it claims. Whether a given character renders well is a property of its LoRA, which segment ratings already record. p@y's rows were unvalidated because p@y was new, not because the poses were in doubt.

## Verification

Run against a real Postgres along the **actual upgrade path** — 071 first with its 24 rows, then 072.

That found a real ordering bug: the unique constraint on `name` was added while 8 names × 3 characters were still present, and failed outright. Delete, insert, then constrain.

After the migration:

| check | result |
|---|---|
| poses | 8 (from 24) |
| characters keep triggers | k3lly2026, k3llydw, p@y |
| every pose carries `<TRIGGER>` | yes |
| any pose naming a character | none |
| **new character via the API** | **gets all 8 poses, no rows added** |
| trigger omitted | defaults to the character's name |
| poses survive character deletion | yes — not owned by one |

473 passed, 119 skipped.

## Follow-up

wanly-console#360 still reads the per-character shape and needs updating to poses × characters before it will work against this.