### PR TITLE
DURATION_EXPONENT described WAN, not LTX

### DIFF
--- a/app/estimation.py
+++ b/app/estimation.py
@@ -32,14 +32,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.enums import SegmentStatus
 from app.models import Job, Segment
 
-# Run time grows faster than duration because attention over the video tokens does. Measured on
-# the one shape with real leverage, 1056x720 at 3s (n=41) and 5s (n=102): the ComfyUI execution
-# ran 812s against 1666s, a 2.05x cost for a 1.67x duration, which is an exponent of 1.41; the
-# 1.5s runs give 1.38 by the same arithmetic. Backtesting the estimator against every segment it
-# had history for, the exponent cuts median absolute error on non-5s segments from 17.5% to 4.5%
-# (p90 23.0% to 7.4%) and leaves the 5s case untouched, since the rate is fitted the same way it
-# is applied.
-DURATION_EXPONENT = 1.4
+# Linear in duration. NOT fitted — this is a neutral prior, and saying so is the point.
+#
+# It was 1.4, fitted on WAN 2.2: run time grew faster than duration because attention over the
+# video tokens did, measured at 1056x720 on 3s (n=41) against 5s (n=102), 812s against 1666s.
+# That number described WAN, and it is not transferable. Two reasons:
+#
+#   1. Every LTX render is a fixed 241 frames. Duration barely varies, so a superlinear term
+#      has almost nothing to act on and the exponent is being asked a question the data does
+#      not pose.
+#   2. The WAN measurement was taken on a two-pass sampler with a high/low model split. LTX
+#      samples differently. Carrying the constant across would be assuming the shape of a curve
+#      from a pipeline that no longer runs.
+#
+# 1.0 makes the rate plain seconds-per-second, which is the honest position while there is no
+# LTX history to fit against: wrong in a way that is obvious and neutral, rather than wrong in a
+# way that looks measured. Re-fit it once LTX segments have accumulated across more than one
+# duration — and if they never do, because 241 frames stays fixed, then the right answer is to
+# drop the duration term entirely rather than to pick a number for it.
+DURATION_EXPONENT = 1.0
 
 # Only recent runs. Model, sampler and step count all drift, and a rate learned in February is
 # describing a different pipeline. Backtesting says this is the single largest win available
@@ -193,6 +204,17 @@ def _fit_pixel_law(shape_rates: dict) -> PixelLaw | None:
     over the whole corpus the slope is 1.02, so run time is close to linear in pixel count, which
     is the reassuring part: the fallback is following a real relationship rather than smearing
     480p and 720p together and calling the result an estimate.
+
+    Those figures are WAN 2.2's, and they are kept because they are the argument for the SHAPE
+    of this fallback - a pixel law rather than a flat average - which is not engine-specific.
+    The slope and intercept are not: they are re-fitted on every call from whatever shapes are
+    in the window, so once the window holds LTX segments the fallback describes LTX. Nothing
+    here needs changing for that to happen; it needed only that the WAN rates stop being in the
+    window, which is what clearing the history does.
+
+    Until at least MIN_PIXEL_LAW_SHAPES LTX shapes have MIN_SAMPLES runs each, this returns
+    None and callers get no estimate. That is the correct answer to "how long will this take"
+    when nothing comparable has been run yet.
     """
     points = [
         (math.log(width * height), math.log(value), samples)

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -16,6 +16,7 @@ import pytest
 from app import estimation
 from app.estimation import (
     DURATION_EXPONENT,
+    DURATION_EXPONENT,
     MIN_SAMPLES,
     Estimate,
     PixelLaw,
@@ -103,23 +104,38 @@ class TestNoGlobalAverage:
 
 
 class TestDurationModel:
-    def test_run_time_grows_faster_than_duration(self):
-        """Measured at 1056x720: 812s of sampling at 3s against 1666s at 5s, a 2.05x cost for a
-        1.67x duration. A per-second rate would price the 5s segment 18% low."""
+    def test_run_time_is_linear_in_duration(self):
+        """DURATION_EXPONENT is 1.0, and that is a neutral prior rather than a measurement.
+
+        It was 1.4, fitted on WAN 2.2 at 1056x720: 812s of sampling at 3s against 1666s at 5s, a
+        2.05x cost for a 1.67x duration. That described WAN's two-pass sampler and does not
+        transfer — and every LTX render is a fixed 241 frames, so duration barely varies and a
+        superlinear term has almost nothing to act on.
+
+        This test now pins the honest position, not a curve nobody has measured. When LTX
+        history exists across more than one duration, re-fit and change this deliberately.
+        """
         r = rates(shape={SHAPE: (100.0, 40)})
         three = estimate_segment_time(r, *SHAPE, 3.0, None)
         five = estimate_segment_time(r, *SHAPE, 5.0, None)
-        assert five / three > 5.0 / 3.0
+        assert five / three == pytest.approx(5.0 / 3.0)
 
     def test_there_is_no_fixed_overhead_term(self):
         """Fitting a shared intercept across the eight shapes with more than one duration puts it
-        at -326s, so a fixed post-sampling tail is not just unsupported, the sign is wrong."""
+        at -326s, so a fixed post-sampling tail is not just unsupported, the sign is wrong.
+
+        That finding is about the SHAPE of the model, not about WAN's exponent, so it survives.
+        Asserted as proportionality rather than against an absolute tolerance, which is what
+        makes it independent of whatever DURATION_EXPONENT happens to be.
+        """
         r = rates(shape={SHAPE: (100.0, 40)})
         assert estimate_segment_time(r, *SHAPE, 0.5, None) < estimate_segment_time(
             r, *SHAPE, 1.0, None
         )
-        # Doubling the duration from zero-ish must not converge on a constant.
-        assert estimate_segment_time(r, *SHAPE, 0.001, None) == pytest.approx(0.0, abs=0.05)
+        # Halving the duration must halve the estimate. An intercept would leave a residue.
+        half = estimate_segment_time(r, *SHAPE, 1.0, None)
+        whole = estimate_segment_time(r, *SHAPE, 2.0, None)
+        assert half / whole == pytest.approx(0.5 ** DURATION_EXPONENT)
 
     @pytest.mark.parametrize("duration", [0, 0.0, None, -1.0])
     def test_impossible_durations_are_not_priced(self, duration):


### PR DESCRIPTION
## The exponent

`DURATION_EXPONENT = 1.4` was fitted on WAN 2.2 at 1056×720 — 812s of sampling at 3s against 1666s at 5s, a 2.05× cost for a 1.67× duration. That described WAN's two-pass sampler with its high/low model split, and it doesn't transfer.

It's also being asked a question LTX doesn't pose: **every LTX render is a fixed 241 frames**, so duration barely varies and a superlinear term has almost nothing to act on.

Now `1.0`, and the comment says plainly this is a **neutral prior, not a measurement** — wrong in a way that's obvious, rather than wrong in a way that looks measured. Re-fit once LTX history exists across more than one duration; and if it never does, because 241 frames stays fixed, the right answer is to drop the duration term rather than pick a number for it.

## The fallback needed no code change

The pixel law's slope and intercept are **re-fitted on every call** from whatever shapes are in the 30-day window, so it describes LTX as soon as LTX segments are in there.

The WAN figures in its docstring are kept deliberately: they argue for the *shape* of the fallback — a pixel law rather than a flat average — which isn't engine-specific. Below `MIN_PIXEL_LAW_SHAPES` it returns `None` and the caller gets no estimate, which is the correct answer to "how long will this take" when nothing comparable has been run.

## Two tests encoded WAN measurements as assertions

`test_run_time_grows_faster_than_duration` was false by construction once the exponent changed. Rewritten to pin linearity and to say it's a prior, not a curve anyone measured.

`test_there_is_no_fixed_overhead_term` survives — that finding is about the *shape* of the model, not the exponent — but now asserts **proportionality** rather than an absolute tolerance, which makes it independent of whatever the exponent is.

473 passed.

## Note

Estimates are fitted live from the last 30 days, so no stored WAN rates exist to correct — clearing history is sufficient for the data side, and this PR fixes the part that lives in code.