### PR TITLE
Drop Job.config_starred, the last of Configurations

### DIFF
--- a/alembic/versions/076_drop_config_starred.py
+++ b/alembic/versions/076_drop_config_starred.py
@@ -1,0 +1,35 @@
+"""Drop Job.config_starred
+
+Revision ID: 076
+Revises: 075
+Create Date: 2026-08-31
+
+The last of the Configurations feature. It starred a job's WAN sampler settings — lightx2v,
+cfg high/low, steps, flow shift — so a combination that worked could be found again. Those
+settings were dropped in 075, so the flag pointed at nothing.
+
+Under LTX there is nothing to star. The stack is one global configuration and a recipe is
+(character, prompt), so a validated pose is already a first-class row in `ltx_recipes` with a
+`validated` flag — which is what starring was approximating.
+
+Nullable-free and non-destructive in the sense that matters: the column held a boolean opinion
+about settings that no longer exist.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "076"
+down_revision = "075"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("jobs", "config_starred")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("config_starred", sa.Boolean(), nullable=False, server_default="false"),
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -44,7 +44,6 @@ class Job(Base):
     # Optional link to a named video-settings preset (job default). Live: the 7 sampler values
     # are read from the preset at claim time. NULL -> use this job's raw params above.
     priority = mapped_column(Integer, nullable=False, default=0)
-    config_starred = mapped_column(Boolean, nullable=False, default=False)
     # Per-job continuation-mode override ("traditional"|"vace"); NULL -> global app setting.
     continuation_mode = mapped_column(String(20), nullable=True)
     # === Lynx identity-preserving engine (ByteDance Lynx on Wan2.1 T2V-14B) ===

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -223,7 +223,6 @@ def job_filter(
     name: str | None = None,
     search: str | None = None,
     tags: list[str] | None = None,
-    starred: bool | None = None,
 ) -> list:
     """Every criterion ANDs. Returns clauses for .where(*clauses).
 
@@ -240,8 +239,6 @@ def job_filter(
     job". There is no OR.
     """
     clauses = [Job.user_id == user_id]
-    if starred:
-        clauses.append(Job.config_starred.is_(True))
     if name:
         clauses.append(Job.name.ilike(f"%{like_escape(name)}%", escape="\\"))
     if search and search.strip():
@@ -255,9 +252,7 @@ def job_filter(
     if status_filter:
         statuses = [s.strip() for s in status_filter.split(",") if s.strip()]
         clauses.append(Job.status.in_(statuses))
-    elif not starred:
-        # Starred = "successful configs" and those are usually finalized jobs, so the
-        # star filter must see all statuses; only hide finalized/archived otherwise.
+    else:
         clauses.append(Job.status.notin_([JobStatus.FINALIZED, JobStatus.FINALIZING, JobStatus.ARCHIVED]))
     return clauses
 
@@ -271,7 +266,6 @@ async def list_jobs(
     name: str | None = Query(None, min_length=1, max_length=255, description="Filter jobs by name (case-insensitive partial match)"),
     search: str | None = Query(None, min_length=1, max_length=255, alias="q", description="Search jobs by name (partial) or by a whole tag"),
     tags: list[str] = Query(default_factory=list, description="Only jobs carrying ALL of these tags, matched in full"),
-    starred: bool | None = Query(None, description="Only jobs flagged as successful configs"),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -282,7 +276,6 @@ async def list_jobs(
             name=name,
             search=search,
             tags=tags,
-            starred=starred,
         )
     )
 
@@ -377,7 +370,6 @@ async def list_jobs(
                 seed=j.seed,
                 starting_image=j.starting_image,
                 priority=j.priority,
-                config_starred=j.config_starred,
                 status=j.status,
                 segment_count=seg_total,
                 completed_segment_count=seg_completed,
@@ -414,7 +406,6 @@ async def job_tag_counts(
     status_filter: str | None = Query(None, alias="status"),
     search: str | None = Query(None, min_length=1, max_length=255, alias="q"),
     tags: list[str] = Query(default_factory=list),
-    starred: bool | None = Query(None),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -437,7 +428,6 @@ async def job_tag_counts(
         status_filter=status_filter,
         search=search,
         tags=tags,
-        starred=starred,
     )
 
     # unnest in a LATERAL rather than the target list: a set-returning function in the select
@@ -562,7 +552,6 @@ async def get_job(
         lynx_scheduler=job.lynx_scheduler,
         lynx_distill_strength=job.lynx_distill_strength,
         priority=job.priority,
-        config_starred=job.config_starred,
         status=job.status,
         tags=job.tags,
         estimated_run_time=job_est,
@@ -597,12 +586,6 @@ async def update_job(
 
     if body.tags is not None:
         job.tags = body.tags
-
-    if body.config_starred is not None:
-        job.config_starred = body.config_starred
-
-    if body.video_preset_id is not None:
-        job.video_preset_id = body.video_preset_id
 
     if body.status is not None:
         allowed = JOB_VALID_TRANSITIONS.get(job.status, set())

--- a/app/schemas/jobs.py
+++ b/app/schemas/jobs.py
@@ -62,7 +62,6 @@ class JobResponse(BaseModel):
     seed: int
     starting_image: Optional[str]
     priority: int
-    config_starred: bool = False
     status: str
     segment_count: int = 0
     completed_segment_count: int = 0
@@ -115,7 +114,6 @@ class JobUpdate(BaseModel):
     name: Optional[str] = None
     status: Optional[str] = None
     tags: Optional[str] = Field(None, max_length=500, description="Comma-separated tags")
-    config_starred: Optional[bool] = Field(None, description="Flag this job's config as a successful one")
 
 
 class WorkerStatsItem(BaseModel):


### PR DESCRIPTION
Configurations starred a job's WAN sampler settings so a working combination could be found again. Those settings went in 075, so the flag pointed at nothing — and the console page went in wanly-console#373.

**I closed #362 claiming this was already gone. It wasn't.** The page had gone; the column, the filter, the PATCH field and the star control had not. Caught by grepping before writing the closing comment rather than after.

Under LTX there's nothing to star: the stack is one global configuration and a recipe is `(character, prompt)`, so a validated pose is already a first-class row in `ltx_recipes` with a `validated` flag — which is what starring approximated.

Gone: the column, both job schemas' field, the `starred` query parameter and its filter clause across three endpoints, and the status-filter special case that existed only so the star filter could see finalized jobs.

Migration 076 verified against a real Postgres. 404 passed.

Refs #362