### PR TITLE
test: widen the dangling-column guard from routes to all of app/

### DIFF
--- a/tests/test_routes_column_refs.py
+++ b/tests/test_routes_column_refs.py
@@ -1,4 +1,4 @@
-"""Every Model.attribute a route mentions must actually exist on that model.
+"""Every Model.attribute anywhere in app/ must actually exist on that model.
 
 `GET /jobs` returned 500 in production for a day because #219 dropped
 `Segment.faceswap_enabled` from the model and the migration, but left a
@@ -23,7 +23,7 @@ import pytest
 
 from app import models
 
-ROUTES = pathlib.Path(__file__).parent.parent / "app" / "routes"
+APP = pathlib.Path(__file__).parent.parent / "app"
 
 # Mapped classes by name, e.g. {"Segment": Segment, "Job": Job, ...}
 MODELS = {
@@ -45,9 +45,9 @@ def _model_attribute_refs(tree: ast.AST):
 
 
 @pytest.mark.parametrize(
-    "path", sorted(ROUTES.glob("*.py")), ids=lambda p: p.name
+    "path", sorted(APP.rglob("*.py")), ids=lambda p: str(p.relative_to(APP))
 )
-def test_route_only_references_columns_that_exist(path):
+def test_module_only_references_columns_that_exist(path):
     tree = ast.parse(path.read_text(), filename=str(path))
     missing = [
         f"{path.name}:{lineno} {model}.{attr}"
@@ -55,7 +55,7 @@ def test_route_only_references_columns_that_exist(path):
         if not hasattr(MODELS[model], attr)
     ]
     assert not missing, (
-        "route references attributes that no longer exist on the model — a dropped "
+        "module references attributes that no longer exist on the model — a dropped "
         "column left behind will 500 at request time, not at import:\n  "
         + "\n  ".join(missing)
     )


### PR DESCRIPTION
Audit of #216 and #217 for anything else broken the way `GET /jobs` was.

**Result: nothing.** Swept every GET endpoint on production (36 of them) — no 5xx. Walked the AST of all 49 modules in `app/` for `Model.attr` references that no longer exist — zero.

The guard shipped with the `/jobs` fix only covered `app/routes/`. The drops in #216/#217 also touched services, stitching and estimation, where a dangling reference fails just as late. This widens it to the whole package: a fence, not a fix.

Separately noted, not addressed here: the console still carries dead faceswap code (an orphaned `FaceswapConfig.tsx` nothing imports, and a `JobDetail` branch gated on `seg.faceswap_enabled`, which the API no longer returns).

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG