### PR TITLE
feat: characters can be edited, not only created and deleted

### DIFF
--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -26,6 +26,7 @@ from app.ltx_stack import LTX_STACK
 from app.models import LtxCharacter, LtxRecipe, User
 from app.schemas.ltx import (
     LtxCharacterCreate,
+    LtxCharacterUpdate,
     LtxCharacterResponse,
     LtxRecipeCreate,
     LtxRecipeResponse,
@@ -144,16 +145,46 @@ async def list_characters(
     return list(rows)
 
 
+@router.patch("/ltx/characters/{character_id}", response_model=LtxCharacterResponse)
+async def update_character(
+    character_id: uuid.UUID,
+    body: LtxCharacterUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Edit a character.
+
+    Without this the only way to correct a strength or a trigger typo was delete and
+    recreate, which is a worse trade than it looks: the character's id changes, and a
+    per-stage strength is exactly the field someone tunes repeatedly.
+    """
+    c = await _character(db, character_id)
+    for k, v in body.model_dump(exclude_unset=True).items():
+        setattr(c, k, v)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="A character with that name already exists")
+    await db.refresh(c)
+    return c
+
+
 @router.delete("/ltx/characters/{character_id}", status_code=204)
 async def delete_character(
     character_id: uuid.UUID,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Deletes the character and its recipes (FK cascade).
+    """Deletes the character. Poses are NOT touched.
 
-    Renders already produced are untouched: a segment records what it ran in its own
-    ltx_recipe blob, so history does not depend on the recipe still existing.
+    The docstring here used to claim it cascaded to "its recipes". That was true of the
+    old per-character shape and false since #212: `ltx_recipes` has no character_id and
+    no relationship to this table, because a pose belongs to every character. Deleting a
+    character removes one LoRA + trigger pairing and nothing else.
+
+    Renders already produced are untouched either way: a segment records what it ran in
+    its own ltx_recipe blob, so history does not depend on the recipe still existing.
     """
     await db.delete(await _character(db, character_id))
     await db.commit()

--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -29,6 +29,22 @@ class LtxCharacterResponse(BaseModel):
     strength_stage_2: float
 
 
+class LtxCharacterUpdate(BaseModel):
+    """Every field optional: a PATCH that only moves a strength must not restate the LoRA.
+
+    `trigger` does NOT re-default to the name here, unlike create. On create an absent
+    trigger means "no opinion", and the name is the best guess. On update an absent trigger
+    means "leave it alone", and quietly rewriting it to the new name would silently change
+    every pose's rendered prompt as a side effect of a rename.
+    """
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    char_lora: Optional[str] = Field(default=None, min_length=1)
+    trigger: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    strength_stage_1: Optional[float] = Field(default=None, ge=0)
+    strength_stage_2: Optional[float] = Field(default=None, ge=0)
+
+
 class LtxRecipeCreate(BaseModel):
     """A pose. Character-agnostic: the prompt carries <TRIGGER>, not a name."""
 

--- a/tests/test_ltx_recipes.py
+++ b/tests/test_ltx_recipes.py
@@ -165,3 +165,97 @@ def test_a_new_character_gets_every_pose_without_adding_rows():
     assert '"poses"' in src
     # Poses must NOT be nested inside characters — that is the shape that locked LoRAs out.
     assert "c.recipes" not in src
+
+
+# --------------------------------------------------------------------------------------
+# Editing a character (console#361)
+# --------------------------------------------------------------------------------------
+import uuid as _uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.main import app
+from app.models import LtxCharacter, LtxRecipe, User
+
+
+async def _user(db):
+    u = User(id=_uuid.uuid4(), username=f"u{_uuid.uuid4().hex[:8]}", password_hash="x")
+    db.add(u)
+    await db.flush()
+    return u
+
+
+async def _call(db, user, method, path, **kw):
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            return await getattr(c, method)(path, **kw)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+class TestUpdateCharacter:
+    async def test_a_strength_can_be_tuned_without_restating_the_lora(self, db):
+        user = await _user(db)
+        c = LtxCharacter(id=_uuid.uuid4(), name="k9", char_lora="k9_v2", trigger="k9",
+                         strength_stage_1=0.8, strength_stage_2=1.5)
+        db.add(c)
+        await db.flush()
+
+        r = await _call(db, user, "patch", f"/ltx/characters/{c.id}",
+                        json={"strength_stage_2": 1.2})
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["strength_stage_2"] == 1.2
+        assert body["strength_stage_1"] == 0.8      # untouched
+        assert body["char_lora"] == "k9_v2"         # untouched
+
+    async def test_a_rename_leaves_the_trigger_alone(self, db):
+        """The trigger is what every pose's prompt renders with.
+
+        On create an absent trigger defaults to the name. Carrying that rule into update
+        would mean renaming a character silently rewrote the text of every pose rendered
+        for it — a side effect nobody asked for, on the one field the LoRA responds to.
+        """
+        user = await _user(db)
+        c = LtxCharacter(id=_uuid.uuid4(), name="old", char_lora="l", trigger="realtrigger",
+                         strength_stage_1=0.8, strength_stage_2=1.5)
+        db.add(c)
+        await db.flush()
+
+        r = await _call(db, user, "patch", f"/ltx/characters/{c.id}", json={"name": "new"})
+
+        assert r.status_code == 200, r.text
+        assert r.json()["name"] == "new"
+        assert r.json()["trigger"] == "realtrigger"
+
+    async def test_deleting_a_character_leaves_the_poses(self, db):
+        """Poses are not owned by a character — that is the whole point of #212.
+
+        The route's docstring claimed a cascade to "its recipes" long after the FK went,
+        which is the kind of thing that stops someone deleting a bad character.
+        """
+        user = await _user(db)
+        c = LtxCharacter(id=_uuid.uuid4(), name="doomed", char_lora="l", trigger="t",
+                         strength_stage_1=0.8, strength_stage_2=1.5)
+        pose = LtxRecipe(id=_uuid.uuid4(), name=f"pose-{_uuid.uuid4().hex[:6]}",
+                         prompt_template="<TRIGGER>, standing", validated=True)
+        db.add_all([c, pose])
+        await db.flush()
+
+        r = await _call(db, user, "delete", f"/ltx/characters/{c.id}")
+
+        assert r.status_code == 204, r.text
+        assert await db.get(LtxRecipe, pose.id) is not None
+
+    async def test_an_unknown_character_is_404_not_500(self, db):
+        user = await _user(db)
+        r = await _call(db, user, "patch", f"/ltx/characters/{_uuid.uuid4()}",
+                        json={"strength_stage_1": 1.0})
+        assert r.status_code == 404


### PR DESCRIPTION
Groundwork for console#361, which wants characters managed from the UI — name, LoRA, trigger and both strengths. Only `POST` and `DELETE` existed, so correcting a strength meant delete-and-recreate: the id changes, and a per-stage strength is exactly the field someone tunes repeatedly.

Adds `PATCH /ltx/characters/{id}`.

## `trigger` does not re-default to the name on update

On create, an absent trigger means "no opinion" and the name is the best guess. On update it means "leave it alone". Carrying the create rule over would make a **rename silently rewrite the rendered prompt of every pose** for that character — a side effect on the one field the LoRA actually responds to. Covered by a test.

## Also: a wrong docstring on a destructive endpoint

`delete_character` claimed it deletes "the character and its recipes (FK cascade)". True of the old per-character shape, false since #212 — `ltx_recipes` has no `character_id` and no relationship to that table. That is the kind of note that stops someone deleting a bad character. Corrected, and pinned by a test that deletes a character and asserts the pose survives.

540 tests pass against a real Postgres.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG