### PR TITLE
fix: Next Segment raised NameError, and the seed did not follow the chain

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -66,6 +66,32 @@ _CPU_REPROCESS_TYPES = ("ar_hologram", "smashcut_concat")
 router = APIRouter()
 
 
+async def _resolve_trigger(db: AsyncSession, prompt: str, ltx_recipe: dict | None) -> str:
+    """Fill a pose's <TRIGGER> with the character's trigger word.
+
+    Runs BEFORE _resolve_wildcards, and that order is the safeguard: <TRIGGER> shares syntax
+    with wildcards, so a Wildcard named TRIGGER would otherwise substitute a random option and
+    the render would quietly name the wrong character. Doing it first means the resolver never
+    sees the placeholder. (The name is also reserved in the wildcard routes, so both ends are
+    covered.)
+
+    The console normally substitutes at creation time; this catches a prompt that reaches the
+    API still carrying the placeholder — an edited prompt, or any caller that is not the
+    console.
+    """
+    if "<TRIGGER>" not in prompt:
+        return prompt
+    name = (ltx_recipe or {}).get("character")
+    if not name:
+        # Leave it. Rendering the literal text "<TRIGGER>" is bad, but silently dropping the
+        # token that anchors the character LoRA is worse and much harder to notice.
+        return prompt
+    row = (await db.execute(
+        select(LtxCharacter).where(LtxCharacter.name == name)
+    )).scalar_one_or_none()
+    return prompt.replace("<TRIGGER>", row.trigger) if row else prompt
+
+
 async def _resolve_wildcards(db: AsyncSession, prompt: str) -> tuple[str, str | None]:
     """Resolve <wildcard> placeholders in a prompt.
 
@@ -401,13 +427,18 @@ async def claim_next_segment(
         width=job.width,
         height=job.height,
         fps=job.fps,
-        # An explicit segment seed wins; otherwise derive it as job.seed + index, which keeps
-        # seg0 exactly job.seed (so the whole job still reproduces from that one number) and
-        # decorrelates later segments so they don't repeat the same motion pattern.
+        # THE SEED IS LOCKED ACROSS A CHAIN. Every segment of a job runs on the job's seed, so
+        # a continuation inherits the one that produced the segment it continues from.
         #
-        # A segment only carries its own seed when it needed one the derivation cannot express --
-        # today, a re-rolled segment 0, which must change seed without changing position.
-        seed=segment.seed if segment.seed is not None else (job.seed + segment.index) % (2**63 - 1),
+        # It used to be job.seed + index, which decorrelated later segments "so they don't
+        # repeat the same motion pattern". That was WAN reasoning: WAN drifted, and varying the
+        # seed spread the drift around. Under LTX a continuation is meant to look like the same
+        # shot continuing, and the seed is the single biggest determinant of what a take looks
+        # like -- expression especially is seed-driven far more than it is LoRA-driven.
+        #
+        # A segment still carries its own seed when it needs one the job's cannot express: a
+        # re-rolled segment 0, which must change seed without changing position.
+        seed=segment.seed if segment.seed is not None else job.seed,
         continuation_mode=continuation_mode,
         previous_output_path=prev_output_path if use_vace else None,
         vace_overlap_frames=vace_overlap,

--- a/tests/test_chain_seed.py
+++ b/tests/test_chain_seed.py
@@ -1,0 +1,74 @@
+"""The seed is locked across a continuation chain, and _resolve_trigger exists.
+
+Two things that had both broken at once, found when a "Next Segment" click did nothing.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+from app.routes import segments
+
+
+def test_resolve_trigger_still_exists():
+    """It was removed as collateral damage, and nothing noticed for two merges.
+
+    _resolve_loras was deleted by slicing from its `def` to the next one — and
+    _resolve_trigger sat between them. The call site survived, so every
+    POST /jobs/{id}/segments raised NameError: Next Segment could never have worked.
+
+    Both halves are asserted: a call with no definition is exactly the state that shipped.
+    """
+    src = Path(inspect.getfile(segments)).read_text()
+    tree = ast.parse(src)
+    defined = {
+        n.name for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    called = {
+        n.func.id for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    }
+    assert "_resolve_trigger" in defined, "_resolve_trigger is called but not defined"
+    assert "_resolve_trigger" in called, "nothing resolves <TRIGGER> before wildcards run"
+
+
+def test_no_module_level_function_is_called_but_undefined():
+    """The general form. A slice that removes a definition and leaves its call site is not a
+    syntax error, so nothing catches it until the endpoint is exercised."""
+    src = Path(inspect.getfile(segments)).read_text()
+    tree = ast.parse(src)
+    defined = {
+        n.name for n in ast.walk(tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    private_calls = {
+        n.func.id for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+        and n.func.id.startswith("_") and not n.func.id.startswith("__")
+    }
+    imported = set()
+    for n in ast.walk(tree):
+        if isinstance(n, ast.ImportFrom):
+            imported |= {a.asname or a.name for a in n.names}
+    missing = private_calls - defined - imported
+    assert not missing, f"called but never defined or imported: {sorted(missing)}"
+
+
+def test_the_claim_does_not_vary_the_seed_by_index():
+    """The seed is LOCKED across a chain: every segment runs on the job's seed.
+
+    It used to be `job.seed + segment.index`, justified as decorrelating later segments "so
+    they don't repeat the same motion pattern" — WAN reasoning, where drift was spread around
+    deliberately. Under LTX a continuation should look like the same shot continuing, and the
+    seed is the single biggest determinant of what a take looks like.
+
+    Verified against a real Postgres too: two segments of one job both claim on job.seed, and
+    segment 1's start image resolves to segment 0's last frame.
+    """
+    src = Path(inspect.getfile(segments)).read_text()
+    assert "job.seed + segment.index" not in src, (
+        "the claim varies the seed by index again — a continuation would run on a different "
+        "seed from the segment it continues from"
+    )
+    assert "seed=segment.seed if segment.seed is not None else job.seed," in src

--- a/tests/test_claim_endpoint.py
+++ b/tests/test_claim_endpoint.py
@@ -206,12 +206,21 @@ class TestSeed:
 
         assert (await _claim(db)).json()["seed"] == 1000
 
-    async def test_a_later_segment_is_decorrelated_by_its_index(self, db):
+    async def test_a_later_segment_inherits_the_jobs_seed_unchanged(self, db):
+        """The seed is LOCKED across a chain: segment 1 runs on the same seed as segment 0.
+
+        This asserted `job.seed + index` until the LTX migration. That was WAN reasoning --
+        WAN drifted, so decorrelating later segments spread the drift around. Under LTX a
+        continuation is meant to look like the same shot continuing, and the seed is the
+        single biggest determinant of how a take looks; expression especially is seed-driven
+        far more than it is LoRA-driven. Varying it per index is exactly the thing that made
+        a continuation look like a different woman.
+        """
         job = await _job(db, seed=1000)
         await _segment(db, job, 0, status=SegmentStatus.COMPLETED, last_frame="s3://b/0.png")
         await _segment(db, job, 1)
 
-        assert (await _claim(db)).json()["seed"] == 1001
+        assert (await _claim(db)).json()["seed"] == 1000
 
     async def test_a_segments_own_seed_wins(self, db):
         # What a re-roll writes: same position, different seed.

--- a/tests/test_no_undefined_helpers.py
+++ b/tests/test_no_undefined_helpers.py
@@ -1,0 +1,71 @@
+"""A module-private helper that is called must also be defined.
+
+`_resolve_trigger` was deleted from `app/routes/segments.py` as collateral in #216 — the
+diff sliced from `_resolve_loras` to `_resolve_wildcards` and it sat between them. Its call
+site survived, so every `POST /jobs/{id}/segments` raised NameError from the moment that
+merged: Next Segment could not work at all, and nothing failed until a request arrived.
+
+Python does not catch this. The name is resolved when the line executes, so the module
+imports cleanly, every other endpoint works, and the tests that never call the route pass.
+
+That is the same shape as the `GET /jobs` 500 (a dropped column still named by a query) and
+it went unnoticed for the same reason: the failure is per request, not per import. This walks
+the AST and asserts every `_helper(...)` a module calls is defined, imported, or assigned in
+it.
+"""
+
+import ast
+import builtins
+import pathlib
+
+import pytest
+
+APP = pathlib.Path(__file__).parent.parent / "app"
+
+
+def _bound_names(tree: ast.AST) -> set[str]:
+    """Everything a module binds at any level: defs, classes, imports, assignments, params."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for a in node.names:
+                names.add((a.asname or a.name).split(".")[0])
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            names.add(node.id)
+        elif isinstance(node, ast.arg):
+            names.add(node.arg)
+    return names
+
+
+def _called_private_names(tree: ast.AST) -> set[tuple[str, int]]:
+    """`_helper(...)` call targets. Attribute calls (`x._m()`) are somebody else's problem."""
+    out = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id.startswith("_")
+            and not node.func.id.startswith("__")
+        ):
+            out.add((node.func.id, node.lineno))
+    return out
+
+
+@pytest.mark.parametrize(
+    "path", sorted(APP.rglob("*.py")), ids=lambda p: str(p.relative_to(APP))
+)
+def test_every_private_helper_called_is_also_defined(path):
+    tree = ast.parse(path.read_text(), filename=str(path))
+    bound = _bound_names(tree) | set(dir(builtins))
+    missing = sorted(
+        f"{path.name}:{line} {name}()"
+        for name, line in _called_private_names(tree)
+        if name not in bound
+    )
+    assert not missing, (
+        "private helper called but never defined — this raises NameError at request time, "
+        "not at import, so the module loads and only the endpoint breaks:\n  "
+        + "\n  ".join(missing)
+    )


### PR DESCRIPTION
## Next Segment has never worked since #216

`_resolve_trigger` was deleted as collateral there — the diff sliced from `_resolve_loras` to `_resolve_wildcards` and it sat between them. **The call site at `segments.py:153` survived**, so every `POST /jobs/{id}/segments` has raised `NameError` since that merged.

Python resolves the name when the line runs, so the module imports cleanly, every other endpoint works, and nothing fails until a request arrives — the same shape as the `GET /jobs` 500, invisible for the same reason.

**Guard:** `tests/test_no_undefined_helpers.py` walks the AST of every module in `app/` and asserts each `_helper(...)` called is defined, imported or assigned there. Verified both ways — with the fix reverted it reports `segments.py:153 _resolve_trigger()`.

## The seed is locked across a chain

A continuation now runs on the job's seed instead of `job.seed + index`.

The old rule was WAN reasoning: WAN drifted, so decorrelating later segments spread the drift around. Under LTX a continuation is meant to look like the same shot continuing, and the seed is the single biggest determinant of how a take looks — expression especially is seed-driven far more than it is LoRA-driven. Varying it per index is what made a continuation look like a different woman.

A segment still carries its own seed where it needs one the job's cannot express: a re-rolled segment 0 changes seed without changing position.

`test_a_later_segment_is_decorrelated_by_its_index` asserted the old rule. Rewritten rather than deleted, so the reason it changed is recorded where the next person looks.

592 tests pass against a real Postgres.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG