### PR TITLE
docs: state what the chain seed guarantees, and fix a stale archive stamp

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -427,17 +427,21 @@ async def claim_next_segment(
         width=job.width,
         height=job.height,
         fps=job.fps,
-        # THE SEED IS LOCKED ACROSS A CHAIN. Every segment of a job runs on the job's seed, so
-        # a continuation inherits the one that produced the segment it continues from.
+        # THE SEED IS LOCKED ACROSS A CHAIN. Next Segment must keep the seed -- a
+        # continuation should look like the same shot carrying on, and the seed drives how a
+        # take looks more than anything else. Re-roll must CHANGE it, which is the opposite
+        # requirement and is served elsewhere: _roll_new_take sets a new job.seed, so the
+        # fresh take and every continuation after it inherit that instead.
+        #
+        # job.seed is therefore always the live chain's seed. A segment's own seed is only
+        # ever set on a DISCARDED take, stamped at re-roll time to record what it actually
+        # ran on, and a discarded take is never claimed.
         #
         # It used to be job.seed + index, which decorrelated later segments "so they don't
         # repeat the same motion pattern". That was WAN reasoning: WAN drifted, and varying the
         # seed spread the drift around. Under LTX a continuation is meant to look like the same
         # shot continuing, and the seed is the single biggest determinant of what a take looks
         # like -- expression especially is seed-driven far more than it is LoRA-driven.
-        #
-        # A segment still carries its own seed when it needs one the job's cannot express: a
-        # re-rolled segment 0, which must change seed without changing position.
         seed=segment.seed if segment.seed is not None else job.seed,
         continuation_mode=continuation_mode,
         previous_output_path=prev_output_path if use_vace else None,
@@ -1101,7 +1105,12 @@ def _roll_new_take(job: Job, old: Segment) -> Segment:
     replaced is still recorded, on the row it actually produced. See #199 for the full model.
     """
     if old.seed is None:
-        old.seed = (job.seed + old.index) % (2**63 - 1)
+        # Exactly what the worker ran: the claim hands out job.seed. This said
+        # `(job.seed + old.index) % (2**63 - 1)`, the derivation the claim used before the
+        # seed was locked across a chain. It survived because re-roll only ever acts on
+        # index 0, where the two agree -- so it would have recorded a seed the take never
+        # ran on the first time anyone re-rolled a continuation.
+        old.seed = job.seed
     old.discarded = True
     job.seed = new_seed()
 

--- a/tests/test_claim_endpoint.py
+++ b/tests/test_claim_endpoint.py
@@ -229,6 +229,29 @@ class TestSeed:
 
         assert (await _claim(db)).json()["seed"] == 150488800771430
 
+    async def test_a_re_roll_changes_the_seed_and_the_chain_follows_the_new_one(self, db):
+        """Re-roll and Next Segment want opposite things from a seed, and both are right.
+
+        A re-roll asks for a DIFFERENT take, so it must change the seed. A continuation asks
+        for the SAME shot carrying on, so it must keep it. Both are served by one field:
+        re-roll sets a new `job.seed`, and everything live derives from that.
+
+        The seed the discarded take ran on is stamped onto it so the archive can answer
+        "which seed gave me that one" -- and that stamped seed must never leak into a
+        continuation, because it produced a take that is no longer in the chain.
+        """
+        job = await _job(db, seed=1000)
+        # what a re-roll leaves behind: the old take stamped and discarded, a new job seed,
+        # and a fresh take deriving from it.
+        await _segment(db, job, 0, seed=1000, status=SegmentStatus.COMPLETED,
+                       discarded=True, last_frame="s3://b/old.png")
+        job.seed = 2000
+        await _segment(db, job, 0, status=SegmentStatus.COMPLETED, last_frame="s3://b/0.png")
+        await _segment(db, job, 1)
+
+        # 2000, not 1000: the continuation follows the take that survived.
+        assert (await _claim(db)).json()["seed"] == 2000
+
     async def test_the_worker_gets_an_integer_not_a_string(self, db):
         # The console's schema sends seeds as strings for display precision. This payload feeds
         # the sampler, and it must not inherit that.


### PR DESCRIPTION
Prompted by "does next segment lock previous seed?" — which needed an answer with evidence.

**It does.** Re-roll and Next Segment want opposite things from a seed and both are right: a re-roll asks for a *different* take, a continuation asks for the *same* shot carrying on. One field serves both — `_roll_new_take` sets a new `job.seed`, and everything live derives from it.

So `job.seed` is always the live chain's seed. A segment's own seed is only ever set on a **discarded** take, stamped at re-roll time to record what it ran on, and a discarded take is never claimed.

## A wrong fix, recorded

I first changed this to walk back to the nearest earlier segment carrying a seed. That is wrong in a way worth keeping in the history: the only rows carrying one are the archived takes, so it would have handed a continuation the seed of a take no longer in the chain — 1000 after a re-roll to 2000. Reverted. The comment now states the invariant, since the code was right and only looked arbitrary.

## The real defect

The archive stamped the outgoing take with `(job.seed + old.index) % (2**63 - 1)` — the derivation the claim used *before* the seed was locked. It agrees with reality only at index 0, which is the only place re-roll acts today. The first re-roll of a continuation would have recorded a seed that take never ran on, in the field whose whole purpose is answering "which seed gave me that one".

Now records `job.seed`.

Test built from what a re-roll actually leaves behind — stamped discarded take, new job seed, fresh take — asserting the continuation follows the survivor, not the archive. 643 tests pass.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG