### PR TITLE
fix: total queue time is a wait, not a sum of work

### DIFF
--- a/app/estimation.py
+++ b/app/estimation.py
@@ -305,20 +305,41 @@ def estimate_segment_time(
     return estimate.seconds if estimate else None
 
 
-def sum_estimated_queue_time(rates: dict, segments) -> float:
-    """Total estimated seconds for a set of queued segments.
+def estimate_queue_drain_seconds(
+    rates: dict, segments, worker_count: int, now: datetime
+) -> float:
+    """Wall-clock seconds until the queue is empty, not the sum of the work in it.
 
-    Each row is (width, height, fps, duration_seconds, gpu_name).
+    Each row is (width, height, fps, duration_seconds, gpu_name, status, claimed_at).
 
-    A segment the estimator cannot price contributes nothing rather than a guess. That makes the
-    total read low on a cold database instead of confidently wrong, which is the safer failure
-    for a number used to decide whether there is time to queue more work.
+    Two corrections to a straight sum, both of which made the old number wrong in the
+    direction that matters:
+
+    WORKERS. The sum is the work; the wait is the work divided by the machines doing it. With
+    one worker the two agree, which is why this was never noticed — and then a pod is launched
+    and the real wait halves while the number does not move. Divided by the workers actually
+    able to claim, floored at one so an empty fleet reports the work rather than infinity.
+
+    WORK ALREADY DONE. A segment being rendered was counted at its full estimate however long
+    it had been running. Measured live: 235s into a 586s render, counted as 586. That is 1% of
+    a long queue and all of a short one -- the last segment at 90% reported ten minutes with
+    one to go, so the number stopped converging on zero exactly when someone was watching it
+    to decide whether to queue more.
+
+    A segment the estimator cannot price still contributes nothing rather than a guess. That
+    makes the total read low on a cold database instead of confidently wrong, which is the
+    safer failure for a number used to decide whether there is time for more work.
     """
     total = 0.0
-    for width, height, fps, duration_seconds, gpu_name in segments:
+    for width, height, fps, duration_seconds, gpu_name, status, claimed_at in segments:
         if not duration_seconds:
             continue
         est = estimate_segment_time(rates, width, height, fps, duration_seconds, gpu_name)
-        if est:
-            total += est
-    return round(total, 1)
+        if not est:
+            continue
+        if claimed_at is not None:
+            # Never negative: a segment running longer than its estimate is late, not
+            # ahead, and a negative would silently pay for some other segment's time.
+            est = max(0.0, est - (now - claimed_at).total_seconds())
+        total += est
+    return round(total / max(1, worker_count), 1)

--- a/app/estimation.py
+++ b/app/estimation.py
@@ -331,6 +331,7 @@ def estimate_queue_drain_seconds(
     safer failure for a number used to decide whether there is time for more work.
     """
     total = 0.0
+    longest = 0.0
     for width, height, fps, duration_seconds, gpu_name, status, claimed_at in segments:
         if not duration_seconds:
             continue
@@ -342,4 +343,10 @@ def estimate_queue_drain_seconds(
             # ahead, and a negative would silently pay for some other segment's time.
             est = max(0.0, est - (now - claimed_at).total_seconds())
         total += est
-    return round(total / max(1, worker_count), 1)
+        longest = max(longest, est)
+
+    # A segment cannot be split across workers. With fewer segments than workers, dividing
+    # says half a render time for one render — so the wait is never shorter than the longest
+    # single segment left. That is the case that matters right after a pod joins an
+    # almost-empty queue, which is exactly when someone is watching this number.
+    return round(max(total / max(1, worker_count), longest), 1)

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -19,7 +19,7 @@ from app.config import settings
 from app.database import get_db
 from app.enums import JOB_VALID_TRANSITIONS, JobStatus, SegmentStatus, VideoStatus
 from app.seeds import new_seed
-from app.estimation import estimate_segment_time, get_estimation_rates, sum_estimated_queue_time
+from app.estimation import estimate_segment_time, get_estimation_rates, estimate_queue_drain_seconds
 from app.models import Job, Segment, User, Video
 from app.routes.segments import _resolve_wildcards
 from app.s3 import delete_object, delete_prefix, delete_prefix_except, upload_bytes
@@ -792,7 +792,10 @@ async def get_stats(
     queue_rows = (
         await db.execute(
             select(
-                Job.width, Job.height, Job.fps, Segment.duration_seconds, Segment.gpu_name
+                Job.width, Job.height, Job.fps, Segment.duration_seconds, Segment.gpu_name,
+                # For the in-flight correction: what has already been rendered is not still
+                # ahead of you.
+                Segment.status, Segment.claimed_at,
             )
             .join(Job, Segment.job_id == Job.id)
             .where(
@@ -805,7 +808,27 @@ async def get_stats(
     total_queue_time = 0.0
     if queue_rows:  # skip three estimator queries when the queue is empty
         rates = await get_estimation_rates(db, user.id)
-        total_queue_time = sum_estimated_queue_time(rates, queue_rows)
+        # Workers that can actually claim. A drained or offline worker will never take a
+        # segment, so counting it would halve a number that is not going to halve.
+        # Heartbeat rather than status alone: a worker that died without saying so still
+        # reads "online-busy" until something reaps it.
+        cutoff = datetime.now(timezone.utc) - timedelta(
+            seconds=settings.heartbeat_offline_seconds
+        )
+        worker_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(Worker)
+                .where(
+                    Worker.status.notin_(("offline", "draining")),
+                    Worker.last_heartbeat.isnot(None),
+                    Worker.last_heartbeat >= cutoff,
+                )
+            )
+        ).scalar() or 0
+        total_queue_time = estimate_queue_drain_seconds(
+            rates, queue_rows, worker_count, datetime.now(timezone.utc)
+        )
 
     # Worker stats
     worker_rows = (

--- a/tests/test_queue_drain_estimate.py
+++ b/tests/test_queue_drain_estimate.py
@@ -64,3 +64,20 @@ class TestDrain:
         # Reads low on a cold database rather than confidently wrong.
         unknown = (None, None, 24, 10.04, None, "pending", None)
         assert estimate_queue_drain_seconds(RATES, [unknown], 1, NOW) == 0.0
+
+    def test_more_workers_than_segments_cannot_beat_one_segment(self):
+        """A segment cannot be split across workers.
+
+        One segment and four workers is still one render: dividing would report a quarter of
+        it. This is the case right after a pod joins an almost-empty queue -- precisely when
+        the number is being watched.
+        """
+        one = estimate_queue_drain_seconds(RATES, [_row()], 1, NOW)
+        many = estimate_queue_drain_seconds(RATES, [_row()], 4, NOW)
+        assert many == one
+
+    def test_workers_still_help_when_there_is_work_for_them(self):
+        rows = [_row() for _ in range(8)]
+        assert estimate_queue_drain_seconds(RATES, rows, 4, NOW) == pytest.approx(
+            estimate_queue_drain_seconds(RATES, rows, 1, NOW) / 4, rel=0.01
+        )

--- a/tests/test_queue_drain_estimate.py
+++ b/tests/test_queue_drain_estimate.py
@@ -1,0 +1,66 @@
+"""Total queue time is a WAIT, not a sum of work.
+
+Measured on production before this changed: 36 segments, 21741s reported, which is exactly
+36 x the 586s average. Correct with one worker and wrong the moment a pod joins — the real
+wait halves while the number does not move. The in-flight segment was also counted at full
+price 235s into its render.
+"""
+
+import datetime as dt
+
+import pytest
+
+from app.estimation import PixelLaw, estimate_queue_drain_seconds
+
+NOW = dt.datetime(2026, 9, 1, 12, 0, tzinfo=dt.timezone.utc)
+
+# A rate table the estimator can price from: one shape, plenty of samples.
+RATES = {
+    "shape_rates": {(1216, 832, 24): (58.0, 22)},
+    "gpu_rates": {},
+    "gpu_factors": {},
+    "pixel_law": PixelLaw(slope=1.0, intercept=0.0, shapes=3, min_pixels=1, max_pixels=10**9),
+}
+
+
+def _row(status="pending", claimed_at=None):
+    return (1216, 832, 24, 10.04, "NVIDIA GeForce RTX 3090", status, claimed_at)
+
+
+def _one_segment_estimate():
+    return estimate_queue_drain_seconds(RATES, [_row()], 1, NOW)
+
+
+@pytest.mark.skipif(_one_segment_estimate() == 0, reason="estimator cannot price this shape")
+class TestDrain:
+    def test_two_workers_halve_the_wait(self):
+        rows = [_row(), _row(), _row(), _row()]
+        one = estimate_queue_drain_seconds(RATES, rows, 1, NOW)
+        two = estimate_queue_drain_seconds(RATES, rows, 2, NOW)
+        assert two == pytest.approx(one / 2, rel=0.01)
+
+    def test_no_workers_reports_the_work_rather_than_infinity(self):
+        rows = [_row(), _row()]
+        assert estimate_queue_drain_seconds(RATES, rows, 0, NOW) == estimate_queue_drain_seconds(
+            RATES, rows, 1, NOW
+        )
+
+    def test_an_in_flight_segment_is_discounted_by_what_it_has_already_run(self):
+        fresh = estimate_queue_drain_seconds(RATES, [_row()], 1, NOW)
+        started = NOW - dt.timedelta(seconds=100)
+        part_done = estimate_queue_drain_seconds(
+            RATES, [_row("processing", started)], 1, NOW
+        )
+        assert part_done == pytest.approx(fresh - 100, abs=1.0)
+
+    def test_a_segment_running_over_its_estimate_never_goes_negative(self):
+        """Late is not ahead. A negative would silently pay for another segment's time."""
+        long_ago = NOW - dt.timedelta(hours=5)
+        assert estimate_queue_drain_seconds(
+            RATES, [_row("processing", long_ago)], 1, NOW
+        ) == 0.0
+
+    def test_an_unpriceable_segment_still_contributes_nothing(self):
+        # Reads low on a cold database rather than confidently wrong.
+        unknown = (None, None, 24, 10.04, None, "pending", None)
+        assert estimate_queue_drain_seconds(RATES, [unknown], 1, NOW) == 0.0

--- a/tests/test_queue_time.py
+++ b/tests/test_queue_time.py
@@ -1,18 +1,32 @@
-"""Tests for the dashboard's Total Queue Time sum.
+"""Tests for the dashboard's Total Queue Time.
 
 The number answers "is there room to queue more work", so the failure that matters is a
 confident overestimate. An unpriceable segment therefore contributes nothing rather than a
 fallback guess, and the total reads low on a cold database instead of wrong.
+
+It is now a WAIT rather than a sum: divided by the workers able to claim, and discounted by
+what an in-flight segment has already rendered. These cases all use one worker and unstarted
+segments, so they keep testing the pricing itself; the drain behaviour is covered in
+test_queue_drain_estimate.py.
 
 Pure logic — no HTTP, no database, matching the house style.
 """
 
 import pytest
 
-from app.estimation import DURATION_EXPONENT, sum_estimated_queue_time
+import datetime as dt
 
-# (width, height, fps, duration_seconds, gpu_name)
-ROW = (720, 1056, 30, 4.0, "NVIDIA GeForce RTX 3090")
+from app.estimation import DURATION_EXPONENT, estimate_queue_drain_seconds
+
+# (width, height, fps, duration_seconds, gpu_name, status, claimed_at)
+ROW = (720, 1056, 30, 4.0, "NVIDIA GeForce RTX 3090", "pending", None)
+
+NOW = dt.datetime(2026, 9, 1, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def sum_estimated_queue_time(rates_, rows):
+    """One worker, nothing started: the historical meaning of this number."""
+    return estimate_queue_drain_seconds(rates_, rows, 1, NOW)
 
 # Run time is rate * duration ** DURATION_EXPONENT, so the tests state the rate they want and
 # let this do the arithmetic rather than hard-coding numbers that move when the exponent does.
@@ -42,7 +56,7 @@ class TestSumming:
         """A 720p and a 1080p segment must not be priced with the same rate."""
         r = rates(shape={(720, 1056, 30): (2.0, 10), (1056, 720, 30): (5.0, 10)})
         total = sum_estimated_queue_time(
-            r, [(720, 1056, 30, 4.0, None), (1056, 720, 30, 4.0, None)]
+            r, [(720, 1056, 30, 4.0, None, "pending", None), (1056, 720, 30, 4.0, None, "pending", None)]
         )
         assert total == pytest.approx(7.0 * SCALED_4S, abs=0.2)
 
@@ -55,14 +69,14 @@ class TestUnpriceableSegments:
     def test_priceable_segments_still_count_when_others_cannot_be_priced(self):
         """One unknown shape must not zero out the whole total."""
         r = rates(shape={(720, 1056, 30): (2.0, 10)})
-        total = sum_estimated_queue_time(r, [ROW, (9999, 9999, 30, 4.0, None)])
+        total = sum_estimated_queue_time(r, [ROW, (9999, 9999, 30, 4.0, None, "pending", None)])
         assert total == pytest.approx(2.0 * SCALED_4S, abs=0.2)
 
     @pytest.mark.parametrize("duration", [0, 0.0, None])
     def test_segments_with_no_duration_are_skipped(self, duration):
         """duration_seconds is nullable; rate * None would raise rather than degrade."""
         r = rates(shape={(720, 1056, 30): (2.0, 10)})
-        assert sum_estimated_queue_time(r, [(720, 1056, 30, duration, None)]) == 0.0
+        assert sum_estimated_queue_time(r, [(720, 1056, 30, duration, None, "pending", None)]) == 0.0
 
 
 class TestRateSelection:
@@ -77,6 +91,6 @@ class TestRateSelection:
     def test_unclaimed_segments_use_the_pooled_shape_rate(self):
         """Pending segments have no gpu_name yet - the common case for a deep queue."""
         r = rates(shape={(720, 1056, 30): (2.0, 10)})
-        assert sum_estimated_queue_time(r, [(720, 1056, 30, 4.0, None)]) == pytest.approx(
+        assert sum_estimated_queue_time(r, [(720, 1056, 30, 4.0, None, "pending", None)]) == pytest.approx(
             2.0 * SCALED_4S, abs=0.2
         )


### PR DESCRIPTION
Closes #227.

Measured on production before this changed: **36 queued segments, 21741s reported — exactly 36 × the 586s average.** A straight sum. Correct with one worker, which is why it was never noticed, and wrong the moment a pod joins: the real wait halves while the number does not move. Heterogeneous workers are the entire point of launching pods.

## Two corrections

**Workers.** Divided by the workers actually able to claim — heartbeat within `heartbeat_offline_seconds`, status not `offline`/`draining`. Status alone is not enough: a worker that died without saying so still reads `online-busy` until something reaps it, and counting it would halve a number that is not going to halve. Floored at one, so an empty fleet reports the work rather than infinity.

**Work already done.** An in-flight segment was counted at full price however long it had run — measured live at **235s into a 586s render, counted as 586**. That is 1% of a long queue and *all* of a short one: the last segment at 90% reported ten minutes with one to go, so the number stopped converging on zero exactly when someone was watching it to decide whether to queue more. Discounted by elapsed and floored at zero, because a segment running over its estimate is late rather than ahead — a negative would silently pay for another segment's time.

Unpriceable segments still contribute nothing rather than a guess: reading low on a cold database beats being confidently wrong.

## Tests

`test_queue_time.py` is **adapted, not replaced** — its cases test the pricing, which has not changed, so they call through a one-worker helper that preserves their original meaning. Drain behaviour gets its own file, including the two cases that would otherwise regress silently: no workers, and a segment running over its estimate.

648 tests pass.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG