### PR TITLE
fix: a naive claimed_at must not take the dashboard down

### DIFF
--- a/app/estimation.py
+++ b/app/estimation.py
@@ -339,6 +339,14 @@ def estimate_queue_drain_seconds(
         if not est:
             continue
         if claimed_at is not None:
+            # Assume UTC for a naive timestamp rather than raising. The column is
+            # `timestamp with time zone` and the driver returns aware datetimes, so this
+            # should not happen -- but "should not happen" here means TypeError inside
+            # GET /stats, which takes the whole dashboard down for a number that is
+            # decoration. Every timestamp this system writes is UTC, so the assumption is
+            # the correct one and not a guess.
+            if claimed_at.tzinfo is None:
+                claimed_at = claimed_at.replace(tzinfo=timezone.utc)
             # Never negative: a segment running longer than its estimate is late, not
             # ahead, and a negative would silently pay for some other segment's time.
             est = max(0.0, est - (now - claimed_at).total_seconds())

--- a/tests/test_queue_drain_estimate.py
+++ b/tests/test_queue_drain_estimate.py
@@ -81,3 +81,13 @@ class TestDrain:
         assert estimate_queue_drain_seconds(RATES, rows, 4, NOW) == pytest.approx(
             estimate_queue_drain_seconds(RATES, rows, 1, NOW) / 4, rel=0.01
         )
+
+    def test_a_naive_claimed_at_does_not_take_the_dashboard_down(self):
+        """The column is timestamptz and the driver returns aware datetimes, so this should
+        not arise — and "should not arise" here meant TypeError inside GET /stats, which is
+        the whole dashboard down for a number that is decoration."""
+        started = (NOW - dt.timedelta(seconds=100)).replace(tzinfo=None)
+        fresh = estimate_queue_drain_seconds(RATES, [_row()], 1, NOW)
+        assert estimate_queue_drain_seconds(
+            RATES, [_row("processing", started)], 1, NOW
+        ) == pytest.approx(fresh - 100, abs=1.0)


### PR DESCRIPTION
`GET /stats` has been 500ing since #229. I cannot read the server's traceback (deploy is via SSM, no AWS credentials here; SSH keys rejected), so this fixes the one failure mode I could **reproduce against production's own queue rows**, pulled back through the API:

```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

That arithmetic is new code from #229 — the in-flight discount.

The column is `timestamp with time zone` and the driver returns aware datetimes, so this should not arise. But *should not arise* here means the whole dashboard is down for a number that is decoration, and every timestamp this system writes is UTC, so assuming UTC for a naive value is the correct reading rather than a guess.

**Whether this is the actual production failure is unproven.** If `/stats` still 500s after it deploys, I will revert the drain change rather than patch blind a third time.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG