### PR TITLE
feat: img_compression is tunable — stack default, per-pose override

### DIFF
--- a/alembic/versions/078_recipe_img_compression.py
+++ b/alembic/versions/078_recipe_img_compression.py
@@ -1,0 +1,30 @@
+"""Per-pose img_compression override
+
+Revision ID: 078
+Revises: 077
+Create Date: 2026-09-01
+
+NULLABLE on purpose, and null means "use the stack's value" — the same shape as
+`negative_prompt` and `frames`, which resolve as `r.frames or LTX_STACK["frames"]`. Every
+existing pose keeps rendering at the stack default, so this migration changes no output.
+
+img_compression is a video CRF: the conditioning frame is H.264-encoded at this quality and
+decoded back before it anchors the render. 0 bypasses it. Measured at 18 (current) against 4
+on a 4090, the lower value cut per-frame divergence by ~34% (wanly-gpu-docker#48) — which is
+why it is worth exposing per pose rather than only globally.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "078"
+down_revision = "077"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ltx_recipes", sa.Column("img_compression", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("ltx_recipes", "img_compression")

--- a/app/ltx_stack.py
+++ b/app/ltx_stack.py
@@ -19,6 +19,16 @@ LTX_STACK = {
     'distill_stage_2': 0.6,
     'frames': 241,
     'frame_rate': 24,
+    # A video CRF, not an abstract amount: the conditioning frame is H.264-encoded at this
+    # quality and decoded back (comfy_extras/nodes_lt.py `preprocess`), so the model is
+    # anchored on something that looks like a video frame rather than a pristine still.
+    # 0 bypasses it entirely. Node bounds are 0-100, but x264's real scale is 0-51.
+    #
+    # 18 is what every rated result was produced at. Measured on a 4090 (wanly-gpu-docker#48),
+    # dropping it to 4 cut per-frame divergence ~34% from frame 8 on -- but that was measured
+    # against each clip's own frame 0, which cannot distinguish "holds the anchor" from
+    # "moves less", so the default stays where the results came from until that is settled.
+    'img_compression': 18,
     'steps_stage_1': 20,
     'sigmas_stage_2': '0.85, 0.7250, 0.4219, 0.0',
     'cfg': 3,

--- a/app/models.py
+++ b/app/models.py
@@ -393,5 +393,9 @@ class LtxRecipe(Base):
     # renders well is a property of its LoRA, and segment ratings already record that.
     # NOT a quality score: the automated metrics have picked the wrong clip before.
     validated = mapped_column(Boolean, nullable=False, server_default="false", default=False)
+    # NULL means "use the stack's value", exactly as frames and negative_prompt do.
+    # A video CRF applied to the conditioning frame before it anchors the render;
+    # 0 bypasses it. See wanly-api#235.
+    img_compression = mapped_column(Integer, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), nullable=True)

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -97,6 +97,11 @@ async def get_recipe_book(
                 "prompt_template": r.prompt_template,
                 "negative_prompt": r.negative_prompt or LTX_STACK["negative"],
                 "frames": r.frames or LTX_STACK["frames"],
+                # `or` is wrong here and `is None` is right: img_compression 0 is a REAL
+                # setting -- it bypasses the conditioning-frame encode entirely -- and `or`
+                # would silently replace it with the stack default.
+                "img_compression": (r.img_compression if r.img_compression is not None
+                                    else LTX_STACK["img_compression"]),
                 "validated": r.validated,
             }
             for r in poses

--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -53,6 +53,10 @@ class LtxRecipeCreate(BaseModel):
     # NULL means the global stack's negative, which is true of every seeded recipe.
     negative_prompt: Optional[str] = None
     frames: Optional[int] = Field(default=None, gt=0)
+    # A video CRF for the conditioning frame. NULL uses the stack's value. 0 is meaningful:
+    # it bypasses the encode. Bounded at 51 -- the node accepts 100, but x264's scale ends
+    # at 51 and anything above it is nominal.
+    img_compression: Optional[int] = Field(default=None, ge=0, le=51)
     validated: bool = False
 
 
@@ -61,6 +65,7 @@ class LtxRecipeUpdate(BaseModel):
     prompt_template: Optional[str] = Field(default=None, min_length=1)
     negative_prompt: Optional[str] = None
     frames: Optional[int] = Field(default=None, gt=0)
+    img_compression: Optional[int] = Field(default=None, ge=0, le=51)
     validated: Optional[bool] = None
 
 
@@ -72,6 +77,7 @@ class LtxRecipeResponse(BaseModel):
     prompt_template: str
     negative_prompt: Optional[str]
     frames: Optional[int]
+    img_compression: Optional[int]
     validated: bool
     created_at: datetime
     updated_at: Optional[datetime]

--- a/tests/test_img_compression.py
+++ b/tests/test_img_compression.py
@@ -1,0 +1,53 @@
+"""img_compression: a per-pose override that must survive being zero.
+
+0 is a REAL setting — comfy_extras/nodes_lt.py `preprocess` returns the image untouched at
+crf 0 — so every hop has to use `is None` rather than truthiness. A falsy check silently
+replaces "skip the encode" with the stack default, which is a different render that looks
+plausible and is not what the pose asked for.
+"""
+import pytest
+
+from app.ltx_stack import LTX_STACK
+
+
+def resolve(pose_value):
+    """Mirrors the book's resolution, which is the rule under test."""
+    return pose_value if pose_value is not None else LTX_STACK["img_compression"]
+
+
+def test_the_stack_carries_the_value_every_rated_result_used():
+    assert LTX_STACK["img_compression"] == 18
+
+
+def test_a_pose_with_no_override_uses_the_stack():
+    assert resolve(None) == 18
+
+
+def test_a_pose_override_wins():
+    assert resolve(4) == 4
+
+
+def test_zero_is_honoured_and_not_treated_as_unset():
+    # The bug this guards: `r.img_compression or LTX_STACK[...]` yields 18 here, so a pose
+    # asking to skip the conditioning encode would quietly render at the default instead.
+    assert resolve(0) == 0
+
+
+@pytest.mark.parametrize("bad", [-1, 52, 100])
+def test_out_of_range_is_rejected_by_the_schema(bad):
+    from pydantic import ValidationError
+
+    from app.schemas.ltx import LtxRecipeCreate
+
+    with pytest.raises(ValidationError):
+        LtxRecipeCreate(name="p", prompt_template="<TRIGGER>, x", img_compression=bad)
+
+
+@pytest.mark.parametrize("ok", [0, 4, 18, 51])
+def test_the_meaningful_crf_range_is_accepted(ok):
+    from app.schemas.ltx import LtxRecipeCreate
+
+    # 0-51 is x264's actual scale. The node accepts up to 100, but above 51 the number stops
+    # meaning anything, so the schema is the tighter of the two on purpose.
+    assert LtxRecipeCreate(name="p", prompt_template="<TRIGGER>, x",
+                           img_compression=ok).img_compression == ok


### PR DESCRIPTION
Closes #235.

Measured on a 4090 (wanly-gpu-docker#48): dropping `img_compression` **18 → 4 cut per-frame divergence ~34%** from frame 8 onward, exactly where the start-frame anchor lapses. The stage-2 sigma hypothesis from the same experiment did nothing (+1%).

## It is a video CRF

The conditioning frame is H.264-encoded at this quality and decoded back before it anchors the render — the model is held to something that *looks like a video frame* rather than a pristine still. That is why 0 is not obviously right: it bypasses the encode, and an uncompressed anchor can sit visibly cleaner than anything generated after it.

## Shape

Same as the two per-pose values that already exist, so no new mechanism:

```python
negative_prompt: r.negative_prompt or LTX_STACK["negative"]
frames:          r.frames          or LTX_STACK["frames"]
```

**Default stays 18** — the value every rated result was produced at. Existing poses are all NULL, so nothing renders differently until someone chooses otherwise.

## The trap, and why it has four tests

`or` is **wrong** here. 0 is a real setting, and `r.img_compression or LTX_STACK[...]` silently turns "skip the encode" into 18 — a different render that looks plausible. Every hop uses `is None`.

Range is **0–51**, not the node's 0–100: x264's scale ends at 51, so the schema is the tighter of the two.

Migration 078 verified up **and down** against a real Postgres. 609 tests pass.

Companion PRs: wanly-gpu-docker (engine patches the node), wanly-gpu-daemon (forwards it), wanly-console (pose editor field).

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG