### PR TITLE
loras: GET /loras so a worker can diff what it holds against the bucket

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,12 @@ class Settings(BaseSettings):
     s3_jobs_bucket: str = "wanly-jobs"
     s3_faces_bucket: str = "wanly-faces"
     s3_images_bucket: str = "wanly-images"
+    # Character LoRAs, so a worker can obtain one instead of only rendering on a box that
+    # already has the file. Its own region: the bucket was created in us-east-1 while
+    # everything else here is us-west-2, and a presigned URL signed for the wrong region
+    # fails with SignatureDoesNotMatch — which reads like an auth problem and is not one.
+    s3_loras_bucket: str = "ltx-loras"
+    s3_loras_region: str = "us-east-1"
     aws_region: str = "us-west-2"
     api_key: str = ""
     civitai_api_token: str = ""

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -12,6 +12,7 @@ are not.
 """
 
 import logging
+import asyncio
 import uuid
 from datetime import datetime, timezone
 
@@ -20,7 +21,9 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import get_current_user
+from app.config import settings
+from app.s3 import list_bucket
+from app.auth import get_current_user, verify_api_key_or_token
 from app.database import get_db
 from app.ltx_stack import LTX_STACK
 from app.models import LtxCharacter, LtxRecipe, User
@@ -118,6 +121,38 @@ async def get_recipe_book(
             for c in chars
         ],
     }
+
+
+@router.get("/loras", dependencies=[Depends(verify_api_key_or_token)])
+async def list_available_loras():
+    """Every character LoRA a worker could fetch, so it can diff against what it holds.
+
+    Exists because workers deliberately carry NO AWS credentials — a rented pod should not
+    hold them — and so they cannot list the bucket themselves. They already download through
+    GET /files, which 307s to a presigned URL; this is the missing half that tells them what
+    is there.
+
+    `etag` is the md5 of the content for these objects and is what a worker should compare
+    against, NOT the name: a retrained LoRA republished under the same name would otherwise
+    never be picked up, and the worker would render old weights while the console showed the
+    new character. Size is not sufficient either — two of the current three are byte-identical
+    in size and completely different in content.
+
+    `multipart: true` means the etag is not an md5 of the whole object and cannot be compared;
+    a worker should fall back to size and say so rather than re-downloading forever.
+    """
+    objs = await asyncio.to_thread(list_bucket, settings.s3_loras_bucket)
+    return [
+        {
+            "name": o["name"],
+            "size": o["size"],
+            "etag": o["etag"],
+            "multipart": o["multipart"],
+            "uri": f"s3://{settings.s3_loras_bucket}/{o['name']}",
+        }
+        for o in objs
+        if o["name"].endswith(".safetensors")
+    ]
 
 
 @router.post("/ltx/characters", response_model=LtxCharacterResponse, status_code=201)

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -23,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.s3 import list_bucket
-from app.auth import get_current_user, verify_api_key_or_token
+from app.auth import get_current_user, verify_api_key_or_bearer
 from app.database import get_db
 from app.ltx_stack import LTX_STACK
 from app.models import LtxCharacter, LtxRecipe, User
@@ -123,9 +123,17 @@ async def get_recipe_book(
     }
 
 
-@router.get("/loras", dependencies=[Depends(verify_api_key_or_token)])
+@router.get("/loras", dependencies=[Depends(verify_api_key_or_bearer)])
 async def list_available_loras():
-    """Every character LoRA a worker could fetch, so it can diff against what it holds.
+    """Every character LoRA in the bucket — the worker's sync list AND the console's dropdown.
+
+    Two callers, deliberately one endpoint: what the console offers to pick from is exactly
+    what a worker can actually obtain. A dropdown listing a LoRA no worker can fetch is a
+    job that fails ten minutes into a claimed segment.
+
+    Hence verify_api_key_or_bearer and not verify_api_key_or_token: the worker authenticates
+    with X-API-Key, the console with a Bearer JWT. The _or_token variant accepts a ?token=
+    query param for <img src> media loads and would 401 the console outright.
 
     Exists because workers deliberately carry NO AWS credentials — a rented pod should not
     hold them — and so they cannot list the bucket themselves. They already download through

--- a/app/s3.py
+++ b/app/s3.py
@@ -10,6 +10,48 @@ logger = logging.getLogger(__name__)
 _client = None
 
 
+def _client_for_bucket(bucket: str):
+    """A client in the right region for this bucket.
+
+    Buckets here are not all in one region: ltx-loras is us-east-1 and the rest are
+    us-west-2. A presigned URL signed by a client in the wrong region is accepted by S3's
+    endpoint and then rejected at use with SignatureDoesNotMatch, so this has to be right
+    at signing time rather than discovered later.
+    """
+    if bucket == settings.s3_loras_bucket:
+        return boto3.client("s3", region_name=settings.s3_loras_region)
+    return _get_client()
+
+
+def list_bucket(bucket: str) -> list[dict]:
+    """Every object in a bucket: key, size, and etag.
+
+    The etag is the md5 of the content for a single-part upload, which is what these are —
+    so it is usable as a content check. A MULTIPART upload has an etag ending in "-<n>"
+    which is NOT an md5 of the whole object; callers must treat that as "cannot compare
+    content" rather than as a hash, or they will re-download it forever.
+    """
+    client = _client_for_bucket(bucket)
+    out: list[dict] = []
+    token = None
+    while True:
+        params = {"Bucket": bucket}
+        if token:
+            params["ContinuationToken"] = token
+        resp = client.list_objects_v2(**params)
+        for o in resp.get("Contents", []):
+            etag = (o.get("ETag") or "").strip('"')
+            out.append({
+                "name": o["Key"],
+                "size": o["Size"],
+                "etag": etag,
+                "multipart": "-" in etag,
+            })
+        if not resp.get("IsTruncated"):
+            return out
+        token = resp.get("NextContinuationToken")
+
+
 def _get_client():
     global _client
     if _client is None:
@@ -213,7 +255,7 @@ def generate_presigned_url(uri: str, expires: int = 21600) -> str:
     cached redirect that points to an expired signature.
     """
     bucket, key = parse_s3_uri(uri)
-    client = _get_client()
+    client = _client_for_bucket(bucket)
     return client.generate_presigned_url(
         "get_object",
         Params={"Bucket": bucket, "Key": key},

--- a/tests/test_lora_listing.py
+++ b/tests/test_lora_listing.py
@@ -1,0 +1,54 @@
+"""GET /loras — what a worker diffs against.
+
+Workers hold no AWS credentials on purpose, so they cannot list the bucket themselves. This
+endpoint is the half that tells them what exists; they already download through GET /files.
+
+The rule that matters is what a worker COMPARES. Name is not enough: a retrained LoRA
+republished under the same name would never be picked up, and the worker would render old
+weights while the console showed the new character — wrong output rather than a failure.
+"""
+from app.config import settings
+from app.s3 import _client_for_bucket
+
+
+def test_the_loras_bucket_is_signed_in_its_own_region():
+    """ltx-loras is us-east-1 while everything else is us-west-2.
+
+    A presigned URL signed by a client in the wrong region is accepted at signing and
+    rejected at use with SignatureDoesNotMatch, which reads like an auth bug and is not one.
+    """
+    loras = _client_for_bucket(settings.s3_loras_bucket)
+    jobs = _client_for_bucket(settings.s3_jobs_bucket)
+    assert loras.meta.region_name == settings.s3_loras_region == "us-east-1"
+    assert jobs.meta.region_name == settings.aws_region == "us-west-2"
+    assert loras.meta.region_name != jobs.meta.region_name
+
+
+def test_a_multipart_etag_is_flagged_rather_than_trusted():
+    """An etag ending in -<n> is not the md5 of the object.
+
+    Treating it as a hash means the local file never matches and the worker re-downloads it
+    on every sync, forever. Flagged so the caller can fall back to size and say so.
+    """
+    from app.s3 import list_bucket
+    import app.s3 as s3mod
+
+    class FakeClient:
+        meta = type("m", (), {"region_name": "us-east-1"})()
+
+        def list_objects_v2(self, **kw):
+            return {"Contents": [
+                {"Key": "single.safetensors", "Size": 10, "ETag": '"abc123"'},
+                {"Key": "big.safetensors", "Size": 20, "ETag": '"def456-7"'},
+            ], "IsTruncated": False}
+
+    orig = s3mod._client_for_bucket
+    s3mod._client_for_bucket = lambda b: FakeClient()
+    try:
+        out = {o["name"]: o for o in list_bucket("ltx-loras")}
+    finally:
+        s3mod._client_for_bucket = orig
+
+    assert out["single.safetensors"]["multipart"] is False
+    assert out["single.safetensors"]["etag"] == "abc123"      # quotes stripped
+    assert out["big.safetensors"]["multipart"] is True        # -7 suffix

--- a/tests/test_lora_listing.py
+++ b/tests/test_lora_listing.py
@@ -52,3 +52,21 @@ def test_a_multipart_etag_is_flagged_rather_than_trusted():
     assert out["single.safetensors"]["multipart"] is False
     assert out["single.safetensors"]["etag"] == "abc123"      # quotes stripped
     assert out["big.safetensors"]["multipart"] is True        # -7 suffix
+
+
+def test_loras_is_reachable_by_both_the_worker_and_the_console():
+    """The dropdown and the sync list are the same endpoint, so both callers must get in.
+
+    verify_api_key_or_token — the near-miss — accepts X-API-Key or a ?token= QUERY PARAM,
+    which exists for <img src> media loads that cannot set headers. The console sends
+    Authorization: Bearer, so that variant would have 401'd the dropdown while the worker
+    kept working: broken for exactly one of the two callers, and only in the browser.
+    """
+    from app.auth import verify_api_key_or_bearer
+    from app.main import app
+
+    route = next(r for r in app.routes if getattr(r, "path", None) == "/loras")
+    deps = [d.call for d in route.dependant.dependencies]
+    assert verify_api_key_or_bearer in deps, (
+        "GET /loras must accept a console Bearer token as well as a worker API key"
+    )


### PR DESCRIPTION
The API half of console#393.

A worker holds no AWS credentials on purpose, so it cannot list the bucket. It could already *download* a LoRA — `GET /files` 307s to a presigned URL — it just had no way to learn what exists. This is the missing half.

`GET /loras` → `[{name, size, etag, multipart, uri}]`

**Why the etag and not the name.** LoRAs get retrained and republished under the same name. A name check is a false hit: the worker keeps the old weights and renders the previous character while the console shows the new one. That is wrong output rather than a failure, which is the expensive kind.

**Why not size either.** The live bucket makes the case:

| name | size | etag |
|---|---|---|
| k3lly2026_v2.safetensors | 654,444,976 | 6425fb13… |
| k3llydw_v2.safetensors | 654,444,976 | b97b6e8e… |
| pay_v2_e05.safetensors | 654,444,968 | 02cfe907… |

The first two are byte-identical in length and are different people.

`multipart` is reported rather than hidden. A multipart etag is `<md5-of-md5s>-<n>`, not the md5 of the object, so a caller holding one knows its check is weaker instead of assuming it is strong.

**Region.** `ltx-loras` is us-east-1 while everything else is us-west-2, so signing moved to a per-bucket client. A presigned URL signed in the wrong region is accepted at signing and rejected at use with `SignatureDoesNotMatch`, which reads like an auth bug and is not one. Pinned by test.

Verified against the real bucket, not a mock. Daemon half: wanly-gpu-daemon#feat/lora-catalog-sync.

Refs console#393