### PR TITLE
loras: report which shelf a LoRA is on, keep its name bare

### DIFF
--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -125,7 +125,13 @@ async def get_recipe_book(
 
 @router.get("/loras", dependencies=[Depends(verify_api_key_or_bearer)])
 async def list_available_loras():
-    """Every character LoRA in the bucket — the worker's sync list AND the console's dropdown.
+    """Every LoRA in the bucket — the worker's sync list AND the console's dropdowns.
+
+    `kind` comes from the key prefix: `character/` are identity LoRAs (which character this
+    is), `content/` are motion/act LoRAs (what is happening), and they are chosen in
+    different places in the console — a character row versus a recipe. A LoRA sitting at the
+    root reports "unfiled" rather than being hidden, because a file nobody can see is worse
+    than one that is merely mis-shelved.
 
     Two callers, deliberately one endpoint: what the console offers to pick from is exactly
     what a worker can actually obtain. A dropdown listing a LoRA no worker can fetch is a
@@ -150,17 +156,25 @@ async def list_available_loras():
     a worker should fall back to size and say so rather than re-downloading forever.
     """
     objs = await asyncio.to_thread(list_bucket, settings.s3_loras_bucket)
-    return [
-        {
-            "name": o["name"],
+    out = []
+    for o in objs:
+        key = o["name"]
+        if not key.endswith(".safetensors"):
+            continue
+        prefix, _, base = key.rpartition("/")
+        out.append({
+            # `name` is the BASENAME, deliberately. It is what a ComfyUI LoraLoader takes and
+            # what ltx_characters.char_lora stores, and neither should have to learn about
+            # how the bucket is organised. The prefix is filing, not identity.
+            "name": base,
+            "kind": prefix or "unfiled",
+            "key": key,
             "size": o["size"],
             "etag": o["etag"],
             "multipart": o["multipart"],
-            "uri": f"s3://{settings.s3_loras_bucket}/{o['name']}",
-        }
-        for o in objs
-        if o["name"].endswith(".safetensors")
-    ]
+            "uri": f"s3://{settings.s3_loras_bucket}/{key}",
+        })
+    return out
 
 
 @router.post("/ltx/characters", response_model=LtxCharacterResponse, status_code=201)

--- a/tests/test_lora_listing.py
+++ b/tests/test_lora_listing.py
@@ -70,3 +70,39 @@ def test_loras_is_reachable_by_both_the_worker_and_the_console():
     assert verify_api_key_or_bearer in deps, (
         "GET /loras must accept a console Bearer token as well as a worker API key"
     )
+
+
+async def test_a_prefixed_key_reports_its_kind_and_a_bare_name():
+    """`name` must stay the BASENAME even though the key is prefixed.
+
+    A ComfyUI LoraLoader takes `k3lly2026_v2.safetensors` and ltx_characters.char_lora
+    stores the same. Neither knows the bucket has shelves. If `name` carried the prefix,
+    the console would save "character/k3lly2026_v2" into char_lora and every render with
+    that character would fail to find its LoRA.
+    """
+    import app.routes.ltx_recipes as mod
+
+    fake = [
+        {"name": "character/k3lly2026_v2.safetensors", "size": 10, "etag": "a", "multipart": False},
+        {"name": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": 20, "etag": "b", "multipart": False},
+        {"name": "stray.safetensors", "size": 30, "etag": "c", "multipart": False},
+        {"name": "notes.txt", "size": 1, "etag": "d", "multipart": False},
+    ]
+    orig = mod.list_bucket
+    mod.list_bucket = lambda bucket: fake
+    try:
+        out = {o["name"]: o for o in await mod.list_available_loras()}
+    finally:
+        mod.list_bucket = orig
+
+    assert out["k3lly2026_v2.safetensors"]["kind"] == "character"
+    assert out["k3lly2026_v2.safetensors"]["key"] == "character/k3lly2026_v2.safetensors"
+    assert out["k3lly2026_v2.safetensors"]["uri"].endswith("/character/k3lly2026_v2.safetensors")
+    assert out["sfbehind_LTX2_3_v0_1.safetensors"]["kind"] == "content"
+
+    # A LoRA at the root is surfaced as "unfiled", not hidden: a file nobody can see is
+    # worse than one that is merely mis-shelved.
+    assert out["stray.safetensors"]["kind"] == "unfiled"
+
+    # Non-safetensors are not LoRAs.
+    assert "notes.txt" not in out


### PR DESCRIPTION
Groundwork for console#395. The bucket now files LoRAs under `character/` and `content/`.

The two kinds answer different questions and are never interchangeable — **character** is WHO (identity, picked on a character row), **content** is WHAT IS HAPPENING (motion/act, picked on a recipe) — so callers need to tell them apart.

**`name` stays the BASENAME, deliberately.** A ComfyUI `LoraLoader` takes `k3lly2026_v2.safetensors` and `ltx_characters.char_lora` stores the same; neither knows the bucket has shelves. Had `name` carried the prefix, the console would have written `character/k3lly2026_v2` into `char_lora` and every render with that character would have failed to find its LoRA. The prefix is filing, not identity — it travels as `kind`, with the full `key` alongside for fetching.

```json
{"name": "k3lly2026_v2.safetensors", "kind": "character",
 "key": "character/k3lly2026_v2.safetensors", "size": 654444976,
 "etag": "6425fb13...", "multipart": false,
 "uri": "s3://ltx-loras/character/k3lly2026_v2.safetensors"}
```

A LoRA at the bucket root reports `kind: "unfiled"` rather than being filtered out. A file nobody can see is worse than one that is merely mis-shelved.

The move itself was done by server-side copy with ETags verified identical before the originals were deleted, so content is provably unchanged.

Pairs with wanly-gpu-daemon `feat/lora-kind-collisions` and wanly-console `feat/lora-kind-filter`.