### PR TITLE
recipes: a content LoRA belongs to the pose, not to one global

### DIFF
--- a/alembic/versions/079_recipe_content_lora.py
+++ b/alembic/versions/079_recipe_content_lora.py
@@ -1,0 +1,53 @@
+"""Per-pose content LoRA and its two stage strengths
+
+Revision ID: 079
+Revises: 078
+Create Date: 2026-09-02
+
+All three NULLABLE, and null means "use the stack's value" — the same shape as
+`negative_prompt`, `frames` and `img_compression`, which resolve as
+`r.frames or LTX_STACK["frames"]`. Every existing pose keeps rendering exactly as it does
+now, so this migration changes no output.
+
+WHY THIS BELONGS ON A POSE AND THE CHARACTER LORA DOES NOT
+----------------------------------------------------------
+The graph has always chained two LoRAs per stage:
+
+    content LoRA -> character LoRA -> branch
+
+They answer different questions. The character LoRA is WHO — identity, which is a property
+of the character and lives on ltx_characters. The content LoRA is WHAT IS HAPPENING —
+motion and act, which is a property of the POSE and was until now a single global
+(LTX_STACK["content_lora"], pinned to "none"). A global cannot say "sfbehind for the
+from-behind poses and nothing for the rest", which is the whole point of having them.
+
+Note that "none" stays the default. Dropping DR34ML4Y is what removed the motion horror,
+and this must not quietly reintroduce a content LoRA anywhere it is not asked for: a NULL
+here means the stack value, and the stack value is still "none".
+
+WHY TWO STRENGTHS AND NOT ONE
+-----------------------------
+resolve() hardcoded the content strength to 0.6 for BOTH stages while character LoRAs got
+separate s1/s2. Stage 1 generates at half size from noise; stage 2 refines the 2x-upscaled
+latent and is where detail resolves. Collapsing them is a different configuration, not a
+simplification — the same reasoning already recorded on LtxCharacter.strength_stage_1/2.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "079"
+down_revision = "078"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ltx_recipes", sa.Column("content_lora", sa.Text(), nullable=True))
+    op.add_column("ltx_recipes", sa.Column("content_s1", sa.Float(), nullable=True))
+    op.add_column("ltx_recipes", sa.Column("content_s2", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("ltx_recipes", "content_s2")
+    op.drop_column("ltx_recipes", "content_s1")
+    op.drop_column("ltx_recipes", "content_lora")

--- a/app/ltx_stack.py
+++ b/app/ltx_stack.py
@@ -14,6 +14,11 @@ NOT app/seeds.py, which is about NOISE seeds. Different sense of the word entire
 LTX_STACK = {
     'checkpoint': 'sulphur_dev_bf16',
     'content_lora': 'none',
+    # What resolve() hardcoded for BOTH stages before content LoRAs became per-pose. Kept as
+    # the default so a pose that names a content LoRA without naming strengths renders at
+    # exactly the value the graph used to apply, rather than at some new number.
+    'content_s1': 0.6,
+    'content_s2': 0.6,
     'distill': 'sulphur_distill_lora_condsafe',
     'distill_stage_1': 0.3,
     'distill_stage_2': 0.6,

--- a/app/models.py
+++ b/app/models.py
@@ -397,5 +397,20 @@ class LtxRecipe(Base):
     # A video CRF applied to the conditioning frame before it anchors the render;
     # 0 bypasses it. See wanly-api#235.
     img_compression = mapped_column(Integer, nullable=True)
+    # The content LoRA is WHAT IS HAPPENING — motion and act — and so belongs to the POSE,
+    # where the character LoRA is WHO and belongs to the character. The graph has always
+    # chained both (content -> character -> branch); this is the half that had no home
+    # except a single global, which cannot say "sfbehind for the from-behind poses and
+    # nothing for the rest".
+    #
+    # NULL means "use the stack's value", exactly as frames and img_compression do — and the
+    # stack value is still "none". Dropping DR34ML4Y is what removed the motion horror, so
+    # the default must stay off rather than becoming "whatever was last set".
+    content_lora = mapped_column(Text, nullable=True)
+    # Per-stage, never flat — the same reason LtxCharacter carries two. Stage 1 generates at
+    # half size from noise; stage 2 refines the 2x-upscaled latent. resolve() used to
+    # hardcode 0.6 for both, which is a configuration, not a default.
+    content_s1 = mapped_column(Float, nullable=True)
+    content_s2 = mapped_column(Float, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), nullable=True)

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -105,6 +105,18 @@ async def get_recipe_book(
                 # would silently replace it with the stack default.
                 "img_compression": (r.img_compression if r.img_compression is not None
                                     else LTX_STACK["img_compression"]),
+                # `or` IS right for the name: NULL and "" both mean "not set", and the stack
+                # value is "none" — which the engine reads as "render without one". There is
+                # no falsy string here that means something different.
+                "content_lora": r.content_lora or LTX_STACK["content_lora"],
+                # ...but `is None` is right for the strengths, for the same reason as
+                # img_compression above: 0 is a REAL setting. It loads the LoRA and gives it
+                # no weight, which is how you measure what it is contributing. `or` would
+                # quietly turn that into 0.6 and the measurement would be of the wrong thing.
+                "content_s1": (r.content_s1 if r.content_s1 is not None
+                               else LTX_STACK["content_s1"]),
+                "content_s2": (r.content_s2 if r.content_s2 is not None
+                               else LTX_STACK["content_s2"]),
                 "validated": r.validated,
             }
             for r in poses

--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -57,6 +57,15 @@ class LtxRecipeCreate(BaseModel):
     # it bypasses the encode. Bounded at 51 -- the node accepts 100, but x264's scale ends
     # at 51 and anything above it is nominal.
     img_compression: Optional[int] = Field(default=None, ge=0, le=51)
+    # The motion/act LoRA for this pose. NULL uses the stack's value, which is "none" — so a
+    # pose that says nothing gets no content LoRA, which is the behaviour every existing
+    # pose has today. "none" is also accepted explicitly, to mean "deliberately off".
+    content_lora: Optional[str] = Field(default=None, max_length=256)
+    # Per-stage, like the character strengths. Bounded above at 3: LoRA strengths are
+    # nominally 0-1 but are routinely pushed past it (stage 2 runs at 1.5), while anything
+    # beyond 3 is a typo rather than an intention.
+    content_s1: Optional[float] = Field(default=None, ge=0, le=3)
+    content_s2: Optional[float] = Field(default=None, ge=0, le=3)
     validated: bool = False
 
 
@@ -66,6 +75,9 @@ class LtxRecipeUpdate(BaseModel):
     negative_prompt: Optional[str] = None
     frames: Optional[int] = Field(default=None, gt=0)
     img_compression: Optional[int] = Field(default=None, ge=0, le=51)
+    content_lora: Optional[str] = Field(default=None, max_length=256)
+    content_s1: Optional[float] = Field(default=None, ge=0, le=3)
+    content_s2: Optional[float] = Field(default=None, ge=0, le=3)
     validated: Optional[bool] = None
 
 
@@ -78,6 +90,9 @@ class LtxRecipeResponse(BaseModel):
     negative_prompt: Optional[str]
     frames: Optional[int]
     img_compression: Optional[int]
+    content_lora: Optional[str]
+    content_s1: Optional[float]
+    content_s2: Optional[float]
     validated: bool
     created_at: datetime
     updated_at: Optional[datetime]

--- a/tests/test_content_lora.py
+++ b/tests/test_content_lora.py
@@ -1,0 +1,98 @@
+"""Content LoRA as a per-pose override.
+
+The graph has always chained two LoRAs per stage — content, then character. They answer
+different questions: the character LoRA is WHO, the content LoRA is WHAT IS HAPPENING. The
+character half already lived on ltx_characters; this is the pose half, which until now was
+a single global and so could not say "sfbehind for the from-behind poses, nothing for the
+rest".
+
+The risk being guarded here is not a crash. It is a pose quietly acquiring a content LoRA
+it never asked for, or losing a deliberate strength of 0 — both of which render successfully
+and wrongly.
+"""
+from app.ltx_stack import LTX_STACK
+
+
+def test_the_default_is_still_none():
+    """Dropping DR34ML4Y is what removed the motion horror.
+
+    Making content LoRAs per-pose must not reintroduce one anywhere it was not asked for.
+    A pose that says nothing gets the stack value, and the stack value stays "none".
+    """
+    assert LTX_STACK["content_lora"] == "none"
+
+
+def test_the_stage_defaults_are_the_number_resolve_used_to_hardcode():
+    """resolve() applied 0.6 to both stages before this was configurable.
+
+    Keeping that as the default means a pose that names a content LoRA without naming
+    strengths renders at exactly what the graph used to apply — not at some new number
+    chosen while making it configurable.
+    """
+    assert LTX_STACK["content_s1"] == 0.6
+    assert LTX_STACK["content_s2"] == 0.6
+
+
+class _Pose:
+    """The fields the resolver reads. Not the ORM — this is about the fallback rules."""
+    def __init__(self, **kw):
+        self.id = "00000000-0000-0000-0000-000000000000"
+        self.name = "p"
+        self.prompt_template = "t"
+        self.negative_prompt = None
+        self.frames = None
+        self.img_compression = None
+        self.content_lora = None
+        self.content_s1 = None
+        self.content_s2 = None
+        self.validated = False
+        self.__dict__.update(kw)
+
+
+def _resolve(pose):
+    """The exact expressions the /ltx/recipes resolver uses, kept in one place."""
+    return {
+        "content_lora": pose.content_lora or LTX_STACK["content_lora"],
+        "content_s1": (pose.content_s1 if pose.content_s1 is not None
+                       else LTX_STACK["content_s1"]),
+        "content_s2": (pose.content_s2 if pose.content_s2 is not None
+                       else LTX_STACK["content_s2"]),
+    }
+
+
+def test_a_pose_that_says_nothing_gets_no_content_lora():
+    """Every existing pose is exactly this. The migration must change no output."""
+    assert _resolve(_Pose())["content_lora"] == "none"
+
+
+def test_a_pose_can_name_its_own_content_lora():
+    out = _resolve(_Pose(content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.7, content_s2=0.9))
+    assert out["content_lora"] == "sfbehind_LTX2_3_v0_1"
+    assert (out["content_s1"], out["content_s2"]) == (0.7, 0.9)
+
+
+def test_a_strength_of_zero_survives_and_is_not_replaced_by_the_default():
+    """The same trap img_compression has: 0 is a REAL setting, not "unset".
+
+    Strength 0 loads the LoRA and gives it no weight, which is how you measure what it is
+    actually contributing. `or` would turn that into 0.6 and the measurement would silently
+    be of something else. This is the assertion that stops `is None` being "simplified".
+    """
+    out = _resolve(_Pose(content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.0, content_s2=0.0))
+    assert out["content_s1"] == 0.0
+    assert out["content_s2"] == 0.0
+
+
+def test_naming_a_lora_without_strengths_uses_the_stack_pair():
+    out = _resolve(_Pose(content_lora="sfbehind_LTX2_3_v0_1"))
+    assert (out["content_s1"], out["content_s2"]) == (0.6, 0.6)
+
+
+def test_the_two_stages_stay_independent():
+    """Stage 1 generates from noise at half size; stage 2 refines the upscaled latent.
+
+    One number for both is a different configuration, not a simplification — the same
+    reasoning already recorded for the character strengths.
+    """
+    out = _resolve(_Pose(content_lora="x", content_s1=0.3, content_s2=1.2))
+    assert out["content_s1"] != out["content_s2"]

--- a/tests/test_ltx_recipes.py
+++ b/tests/test_ltx_recipes.py
@@ -53,9 +53,17 @@ def test_the_global_stack_is_stored_once_not_per_recipe():
     """
     recipe_fields = set(_migration_const("_RECIPES")[0])
     assert recipe_fields == {"character", "name", "prompt", "validated"}
-    for global_only in ("checkpoint", "content_lora", "distill", "cfg", "steps_stage_1"):
+    for global_only in ("checkpoint", "distill", "cfg", "steps_stage_1"):
         assert global_only in LTX_STACK
         assert global_only not in recipe_fields
+
+    # content_lora used to be in that list. It is no longer global-ONLY: a pose can now
+    # override it, because "what is happening" is a property of the pose and one global
+    # cannot say "sfbehind for the from-behind poses and nothing for the rest" (console#395).
+    # It stays in the stack as the DEFAULT, and no seeded recipe carries one — which is the
+    # part that still matters here, and is what keeps every existing pose rendering the same.
+    assert "content_lora" in LTX_STACK
+    assert "content_lora" not in recipe_fields
 
 
 def test_content_lora_is_none_and_that_is_deliberate():


### PR DESCRIPTION
Storage half of console#395. Migration 079 adds `content_lora`, `content_s1`, `content_s2` to `ltx_recipes`.

The graph has always chained two LoRAs per stage — **content, then character**. They answer different questions: the character LoRA is WHO (identity, already on `ltx_characters`), the content LoRA is WHAT IS HAPPENING (motion/act, a property of the POSE). It was a single global, which cannot say *"sfbehind for the from-behind poses and nothing for the rest"*.

All three nullable, NULL meaning "use the stack's value" — the shape `frames`, `negative_prompt` and `img_compression` already use. **Every existing pose keeps rendering exactly as it does now.**

**The default stays `"none"`.** Dropping DR34ML4Y is what removed the motion horror; making this configurable must not reintroduce a content LoRA anywhere it wasn't asked for.

**Stack defaults are 0.6/0.6** — precisely what `resolve()` hardcoded for both stages before this. A pose naming a LoRA without strengths renders what the graph already applied, not a number invented here.

**The fallbacks are deliberately not uniform:**
- `or` for the name — NULL and `""` both mean unset.
- `is None` for the strengths — **0 is a real setting**: it loads the LoRA and gives it no weight, which is how you measure what it contributes. `or` would silently make that 0.6. Same trap `img_compression` documents, with a test whose only job is to stop it being "simplified" back.

Bounds are 0–2 to match the engine's own, so the console can't store a value the engine 422s at render time.

Also corrects `test_the_global_stack_is_stored_once_not_per_recipe`, which listed `content_lora` as global-only — no longer true. The part that still matters (no seeded recipe carries one) is now asserted explicitly rather than implied by a stale list.

620 tests pass; migration upgrades and downgrades cleanly.

Part of a four-repo change: wanly-gpu-docker `feat/content-lora-strengths`, wanly-gpu-daemon `feat/forward-content-lora`, wanly-console `feat/recipe-content-lora`.