### PR TITLE
fix: content strength bound must not exceed the engine's

### DIFF
--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -61,11 +61,12 @@ class LtxRecipeCreate(BaseModel):
     # pose that says nothing gets no content LoRA, which is the behaviour every existing
     # pose has today. "none" is also accepted explicitly, to mean "deliberately off".
     content_lora: Optional[str] = Field(default=None, max_length=256)
-    # Per-stage, like the character strengths. Bounded above at 3: LoRA strengths are
-    # nominally 0-1 but are routinely pushed past it (stage 2 runs at 1.5), while anything
-    # beyond 3 is a typo rather than an intention.
-    content_s1: Optional[float] = Field(default=None, ge=0, le=3)
-    content_s2: Optional[float] = Field(default=None, ge=0, le=3)
+    # Per-stage, like the character strengths. Bounded at 2.0 to match the ENGINE's own
+    # bound on these fields (engine/app.py Lora and content_s1/s2). A wider bound here would
+    # accept a value the console could store and then fail at render time with a 422, ten
+    # minutes into a claimed segment -- the validation has to be the tighter of the two.
+    content_s1: Optional[float] = Field(default=None, ge=0, le=2)
+    content_s2: Optional[float] = Field(default=None, ge=0, le=2)
     validated: bool = False
 
 
@@ -76,8 +77,8 @@ class LtxRecipeUpdate(BaseModel):
     frames: Optional[int] = Field(default=None, gt=0)
     img_compression: Optional[int] = Field(default=None, ge=0, le=51)
     content_lora: Optional[str] = Field(default=None, max_length=256)
-    content_s1: Optional[float] = Field(default=None, ge=0, le=3)
-    content_s2: Optional[float] = Field(default=None, ge=0, le=3)
+    content_s1: Optional[float] = Field(default=None, ge=0, le=2)
+    content_s2: Optional[float] = Field(default=None, ge=0, le=2)
     validated: Optional[bool] = None
 
 

--- a/tests/test_content_lora.py
+++ b/tests/test_content_lora.py
@@ -96,3 +96,21 @@ def test_the_two_stages_stay_independent():
     """
     out = _resolve(_Pose(content_lora="x", content_s1=0.3, content_s2=1.2))
     assert out["content_s1"] != out["content_s2"]
+
+
+def test_the_api_bound_is_not_looser_than_the_engines():
+    """The engine bounds content_s1/s2 at 2.0 (engine/app.py). This must not exceed it.
+
+    A looser bound here accepts a value the console stores happily and the engine then
+    rejects with a 422 — ten minutes into a claimed segment, not in the dialog. Whichever
+    end is stricter is the real limit, so the two have to agree and this is the one that
+    can drift unnoticed.
+    """
+    from app.schemas.ltx import LtxRecipeCreate, LtxRecipeUpdate
+
+    ENGINE_MAX = 2.0  # engine/app.py: content_s1/content_s2 Field(..., le=2.0)
+    for model in (LtxRecipeCreate, LtxRecipeUpdate):
+        for field in ("content_s1", "content_s2"):
+            meta = model.model_fields[field].metadata
+            le = next(m.le for m in meta if hasattr(m, "le"))
+            assert le <= ENGINE_MAX, f"{model.__name__}.{field} allows {le} > engine {ENGINE_MAX}"


### PR DESCRIPTION
Follow-up to #239.

The schemas shipped allowing `0-3` while the engine bounds `content_s1`/`content_s2` at **2.0**. A looser bound here accepts a value the console stores happily and the engine then rejects with a 422 — ten minutes into a claimed segment rather than in the dialog that set it.

I wrote this change before #239 merged and then left it uncommitted, so the PR went out without it.

Adds a test that reads both numbers, because the API bound is the one that can drift away from the engine unnoticed — nothing else compares them.