### PR TITLE
workers: store the LoRA inventory a worker reports

### DIFF
--- a/alembic/versions/080_worker_lora_inventory.py
+++ b/alembic/versions/080_worker_lora_inventory.py
@@ -1,0 +1,34 @@
+"""What LoRAs a worker holds, as of its last sync
+
+Revision ID: 080
+Revises: 079
+Create Date: 2026-09-02
+
+A worker is the only thing that can see its own LoRA directory, so the console cannot diff
+for it — it has to be told. Reported through the heartbeat and stored here, following
+gpu_stats / sd_scripts / a1111, which are the same shape for the same reason.
+
+NULLABLE: a worker that has not reported yet, or one running an older daemon, has no
+inventory rather than an empty one. Those are different — "nothing here" and "not asked"
+should not render identically on a status page.
+
+The payload is a CACHE of the last sync's verdict, carrying `synced_at`, never a live
+check. Verifying a LoRA means hashing 650 MB; a status page cannot ask for that on every
+heartbeat, and pretending it is live would be a lie with a timestamp missing.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "080"
+down_revision = "079"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("workers", sa.Column("loras", postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "loras")

--- a/app/models.py
+++ b/app/models.py
@@ -292,6 +292,11 @@ class Worker(Base):
     gpu_stats: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
     sd_scripts: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
     a1111: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
+    # What this worker's LoRA directory held as of its last sync — a cached verdict with a
+    # `synced_at`, not a live check: verifying one LoRA means hashing 650 MB, which a
+    # heartbeat cannot do. NULL means "never reported" (or an older daemon), which is not
+    # the same as an empty inventory and should not render the same way. See daemon#165.
+    loras: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
     drain_after_jobs: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -153,6 +153,10 @@ async def heartbeat(
         worker.gpu_stats = body.gpu_stats
     worker.sd_scripts = body.sd_scripts
     worker.a1111 = body.a1111
+    # `is not None`, unlike a1111 above: an older daemon omits this entirely, and writing
+    # None would erase a good inventory every heartbeat during a rolling upgrade.
+    if body.loras is not None:
+        worker.loras = body.loras
     if worker.status == "offline":
         worker.status = "online-idle"
     # If sd-scripts is actively training, worker can't be idle

--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -20,6 +20,9 @@ class WorkerHeartbeat(BaseModel):
     gpu_stats: dict[str, Any] | None = None
     sd_scripts: dict[str, Any] | None = None
     a1111: dict[str, Any] | None = None
+    # Cached LoRA inventory from the worker's last sync. Optional so an older daemon still
+    # heartbeats successfully rather than 422-ing itself out of the pool on upgrade day.
+    loras: dict[str, Any] | None = None
 
 
 class WorkerRename(BaseModel):
@@ -60,6 +63,7 @@ class WorkerResponse(BaseModel):
     gpu_stats: dict[str, Any] | None = None
     sd_scripts: dict[str, Any] | None = None
     a1111: dict[str, Any] | None = None
+    loras: dict[str, Any] | None = None
     drain_after_jobs: int | None = None
     last_heartbeat: datetime
     registered_at: datetime

--- a/tests/test_worker_lora_inventory.py
+++ b/tests/test_worker_lora_inventory.py
@@ -1,0 +1,50 @@
+"""The LoRA inventory a worker reports through its heartbeat (daemon#165).
+
+A worker is the only thing that can see its own LoRA directory, so this is reported, not
+derived. The API's job is to store it without corrupting it — and the one way to corrupt it
+is to overwrite a good inventory with nothing.
+"""
+from app.schemas.workers import WorkerHeartbeat
+
+
+def test_an_older_daemon_still_heartbeats():
+    """`loras` must be optional.
+
+    On upgrade day every worker is running the previous daemon. If this field were required
+    they would all 422 on heartbeat and drop out of the pool — the fleet going offline
+    because the API learned a new field.
+    """
+    hb = WorkerHeartbeat(comfyui_running=True)
+    assert hb.loras is None
+
+
+def test_an_inventory_round_trips_intact():
+    inv = {
+        "synced_at": "2026-09-02T15:00:13+00:00",
+        "dir": "/workspace/models/loras",
+        "items": [
+            {"name": "k3lly2026_v2.safetensors", "kind": "character", "state": "current"},
+            {"name": "sfbehind.safetensors", "kind": "content", "state": "deferred"},
+        ],
+    }
+    hb = WorkerHeartbeat(comfyui_running=True, loras=inv)
+    assert hb.loras == inv
+    assert hb.loras["items"][1]["state"] == "deferred"
+
+
+def test_omitting_loras_must_not_erase_a_stored_one():
+    """The route writes only when the field is present, unlike a1111 which assigns
+    unconditionally.
+
+    An older daemon omits `loras` on every heartbeat. Assigning None would blank a good
+    inventory seconds after a newer worker reported it, and the page would flicker between
+    a real answer and nothing with no explanation.
+    """
+    import inspect
+
+    from app.routes import workers as mod
+
+    src = inspect.getsource(mod.heartbeat)
+    assert "if body.loras is not None:" in src, (
+        "loras must be written conditionally, or an older daemon erases it each heartbeat"
+    )


### PR DESCRIPTION
API half of wanly-gpu-daemon#165. Migration 080 adds `loras` JSONB on `workers`, following `gpu_stats` / `sd_scripts` / `a1111` — same shape, same reason.

**Nullable, and written only when present.** Two separate decisions, both of which matter on upgrade day:

- **Optional in the schema**, so a worker on the previous daemon still heartbeats. Required, and every worker in the fleet would 422 and drop out of the pool — the fleet going offline because the API learned a new field.
- **`is not None` in the route**, unlike `a1111` which assigns unconditionally. An older daemon omits the field on every heartbeat; assigning `None` would blank a good inventory seconds after a newer worker reported it, and the page would flicker between a real answer and nothing with no explanation.

`NULL` means "never reported", which is not the same as an empty inventory and should not render the same way.

The payload is a cached verdict carrying `synced_at`, never a live check: verifying one LoRA means hashing 650 MB, which a heartbeat cannot do, and presenting a cache as live truth is a lie with a timestamp missing.

3 tests, 624 total. Migration upgrades and downgrades cleanly.