### PR TITLE
claims: reclaim a segment whose claim response was lost

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -49,6 +49,10 @@ logger = logging.getLogger(__name__)
 # comfortably past a transient network blip. Renders themselves have no upper bound (60fps jobs
 # run 40+ minutes); a claim is held for as long as its worker keeps heartbeating.
 STALE_HEARTBEAT_MINUTES = 5
+# How long an idle worker may hold a claim it has written no progress against before the
+# claim is treated as orphaned. Two minutes is generous: the daemon posts its first progress
+# line within seconds of receiving a segment. See wanly-api#242.
+ORPHANED_CLAIM_MINUTES = 2
 
 # AR hologram work rides a dedicated carrier segment at this sentinel index (far above any
 # real segment count), so the real video segments and the job's finalized status are never
@@ -227,6 +231,7 @@ async def claim_next_segment(
     now = datetime.now(timezone.utc)
     age_cutoff = now - timedelta(minutes=30)
     heartbeat_cutoff = now - timedelta(minutes=STALE_HEARTBEAT_MINUTES)
+    orphan_cutoff = now - timedelta(minutes=ORPHANED_CLAIM_MINUTES)
 
     stale_result = await db.execute(
         select(Segment, Worker.last_heartbeat)
@@ -239,12 +244,52 @@ async def claim_next_segment(
                 # last_heartbeat is NOT NULL on the workers table, so "no heartbeat to
                 # consult" is exactly "the worker row is gone" (outerjoin came up empty).
                 and_(Segment.claimed_at < age_cutoff, Worker.id.is_(None)),
+                # A claim whose RESPONSE was lost. GET /segments/next mutates: the segment is
+                # marked and assigned before the answer is sent, so a transport failure on the
+                # way back leaves it owned by a worker that never learned of it. That worker
+                # stays healthy and heartbeating, so neither rule above ever fires and the
+                # segment is stuck forever with the queue stopped beside an idle GPU
+                # (wanly-api#242, hit in production 2026-09-03).
+                #
+                # THREE conditions, all required, because reclaiming from a LIVE worker is
+                # how two GPUs once converged on one segment (see the warning above):
+                #
+                #   1. the worker says it is idle. The daemon sets online-busy immediately on
+                #      receiving a claim, BEFORE rendering — so a worker that got the answer
+                #      is never idle here.
+                #   2. no progress has been written. A running segment logs "[1/6] ..." within
+                #      seconds. This is evidence from the SEGMENT, and it is what makes the
+                #      rule safe: the daemon's status push can fail, and the heartbeat only
+                #      re-pushes on a CHANGE, so status alone can lie. An empty progress log
+                #      cannot.
+                #   3. it has sat like that past the grace period, which is far longer than
+                #      the round trip between claiming and the first progress line.
+                and_(
+                    Worker.status == "online-idle",
+                    # Heartbeating RIGHT NOW. This is what rules out a network partition:
+                    # the worry with the two checks below is a worker that is really
+                    # rendering but whose status push and progress writes both failed. If it
+                    # is beating, the API is reachable from that worker, so those writes had
+                    # no reason to fail — and a worker that has genuinely gone quiet is the
+                    # heartbeat rule's business, not this one's.
+                    Worker.last_heartbeat >= heartbeat_cutoff,
+                    Segment.claimed_at < orphan_cutoff,
+                    or_(Segment.progress_log.is_(None), Segment.progress_log == ""),
+                ),
             ),
         )
     )
     for stale, last_heartbeat in stale_result.all():
-        reason = ("worker heartbeat stale" if last_heartbeat is not None
-                  else "worker row gone and claimed over 30m ago")
+        # Naming which rule fired matters: "the worker died" and "the worker is fine but
+        # never received the answer" have completely different fixes, and the log line is
+        # where that is decided at 2am.
+        if last_heartbeat is None:
+            reason = "worker row gone and claimed over 30m ago"
+        elif last_heartbeat < heartbeat_cutoff:
+            reason = "worker heartbeat stale"
+        else:
+            reason = ("claim response lost — worker is idle with no progress logged "
+                      "(wanly-api#242)")
         logger.warning(
             "Reclaiming segment %s (status=%s, claimed_at=%s, worker=%s, last_heartbeat=%s): %s",
             stale.id, stale.status, stale.claimed_at, stale.worker_name, last_heartbeat, reason,

--- a/tests/test_claim_endpoint.py
+++ b/tests/test_claim_endpoint.py
@@ -321,10 +321,18 @@ class TestStaleReclaim:
         which from the outside looked like 'only one GPU ever works the queue'."""
         other = await _worker(db)  # heartbeating right now, mid-render
         other_id = other.id
+        # A worker that is really rendering reports online-busy — the daemon sets it on
+        # receiving the claim, before it starts — and its segment has progress written
+        # within seconds. The fixture used to leave both at their defaults (idle, empty),
+        # which is indistinguishable from a claim whose response was lost, and is the exact
+        # state wanly-api#242 reclaims. Modelled faithfully here so this guard tests the
+        # incident it was written for rather than passing by omission.
+        other.status = "online-busy"
         job = await _job(db, status=JobStatus.PROCESSING)
         held = await _segment(db, job, 0, status=SegmentStatus.PROCESSING)
         held.claimed_at = datetime.now(timezone.utc) - timedelta(minutes=45)
         held.worker_id = other_id
+        held.progress_log = "[4/6] ltx-engine: Processing"
         await db.flush()
 
         body = (await _claim(db)).json()
@@ -333,6 +341,73 @@ class TestStaleReclaim:
         await db.refresh(held)
         assert held.worker_id == other_id
         assert held.status == SegmentStatus.PROCESSING
+
+    async def test_a_claim_whose_response_was_lost_comes_back(self, db):
+        """wanly-api#242. GET /segments/next mutates: the segment is marked and assigned
+        before the answer is sent, so a transport failure on the way back leaves it owned by
+        a worker that never learned of it.
+
+        That worker stays healthy and heartbeating, so neither dead-worker rule fires. Before
+        this, the segment sat PROCESSING forever and the queue stopped beside an idle GPU.
+        """
+        idle = await _worker(db)                     # alive, beating, and genuinely idle
+        idle.status = "online-idle"
+        job = await _job(db, status=JobStatus.PROCESSING)
+        orphan = await _segment(db, job, 0, status=SegmentStatus.PROCESSING)
+        orphan.claimed_at = datetime.now(timezone.utc) - timedelta(minutes=3)
+        orphan.worker_id = idle.id
+        orphan.progress_log = None                   # it never started: nothing was written
+        await db.flush()
+
+        body = (await _claim(db)).json()
+
+        assert body is not None and body["id"] == str(orphan.id)
+        await db.refresh(orphan)
+        assert orphan.worker_id == WORKER_ID
+
+    async def test_an_idle_worker_that_HAS_written_progress_keeps_its_claim(self, db):
+        """Progress is proof the worker received the segment and is working on it.
+
+        The daemon's status push can fail and the heartbeat only re-pushes on a CHANGE, so
+        "idle" can be a lie. An empty progress log cannot be, which is why the rule needs
+        both — and why a segment with progress is never taken, whatever the status says.
+        """
+        worker = await _worker(db)
+        worker.status = "online-idle"                # status is wrong, but...
+        worker_id = worker.id                        # captured: the commit expires the object
+        job = await _job(db, status=JobStatus.PROCESSING)
+        held = await _segment(db, job, 0, status=SegmentStatus.PROCESSING)
+        held.claimed_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+        held.worker_id = worker.id
+        held.progress_log = "[1/6] Downloading start image..."   # ...it is demonstrably working
+        await db.flush()
+
+        body = (await _claim(db)).json()
+
+        assert body is None
+        await db.refresh(held)
+        assert held.worker_id == worker_id
+
+    async def test_a_fresh_claim_is_not_reclaimed_before_the_grace_period(self, db):
+        """A worker that has just claimed has not had time to report busy or write progress.
+
+        Too short a window and the reclaim races the very worker it belongs to, which is how
+        two workers end up on one segment.
+        """
+        worker = await _worker(db)
+        worker.status = "online-idle"
+        worker_id = worker.id                        # captured: the commit expires the object
+        job = await _job(db, status=JobStatus.PROCESSING)
+        fresh = await _segment(db, job, 0, status=SegmentStatus.PROCESSING)
+        fresh.claimed_at = datetime.now(timezone.utc) - timedelta(seconds=20)
+        fresh.worker_id = worker.id
+        await db.flush()
+
+        body = (await _claim(db)).json()
+
+        assert body is None
+        await db.refresh(fresh)
+        assert fresh.worker_id == worker_id
 
     async def test_a_worker_that_stopped_heartbeating_loses_its_claim(self, db):
         # The heartbeat rule needs no 30-minute wait: ~10 missed beats is already proof of death.

--- a/tests/test_orphaned_claim.py
+++ b/tests/test_orphaned_claim.py
@@ -1,0 +1,75 @@
+"""Reclaiming a claim whose RESPONSE was lost (wanly-api#242).
+
+GET /segments/next mutates: the segment is marked and assigned before the answer is sent,
+so a transport failure on the way back leaves it owned by a worker that never learned of it.
+That worker stays healthy and heartbeating, so the dead-worker rules never fire and the
+segment sits forever with the queue stopped beside an idle GPU.
+
+The danger in fixing this is the opposite failure, which has already happened once: on
+2026-08-15 an age rule that applied to a LIVE worker stole renders mid-flight and two GPUs
+converged on the same segment. Every test here is about not doing that again.
+"""
+import inspect
+
+from app.routes import segments as mod
+
+
+def test_the_rule_requires_all_three_conditions():
+    """Idle status alone is not enough, and neither is age.
+
+    The daemon's status push can fail, and the heartbeat only re-pushes on a CHANGE — so a
+    worker can be rendering while marked idle. The empty progress log is the evidence that
+    cannot lie, and it must be part of the conjunction.
+    """
+    src = inspect.getsource(mod.claim_next_segment)
+    assert 'Worker.status == "online-idle"' in src
+    assert "Segment.claimed_at < orphan_cutoff" in src
+    assert "Segment.progress_log.is_(None)" in src
+
+
+def test_the_grace_period_is_far_longer_than_the_first_progress_line():
+    """The daemon logs "[1/6] Downloading start image..." within seconds of claiming.
+
+    The window only has to outlast that round trip. Too short and a slow first write looks
+    like an orphan; too long and the queue stalls for no reason.
+    """
+    assert mod.ORPHANED_CLAIM_MINUTES >= 2
+    assert mod.ORPHANED_CLAIM_MINUTES < mod.STALE_HEARTBEAT_MINUTES
+
+
+def test_a_busy_worker_is_never_a_candidate():
+    """The 2026-08-15 incident in one assertion.
+
+    A worker that received its claim reports online-busy BEFORE it starts rendering, so it
+    can never match. If this ever widens to include busy workers, long renders get stolen
+    mid-flight and two GPUs converge on one segment.
+    """
+    src = inspect.getsource(mod.claim_next_segment)
+    assert 'Worker.status == "online-idle"' in src
+    assert 'Worker.status != "online-busy"' not in src, (
+        "must match idle explicitly, not exclude busy — draining and offline workers "
+        "would otherwise become candidates too"
+    )
+
+
+def test_a_segment_with_progress_is_never_reclaimed_by_this_rule():
+    """Progress is proof the worker got the segment and is working on it.
+
+    Reclaiming one that has written progress is the mid-flight theft this must not do.
+    """
+    src = inspect.getsource(mod.claim_next_segment)
+    # Anchor on the condition itself, not on a variable name that also appears where it is
+    # declared — the three checks must live in ONE and_(), or they are not a conjunction.
+    i = src.index('Worker.status == "online-idle"')
+    clause = src[i:i + 900]   # the rule carries explanatory comments between conditions
+    assert "progress_log" in clause, "the progress check must sit in the same and_() as the idle check"
+    assert "orphan_cutoff" in clause, "the age check must sit in the same and_() too"
+
+
+def test_the_log_says_which_rule_fired():
+    """"The worker died" and "the worker is fine but never got the answer" have completely
+    different fixes. Collapsing them into one message costs the next diagnosis."""
+    src = inspect.getsource(mod.claim_next_segment)
+    assert "claim response lost" in src
+    assert "worker heartbeat stale" in src
+    assert "worker row gone" in src


### PR DESCRIPTION
Fixes #242, hit in production tonight: a job sat unclaimed with a healthy worker and an idle GPU.

`GET /segments/next` **mutates** — the segment is marked and assigned before the answer is sent. A transport failure on the way back leaves it owned by a worker that never learned of it. That worker keeps heartbeating, so neither dead-worker rule fires, and the segment sits `PROCESSING` forever.

### Four conditions, all required

Reclaiming from a **live** worker is how two GPUs once converged on one segment (2026-08-15), so each condition is carrying weight:

| # | condition | why |
|---|---|---|
| 1 | worker is `online-idle` | the daemon sets `online-busy` on *receiving* a claim, before rendering — so a worker that got the answer is never idle |
| 2 | worker is heartbeating **now** | rules out a network partition: if it's beating, the API is reachable from that worker, so its status/progress writes had no reason to fail |
| 3 | segment has **no progress logged** | evidence from the *segment*. The daemon's status push can fail and the heartbeat only re-pushes on a **change**, so status alone can lie. An empty progress log cannot |
| 4 | claimed over 2 minutes ago | far longer than the round trip to the first `[1/6]` line, so the reclaim cannot race the worker it belongs to |

Condition 3 is the one that makes this safe. Without it, a worker whose status push failed while it was genuinely rendering would have its work stolen — the 2026-08-15 incident again.

The log now names **which** rule fired. "The worker died" and "the worker is fine but never got the answer" have different fixes.

### A test that was passing by omission

`test_a_live_workers_long_render_is_not_stolen` — the 2026-08-15 guard — **failed** against this change, and it was right to. Its fixture left the worker at the default status (`online-idle`) and the segment's progress log empty, which is not a mid-render worker at all: it is exactly the orphan state this reclaims.

I modelled it faithfully instead of loosening the rule — `online-busy`, progress written — so the guard now tests the incident it was written for rather than passing because the fixture was incomplete.

Three behavioural tests added beside it: an orphan comes back; an idle worker that *has* written progress keeps its claim; a fresh claim is untouched inside the grace period. 632 pass.

### Residual risk, stated

If a worker's status push **and** every progress write fail while it renders, and it still heartbeats, its claim could be taken. That needs selective failure of two write paths while a third succeeds. The alternative is today's behaviour, where the segment is stuck forever — which is what happened tonight.