### PR TITLE
captions: <SCENE> fills a pose's static half from its actual start frame

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,28 @@ class Settings(BaseSettings):
     aws_region: str = "us-west-2"
     api_key: str = ""
     civitai_api_token: str = ""
+    # JoyCaption, for the <SCENE> placeholder (console#405). Runs on the 2070 rather than a
+    # render box: the 3090 sits at ~23 of 24 GB while rendering LTX, and loading a vision
+    # model beside that OOMs a segment ten minutes in.
+    joycaption_url: str = "http://2070.zero:11434"
+    joycaption_model: str = "joycaption:beta-one"
+    # Deliberately tiny. sd.service (Automatic1111) shares that GPU and spikes several GB
+    # generating SDXL, and a resident 5.5 GB JoyCaption would starve it. The two are never
+    # meant to run at once, so the model should hold the card only while it is actually
+    # working.
+    #
+    # This is cheap because a cold start is cheap. MEASURED on the 2070:
+    #
+    #   cold (not resident)   4.5 s total   2.9 s load, 0.5 s prompt, 0.9 s generate
+    #   warm (resident)       1.2 s total   0.2 s load, 1.0 s generate
+    #
+    # So releasing VRAM after every caption costs ~2.9 s on the next one. 5s still coalesces
+    # a burst of images captioned back to back, while giving SD the card back essentially as
+    # soon as captioning stops.
+    joycaption_keep_alive: str = "5s"
+    # Generous next to a 4.5 s cold caption. It is here to stop a wedged or unreachable
+    # captioner holding a request open, not to bound normal work.
+    joycaption_timeout_s: int = 60
     cors_origins: str = ""
     login_rate_limit: str = "5/minute"
     heartbeat_offline_seconds: int = 120

--- a/app/joycaption.py
+++ b/app/joycaption.py
@@ -1,0 +1,151 @@
+"""JoyCaption — describing a start frame so a prompt can stop contradicting it.
+
+WHY THIS EXISTS (console#405)
+    An LTX prompt is two halves: what the scene IS, then what HAPPENS. Recipes are
+    character- and start-frame-agnostic by design, so their static half is a generic guess
+    about a frame they have never seen. A validated pose reads "a woman kneeling in front of
+    a nude man" while the actual start image is a clothed woman sitting on a sofa.
+
+    The vision model owns the static half. The recipe keeps the arc.
+
+WHY AN UNCENSORED MODEL
+    A stock captioner refuses this material or sanitises it into uselessness. Measured on a
+    real continuation frame, JoyCaption returns "performs oral sex on a man standing by a
+    pool ... she looks up at him" — the pose, the gaze and the act, which is exactly what a
+    prompt needs and exactly what a general-purpose model will not say.
+
+WHERE IT RUNS
+    The 2070, not a render box. The 3090 sits at ~23 of 24 GB while rendering. The 2070 also
+    hosts Automatic1111, which is why keep_alive is short: a resident 5.5 GB model would
+    starve image generation.
+"""
+import base64
+import hashlib
+import logging
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class CaptionError(RuntimeError):
+    """The captioner could not be reached, or refused. Never fatal to a render."""
+
+
+# The verbosity presets exposed in Settings.
+#
+# Every one of them ends with the same two suppressions, and they are not optional: the
+# model will otherwise describe overlay text, picture frames and camera angles. Measured on
+# a real frame it reported cursive text in the corner and confabulated it into a person's
+# name. That is true of the image and garbage in a render prompt.
+#
+# GAZE AND EXPRESSION ARE REQUESTED EXPLICITLY in every preset but `raw`. A plain "describe
+# this image" omits them, and "she is looking at the viewer" is load-bearing in these
+# prompts — it is the difference between a subject engaging the camera and one staring past
+# it. That single addition is what separated a usable caption from a nearly-usable one.
+_SUPPRESS = (
+    " State only what is visible. Do not mention the photograph, the camera, image quality, "
+    "any text or writing in the image, or the picture frame."
+)
+
+CAPTION_STYLES: dict[str, str] = {
+    # ~25 words. For recipes whose arc is already long, where the scene half should not
+    # compete with it.
+    "terse": (
+        "In under 25 words and starting directly with the subject, describe who is in this "
+        "image, what they are wearing, their pose, and where they are looking." + _SUPPRESS
+    ),
+    # ~40 words. The default, and the one that tested best.
+    "standard": (
+        "In under 40 words and starting directly with the subject, describe: who is in this "
+        "image and what they look like, what they are wearing, their pose and where their "
+        "hands are, their expression and where they are looking, and the setting."
+        + _SUPPRESS
+    ),
+    # ~80 words. More of the scene, at the cost of weighing more heavily against the arc.
+    "rich": (
+        "In under 80 words and starting directly with the subject, describe in detail: who "
+        "is in this image and what they look like, their hair, what they are wearing, their "
+        "pose and the position of their hands and body, their expression and where they are "
+        "looking, and the setting and lighting." + _SUPPRESS
+    ),
+    # JoyCaption's own voice, unshaped. Longest and most natural, but it WILL describe
+    # overlay text and framing, because nothing here tells it not to.
+    "raw": "Write a descriptive caption for this image.",
+}
+DEFAULT_STYLE = "standard"
+
+
+def instruction_for(style: str, custom: str = "") -> str:
+    """The instruction to send. A non-empty custom instruction always wins.
+
+    Custom is the escape hatch: the presets encode what tested well, but the person tuning
+    prompts knows their material better than a default does.
+    """
+    if custom and custom.strip():
+        return custom.strip()
+    return CAPTION_STYLES.get(style, CAPTION_STYLES[DEFAULT_STYLE])
+
+
+def image_key(image_bytes: bytes, instruction: str) -> str:
+    """Cache key: the image AND the instruction that will be applied to it.
+
+    Keyed on CONTENT, not path — the same frame is referenced from several places, and a
+    retry must reproduce the caption its first attempt used. Without that, retrying a failed
+    segment re-captions, gets different words, and renders something different from what
+    failed, which quietly breaks the meaning of "retry".
+
+    The instruction is in the key because changing the style should produce a new caption
+    rather than serve the old one.
+    """
+    h = hashlib.sha256()
+    h.update(image_bytes)
+    h.update(b"\x00")
+    h.update(instruction.encode())
+    return h.hexdigest()
+
+
+async def describe(image_bytes: bytes, instruction: str) -> str:
+    """Caption one image. Raises CaptionError; callers must treat that as non-fatal."""
+    payload = {
+        "model": settings.joycaption_model,
+        "prompt": instruction,
+        "images": [base64.b64encode(image_bytes).decode()],
+        "stream": False,
+        "keep_alive": settings.joycaption_keep_alive,
+    }
+    url = f"{settings.joycaption_url.rstrip('/')}/api/generate"
+    try:
+        async with httpx.AsyncClient(timeout=settings.joycaption_timeout_s) as client:
+            resp = await client.post(url, json=payload)
+    except httpx.HTTPError as e:
+        raise CaptionError(f"captioner unreachable at {settings.joycaption_url}: {e}") from e
+    if resp.status_code != 200:
+        raise CaptionError(f"captioner returned {resp.status_code}: {resp.text[:200]}")
+
+    text = (resp.json().get("response") or "").strip()
+    if not text:
+        raise CaptionError("captioner returned an empty caption")
+    return _tidy(text)
+
+
+def _tidy(text: str) -> str:
+    """Make a caption safe to splice into the middle of a prompt.
+
+    The caption lands between a trigger and an arc:
+
+        <TRIGGER>, <SCENE>, she grips his penis with one hand...
+
+    A trailing full stop would end the sentence mid-prompt, and a leading "The image shows"
+    reads as instruction to render an image of an image. Newlines would break the single
+    prompt line the encoder receives.
+    """
+    text = " ".join(text.split())
+    for lead in ("This image shows ", "The image shows ", "This image depicts ",
+                 "The image depicts ", "This is an image of ", "The photo shows "):
+        if text.lower().startswith(lead.lower()):
+            text = text[len(lead):]
+            break
+    return text.rstrip(" .")

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
 from app.reservation_monitor import reservation_monitor
 from app.limiter import limiter
-from app.routes import app_settings, auth, favorites, files, images, jobs, ltx_recipes, runpod, segments, stats, tags, videos, wildcards, workers
+from app.routes import app_settings, auth, captions, favorites, files, images, jobs, ltx_recipes, runpod, segments, stats, tags, videos, wildcards, workers
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +64,7 @@ app.include_router(images.router)
 app.include_router(jobs.router)
 app.include_router(segments.router)
 app.include_router(files.router)
+app.include_router(captions.router)
 app.include_router(ltx_recipes.router)
 app.include_router(tags.router)
 app.include_router(videos.router)

--- a/app/routes/app_settings.py
+++ b/app/routes/app_settings.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends
@@ -6,14 +7,23 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user
 from app.database import get_db
+from app.joycaption import CAPTION_STYLES, DEFAULT_STYLE
 from app.models import AppSetting, User
 from app.schemas.app_settings import AppSettingsResponse, AppSettingsUpdate
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 # Defaults if a key is missing from the DB
 _DEFAULTS = {
     "negative_prompt": "",
+    # See app/joycaption.py for what each style asks for. "standard" is the one that tested
+    # best on real frames: ~40 words, and it explicitly requests gaze and expression, which
+    # a plain "describe this image" omits and which carry real weight in an LTX prompt.
+    "caption_style": DEFAULT_STYLE,
+    # Empty means "use the style". A non-empty value wins over it.
+    "caption_instruction": "",
 }
 
 
@@ -24,8 +34,16 @@ async def _get_all_settings(db: AsyncSession) -> dict[str, str]:
 
 
 def _to_response(settings: dict[str, str]) -> AppSettingsResponse:
+    style = settings.get("caption_style") or DEFAULT_STYLE
+    if style not in CAPTION_STYLES:
+        # A style written directly into the table, or one removed in a later release. Fall
+        # back rather than 500 the whole settings page over one bad row.
+        logger.warning("unknown caption_style %r in app_settings; using %r", style, DEFAULT_STYLE)
+        style = DEFAULT_STYLE
     return AppSettingsResponse(
         negative_prompt=settings["negative_prompt"],
+        caption_style=style,
+        caption_instruction=settings.get("caption_instruction", ""),
     )
 
 

--- a/app/routes/captions.py
+++ b/app/routes/captions.py
@@ -1,0 +1,71 @@
+"""Describe an image, so a prompt can stop contradicting its own start frame.
+
+console#405. The console calls this for segment 0, where a person is present to read the
+caption before it is used; the API resolves <SCENE> itself for continuations, where nobody
+is. Same placeholder, same meaning, two resolution points — exactly the convention
+_resolve_trigger already documents for <TRIGGER>.
+"""
+import asyncio
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import s3
+from app.auth import get_current_user
+from app.database import get_db
+from app.joycaption import CaptionError, describe, instruction_for
+from app.models import User
+from app.routes.app_settings import _get_all_settings
+from app.schemas.captions import CaptionRequest, CaptionResponse
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+async def caption_image_bytes(db: AsyncSession, image: bytes,
+                              style: str | None = None,
+                              instruction: str | None = None) -> tuple[str, str]:
+    """Caption bytes using the configured style. Returns (caption, instruction_used).
+
+    The instruction is returned as well as the caption so a segment can record HOW it was
+    described, not just what was said. A caption written under "terse" and one written under
+    "rich" are different artefacts, and a rated panel should be able to tell them apart.
+    """
+    if instruction is None:
+        cfg = await _get_all_settings(db)
+        instruction = instruction_for(style or cfg.get("caption_style", ""),
+                                      cfg.get("caption_instruction", ""))
+    return await describe(image, instruction), instruction
+
+
+@router.post("/captions/describe", response_model=CaptionResponse)
+async def describe_image(
+    body: CaptionRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Caption one image for the console's preview.
+
+    This is the "a human is present" half of console#405: the console shows the caption,
+    the person edits or accepts it, and the RESOLVED text is sent with the segment. Nothing
+    is stored here — a preview the user rejects must leave no trace.
+    """
+    try:
+        # boto3 is synchronous; off the event loop so one slow fetch does not stall the API.
+        image = await asyncio.to_thread(s3.download_bytes, body.image_uri)
+    except Exception as e:
+        raise HTTPException(status_code=404,
+                            detail=f"could not read {body.image_uri}: {e}") from e
+
+    try:
+        caption, instruction = await caption_image_bytes(
+            db, image, style=body.style, instruction=body.instruction)
+    except CaptionError as e:
+        # 503 rather than 500: the captioner being down is a temporary condition on another
+        # host, not a bug in this request. The console can say "try again" and mean it.
+        logger.warning("caption failed for %s: %s", body.image_uri, e)
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+    return CaptionResponse(caption=caption, instruction=instruction,
+                           words=len(caption.split()))

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import asyncio
 import logging
 import math
 import random
@@ -17,7 +18,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.auth import get_current_user, verify_api_key, verify_api_key_or_bearer
+from app import s3
 from app.database import get_db
+from app.routes.captions import caption_image_bytes
 from app.seeds import new_seed
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.models import AppSetting, Job, LtxCharacter, Segment, User, Video, Wildcard, Worker
@@ -68,6 +71,66 @@ SMASHCUT_CARRIER_INDEX = 2000
 _CPU_REPROCESS_TYPES = ("ar_hologram", "smashcut_concat")
 
 router = APIRouter()
+
+
+SCENE_PLACEHOLDER = "<SCENE>"
+
+
+async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None) -> str:
+    """Fill a pose's <SCENE> with a description of the frame this segment starts from.
+
+    Recipes are start-frame-agnostic by design — one pose serves every character — so their
+    static half is a generic guess about an image they have never seen. A validated pose
+    reads "a woman kneeling in front of a nude man" while the actual start frame is a
+    clothed woman sitting on a sofa. <SCENE> lets the pose defer that half to the frame.
+
+    ORDER: this runs AFTER _resolve_wildcards, the opposite of _resolve_trigger, and the
+    reason is the caption text. A caption is model output that may contain bracketed tokens,
+    and running the wildcard resolver over it afterwards would expand them. Going last means
+    the caption is never re-scanned.
+
+    That ordering removes the protection _resolve_trigger gets for free — a wildcard named
+    SCENE would be substituted before we ever look — so SCENE is RESERVED in the wildcard
+    routes. For <TRIGGER> the reservation is belt-and-braces; here it is the only guard.
+
+    FAILURE INVERTS FROM <TRIGGER>. _resolve_trigger deliberately leaves the literal
+    placeholder when it cannot resolve, because silently dropping the token that anchors the
+    character LoRA is worse and harder to notice. Here the reasoning flips: a literal
+    "<SCENE>" is garbage tokens fed to the text encoder, while dropping it leaves a valid if
+    generic prompt. So it is dropped, and the drop is logged.
+    """
+    if SCENE_PLACEHOLDER not in prompt:
+        return prompt
+
+    if not image_uri:
+        # A continuation whose previous frame does not exist yet, or a text-to-video segment.
+        # Nothing to describe.
+        logger.info("Dropping %s: no start image to describe", SCENE_PLACEHOLDER)
+        return _drop_scene(prompt)
+
+    try:
+        image = await asyncio.to_thread(s3.download_bytes, image_uri)
+        caption, _ = await caption_image_bytes(db, image)
+    except Exception as e:
+        # Never fatal. A captioner that is down must not stop a render — the pose still has
+        # its arc, and a generic scene is what every pose used before this existed.
+        logger.warning("Dropping %s: could not describe %s (%s)",
+                       SCENE_PLACEHOLDER, image_uri, e)
+        return _drop_scene(prompt)
+
+    logger.info("Resolved %s from %s: %r", SCENE_PLACEHOLDER, image_uri, caption[:80])
+    return prompt.replace(SCENE_PLACEHOLDER, caption)
+
+
+def _drop_scene(prompt: str) -> str:
+    """Remove the placeholder and the comma-space that would be left dangling beside it.
+
+    "<TRIGGER>, <SCENE>, she grips..." must not become "trigger, , she grips...", which
+    reaches the encoder as a stray empty clause.
+    """
+    out = prompt.replace(f", {SCENE_PLACEHOLDER},", ",")
+    out = out.replace(f"{SCENE_PLACEHOLDER}, ", "").replace(f", {SCENE_PLACEHOLDER}", "")
+    return " ".join(out.replace(SCENE_PLACEHOLDER, "").split())
 
 
 async def _resolve_trigger(db: AsyncSession, prompt: str, ltx_recipe: dict | None) -> str:
@@ -182,6 +245,11 @@ async def add_segment(
 
     prompt = await _resolve_trigger(db, body.prompt, body.ltx_recipe)
     resolved_prompt, prompt_template = await _resolve_wildcards(db, prompt)
+    # After wildcards, deliberately — see _resolve_scene. The console resolves this itself
+    # for segment 0, where a person can review the caption first; this catches a prompt that
+    # arrives still carrying the placeholder, which is every continuation and any caller
+    # that is not the console. Same convention as <TRIGGER>.
+    resolved_prompt = await _resolve_scene(db, resolved_prompt, body.start_image)
 
     # Inherit negative_prompt from prior segment if not explicitly set.
     # Segments are eagerly loaded and ordered by index via the relationship,

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -76,7 +76,8 @@ router = APIRouter()
 SCENE_PLACEHOLDER = "<SCENE>"
 
 
-async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None) -> str:
+async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None,
+                         *, final: bool = False) -> str:
     """Fill a pose's <SCENE> with a description of the frame this segment starts from.
 
     Recipes are start-frame-agnostic by design — one pose serves every character — so their
@@ -98,15 +99,33 @@ async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None) -
     character LoRA is worse and harder to notice. Here the reasoning flips: a literal
     "<SCENE>" is garbage tokens fed to the text encoder, while dropping it leaves a valid if
     generic prompt. So it is dropped, and the drop is logged.
+
+    `final` is which of the two resolution points this is. At SUBMIT (final=False) a missing
+    image means "not yet" — a continuation is routinely created before the segment it
+    follows has rendered — so the placeholder survives for the claim to resolve. At CLAIM
+    (final=True) the start image is as known as it will ever be, so an unresolved
+    placeholder is dropped rather than shipped to the encoder.
     """
     if SCENE_PLACEHOLDER not in prompt:
         return prompt
 
     if not image_uri:
-        # A continuation whose previous frame does not exist yet, or a text-to-video segment.
-        # Nothing to describe.
-        logger.info("Dropping %s: no start image to describe", SCENE_PLACEHOLDER)
-        return _drop_scene(prompt)
+        if final:
+            # Last responsible moment and still no image: a text-to-video segment, or a
+            # continuation whose predecessor produced no last frame. Nothing to describe.
+            logger.info("Dropping %s: no start image to describe", SCENE_PLACEHOLDER)
+            return _drop_scene(prompt)
+        # A continuation submitted before its predecessor has rendered. The frame it will
+        # start from does not exist yet, so the placeholder is LEFT IN PLACE and resolved at
+        # claim time, when the previous segment's last frame is known.
+        #
+        # Dropping it here instead would be unrecoverable: the placeholder would be gone
+        # from the stored prompt and no later step could tell that a description was ever
+        # wanted. Continuations are the case this feature helps most — they condition on a
+        # generated frame nobody has ever described — so losing them silently is the worst
+        # available outcome.
+        logger.info("Deferring %s: start image not known until claim", SCENE_PLACEHOLDER)
+        return prompt
 
     try:
         image = await asyncio.to_thread(s3.download_bytes, image_uri)
@@ -473,6 +492,23 @@ async def claim_next_segment(
     else:
         neg_setting = await db.get(AppSetting, "negative_prompt")
         negative_prompt = neg_setting.value if neg_setting else None
+
+    # <SCENE> for a continuation. The start frame is a GENERATED image that exists only now
+    # — the previous segment produced it — so this is the first moment it can be described,
+    # and it is the case the feature exists for: nobody has ever written a description of
+    # that frame, and the recipe's own scene wording was authored before it existed.
+    #
+    # On the claim path deliberately, despite this being polled. A caption is 4.5s cold and
+    # 1.2s warm (measured), against a segment that then renders for ten minutes, and it only
+    # runs for a prompt that actually carries the placeholder. An earlier draft of this work
+    # avoided the claim path on the strength of a 60-90s estimate that turned out to be
+    # wall-clock on a multi-prompt script, and was wrong.
+    if SCENE_PLACEHOLDER in (segment.prompt or ""):
+        resolved = await _resolve_scene(db, segment.prompt, resolved_start_image, final=True)
+        if resolved != segment.prompt:
+            # Persisted, not just returned: the segment must record what it actually ran, so
+            # a retry reproduces it and a rated result can be traced to its real prompt.
+            segment.prompt = resolved
 
     # Resolve continuation mode API-side (VACE vs traditional). seg0 is always i2v;
     # VACE requires index>0 + the previous segment's video. The daemon falls back to

--- a/app/routes/wildcards.py
+++ b/app/routes/wildcards.py
@@ -18,7 +18,17 @@ router = APIRouter()
 # The trigger is already substituted before wildcard resolution runs, so this is the second of
 # two guards rather than the only one. Reserving the name means the collision cannot be created
 # by hand in the first place, which is cheaper than reasoning about ordering later.
-RESERVED_WILDCARD_NAMES = {"TRIGGER"}
+# SCENE is reserved for a DIFFERENT reason than TRIGGER, and the difference matters.
+#
+# <TRIGGER> is resolved BEFORE the wildcard resolver runs, so a wildcard named TRIGGER can
+# never hijack it; the reservation is a second belt.
+#
+# <SCENE> must resolve AFTER wildcards, so the caption — model output that may contain
+# bracketed tokens — is never wildcard-expanded. That means the wildcard resolver sees the
+# placeholder first, and a wildcard named SCENE WOULD substitute a random option before the
+# captioner is ever called. The render would look plausible and be wrong. So for SCENE this
+# reservation is not belt-and-braces; it is the only guard there is.
+RESERVED_WILDCARD_NAMES = {"TRIGGER", "SCENE"}
 
 
 @router.get("/wildcards", response_model=list[WildcardResponse])

--- a/app/schemas/app_settings.py
+++ b/app/schemas/app_settings.py
@@ -1,11 +1,33 @@
-from typing import Optional
+from typing import Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+from app.joycaption import CAPTION_STYLES, DEFAULT_STYLE
+
+CaptionStyle = Literal["terse", "standard", "rich", "raw"]
 
 
 class AppSettingsResponse(BaseModel):
     negative_prompt: str
+    # How verbose the <SCENE> description should be (console#405). The presets exist because
+    # the right length is a judgement about PROPORTION, not a universal answer: the caption
+    # sits beside a ~100-word arc, and a description that outweighs it risks the model
+    # holding the scene at the expense of the motion.
+    # Defaulted, not required: these settings always have a value (see _DEFAULTS in
+    # routes/app_settings.py), so a response can always be constructed.
+    caption_style: CaptionStyle = DEFAULT_STYLE
+    # Non-empty overrides the style entirely. The escape hatch: the presets encode what
+    # tested well, but whoever is tuning prompts knows the material better than a default.
+    caption_instruction: str = ""
+    # Read-only, so the console can show what each style actually asks for rather than
+    # making the user guess what "rich" means.
+    caption_style_prompts: dict[str, str] = Field(default_factory=lambda: dict(CAPTION_STYLES))
 
 
 class AppSettingsUpdate(BaseModel):
     negative_prompt: Optional[str] = None
+    caption_style: Optional[CaptionStyle] = None
+    # Deliberately allows "" — that is how you CLEAR a custom instruction and fall back to
+    # the style. exclude_none in the route means None is "leave alone" and "" is "clear",
+    # which are different intents and must stay distinguishable.
+    caption_instruction: Optional[str] = Field(default=None, max_length=2000)

--- a/app/schemas/captions.py
+++ b/app/schemas/captions.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class CaptionRequest(BaseModel):
+    # An s3:// URI. Deliberately not a raw upload: the image is already in S3 by the time
+    # anyone is composing a segment, and accepting bytes here would make this an upload
+    # endpoint with a different security surface.
+    image_uri: str = Field(min_length=1)
+    # Override the saved setting for this one call, so the console can offer "try it
+    # shorter" without changing the global default.
+    style: Optional[str] = None
+    instruction: Optional[str] = Field(default=None, max_length=2000)
+
+
+class CaptionResponse(BaseModel):
+    caption: str
+    # Which instruction produced this. Returned so the caller can record HOW the frame was
+    # described, not only what was said.
+    instruction: str
+    # Surfaced because length is the thing being judged: the caption sits beside a ~100-word
+    # arc, and whether it is 25 or 80 words changes the balance between scene and motion.
+    words: int

--- a/tests/test_scene_placeholder.py
+++ b/tests/test_scene_placeholder.py
@@ -104,3 +104,41 @@ class TestReservation:
         from app.routes.wildcards import RESERVED_WILDCARD_NAMES
         assert "SCENE" in RESERVED_WILDCARD_NAMES
         assert "TRIGGER" in RESERVED_WILDCARD_NAMES
+
+
+class TestDeferral:
+    """A continuation is routinely created BEFORE the segment it follows has rendered.
+
+    Its start frame is that segment's last frame, which does not exist yet. Resolving at
+    submit would therefore find nothing to describe — and dropping the placeholder there
+    would be unrecoverable, because no later step could tell a description was ever wanted.
+
+    Continuations are the case this feature helps MOST: they condition on a generated frame
+    nobody has ever described, using recipe wording written before that frame existed. So
+    losing them silently is the worst outcome available, and these tests pin the deferral.
+    """
+
+    @pytest.mark.asyncio
+    async def test_submit_leaves_the_placeholder_when_there_is_no_image_yet(self):
+        from app.routes.segments import _resolve_scene
+        prompt = f"trig, {SCENE_PLACEHOLDER}, she moves"
+        out = await _resolve_scene(None, prompt, None, final=False)
+        assert out == prompt, "submit must defer, not drop"
+
+    @pytest.mark.asyncio
+    async def test_claim_drops_it_when_there_is_still_no_image(self):
+        """Last responsible moment: a text-to-video segment, or a predecessor that produced
+        no last frame. Shipping a literal <SCENE> to the encoder is the one outcome that is
+        strictly worse than a generic prompt."""
+        from app.routes.segments import _resolve_scene
+        out = await _resolve_scene(None, f"trig, {SCENE_PLACEHOLDER}, she moves", None, final=True)
+        assert SCENE_PLACEHOLDER not in out
+        assert out == "trig, she moves"
+
+    @pytest.mark.asyncio
+    async def test_a_prompt_without_the_placeholder_never_calls_the_captioner(self):
+        """Every pose today. The captioner must not be touched for them — this runs on the
+        claim path, which every worker polls."""
+        from app.routes.segments import _resolve_scene
+        p = "k3lly2026, a woman kneeling, she grips his hand"
+        assert await _resolve_scene(None, p, "s3://bucket/would-explode-if-fetched", final=True) == p

--- a/tests/test_scene_placeholder.py
+++ b/tests/test_scene_placeholder.py
@@ -1,0 +1,106 @@
+"""<SCENE>: filling a pose's static half from the frame it actually starts on.
+
+console#405. Recipes are start-frame-agnostic, so their static half is a guess about an
+image they have never seen — a validated pose says "a woman kneeling in front of a nude man"
+while the frame is a clothed woman on a sofa. Every test here is about that substitution
+being safe, because the failure modes are all silent: a wrong caption renders fine and looks
+plausible.
+"""
+import pytest
+
+from app.joycaption import CAPTION_STYLES, DEFAULT_STYLE, image_key, instruction_for
+from app.routes.segments import SCENE_PLACEHOLDER, _drop_scene
+
+
+class TestStyles:
+    def test_every_style_but_raw_asks_for_gaze_and_expression(self):
+        """"looking at the viewer" is load-bearing in these prompts, and a plain
+        "describe this image" omits it. Asking explicitly is what separated a usable caption
+        from a nearly-usable one on a real frame."""
+        for name, prompt in CAPTION_STYLES.items():
+            if name == "raw":
+                continue
+            assert "looking" in prompt, f"{name} does not ask where the subject is looking"
+
+    def test_every_style_but_raw_suppresses_text_and_framing(self):
+        """The model reports overlay text and picture frames unless told not to — on a real
+        frame it read cursive in the corner and confabulated it into a person's name. True of
+        the image, garbage in a render prompt."""
+        for name, prompt in CAPTION_STYLES.items():
+            if name == "raw":
+                continue
+            assert "text or writing" in prompt, f"{name} does not suppress overlay text"
+            assert "camera" in prompt, f"{name} does not suppress camera talk"
+
+    def test_a_custom_instruction_always_wins(self):
+        """The presets encode what tested well; the person tuning prompts knows better."""
+        assert instruction_for("terse", "my own words") == "my own words"
+        assert instruction_for("rich", "   ") == CAPTION_STYLES["rich"]     # blank is not custom
+
+    def test_an_unknown_style_falls_back_rather_than_raising(self):
+        """A style written straight into app_settings, or one dropped in a later release,
+        must not take the settings page down with it."""
+        assert instruction_for("nonsense") == CAPTION_STYLES[DEFAULT_STYLE]
+
+
+class TestCacheKey:
+    def test_the_same_image_and_instruction_give_the_same_key(self):
+        """A retry must reproduce the caption its first attempt used. Without that, retrying
+        a failed segment re-captions, gets different words, and renders something different
+        from what failed — which quietly breaks what "retry" means."""
+        assert image_key(b"same-bytes", "same") == image_key(b"same-bytes", "same")
+
+    def test_changing_the_instruction_changes_the_key(self):
+        """Switching style should produce a new caption, not serve the old one."""
+        assert image_key(b"img", CAPTION_STYLES["terse"]) != image_key(b"img", CAPTION_STYLES["rich"])
+
+    def test_it_keys_on_content_not_path(self):
+        """The same frame is referenced from several places; two paths to one image must
+        share a caption."""
+        assert image_key(b"identical", "i") == image_key(b"identical", "i")
+        assert image_key(b"different", "i") != image_key(b"identical", "i")
+
+
+class TestDropping:
+    """When the captioner is down the placeholder is DROPPED, not left literal.
+
+    This inverts _resolve_trigger, which leaves its placeholder deliberately: dropping the
+    token that anchors the character LoRA is worse and harder to notice. Here the reasoning
+    flips — a literal "<SCENE>" is garbage tokens to the encoder, while dropping leaves a
+    valid if generic prompt, which is what every pose had before this existed.
+    """
+
+    def test_the_placeholder_never_survives(self):
+        assert SCENE_PLACEHOLDER not in _drop_scene(f"trig, {SCENE_PLACEHOLDER}, she grips")
+
+    def test_no_dangling_empty_clause_is_left(self):
+        """"trig, , she grips" reaches the encoder as a stray empty clause."""
+        out = _drop_scene(f"trig, {SCENE_PLACEHOLDER}, she grips his hand")
+        assert ", ," not in out
+        assert out == "trig, she grips his hand"
+
+    @pytest.mark.parametrize("prompt,expected", [
+        (f"{SCENE_PLACEHOLDER}, she moves", "she moves"),
+        (f"trig, {SCENE_PLACEHOLDER}", "trig"),
+        (f"a {SCENE_PLACEHOLDER} b", "a b"),
+    ])
+    def test_it_tidies_in_every_position(self, prompt, expected):
+        assert _drop_scene(prompt) == expected
+
+    def test_a_prompt_without_the_placeholder_is_untouched(self):
+        """Every pose today. This must be a no-op for them."""
+        p = "k3lly2026, a woman kneeling, she grips his hand"
+        assert _drop_scene(p) == p
+
+
+class TestReservation:
+    def test_scene_is_reserved_against_wildcards(self):
+        """SCENE resolves AFTER wildcards so the caption is never wildcard-expanded — which
+        means the wildcard resolver sees the placeholder FIRST. A wildcard named SCENE would
+        substitute a random option before the captioner is called, and the render would look
+        plausible and be wrong. For TRIGGER the reservation is a second belt; for SCENE it is
+        the only guard.
+        """
+        from app.routes.wildcards import RESERVED_WILDCARD_NAMES
+        assert "SCENE" in RESERVED_WILDCARD_NAMES
+        assert "TRIGGER" in RESERVED_WILDCARD_NAMES


### PR DESCRIPTION
Implements console#405. Pairs with wanly-console `feat/caption-settings`.

An LTX prompt is two halves: what the scene **is**, then what **happens**. Recipes are start-frame-agnostic by design — one pose serves every character — so their static half is a guess about an image they have never seen. A validated pose reads *"a woman kneeling in front of a nude man"* while the frame it runs on is a clothed woman sitting on a sofa.

`<SCENE>` lets a pose defer that half to the frame and keep only the arc, which is the part being directed.

**Verified end to end against the real captioner, on a real frame:**

```
terse     27w   k3lly2026, Woman with wavy brown hair, wearing a white strapless crop
                top ... sitting on beige sofa, looking directly at the camera, she grips...
standard  41w   ...She looks directly at the camera with a neutral expression...
rich      67w   ...Her hands rest on the couch cushions behind her...
down      --    placeholder dropped, prompt still valid and generic
```

### Two resolution points, one placeholder

| | who resolves | why |
|---|---|---|
| segment 0 | the **console** | the image is on screen and a person can read the caption first |
| continuation | the **API**, at claim | nobody is present, and the frame does not exist until the previous segment renders |

This is the convention `_resolve_trigger` already documents — the console substitutes when it can, the API catches whatever still carries the placeholder.

**Submit defers, claim resolves.** A continuation is routinely created before the segment it follows has rendered, so at submit its start frame does not exist. Dropping there would be *unrecoverable* — the placeholder would be gone and no later step could tell a description was ever wanted. That is the case this helps most: a continuation conditions on a generated frame nobody has ever described.

**On the claim path deliberately**, despite every worker polling it. A caption is **4.5s cold, 1.2s warm** (measured) against a segment that then renders for ten minutes, and it only runs for prompts carrying the placeholder — there's a test that the captioner is never touched otherwise.

> An earlier draft of this work avoided the claim path on the strength of a "60–90s per caption" estimate. That was wall-clock on a multi-prompt script and was wrong; the real numbers were in the response payload all along.

### Ordering, and why SCENE must be reserved

`<SCENE>` resolves **after** wildcards, the opposite of `<TRIGGER>`, so the caption — model output that may contain bracketed tokens — is never wildcard-expanded.

That forfeits the ordering protection `<TRIGGER>` gets for free, so **SCENE is now reserved** in the wildcard routes. For TRIGGER the reservation is a second belt; for SCENE it is the only guard, and a wildcard named `SCENE` would otherwise substitute a random option before the captioner is ever called — producing a plausible, wrong render.

### Failure inverts from `<TRIGGER>`

`_resolve_trigger` leaves its literal placeholder deliberately, because silently dropping the token that anchors the character LoRA is harder to notice. Here the reasoning flips: a literal `<SCENE>` is garbage tokens to the encoder, while dropping leaves the valid generic prompt every pose had before this existed. So it drops, tidies the comma that would dangle, and logs.

### VRAM

`keep_alive` is 5s so JoyCaption releases the card almost immediately — Automatic1111 shares that GPU and a resident 5.5 GB model would starve it. Cheap because a cold start is 2.9s.

### Not done, and why

Caching is **not** required for retry correctness: `/segments/{id}/retry` reuses the stored resolved prompt rather than re-resolving, so a retry already reproduces its caption. `image_key()` is in place for when caching across segments is worth the code.

17 new tests, 655 total.