### PR TITLE
recipes: per-pose base model, and workers report which ones they can load

### DIFF
--- a/alembic/versions/081_recipe_checkpoint.py
+++ b/alembic/versions/081_recipe_checkpoint.py
@@ -1,0 +1,41 @@
+"""Per-pose base model (checkpoint)
+
+Revision ID: 081
+Revises: 080
+Create Date: 2026-09-03
+
+NULLABLE, and null means "use the stack's value" — the same shape as frames,
+negative_prompt, img_compression and content_lora. Every existing pose keeps rendering on
+sulphur_dev_bf16, so this migration changes no output.
+
+WHY PER POSE
+    `checkpoint` was a global in LTX_STACK, so every render used one base model and there
+    was no way to compare two. Four sit on the 3090 — sulphur_dev_bf16, 10Eros_v1.5_bf16,
+    ltx-2.3-22b-dev, ltx-2.3-22b-distilled-1.1 — and only one was reachable.
+
+THE RISK, STATED
+    Character LoRAs were trained against sulphur. Against a different base, a LoRA whose
+    keys do not line up fuses NOTHING and says nothing about it — the engine's own
+    lora_coverage() docstring records that there is no error, no warning and no log line,
+    and the run looks completely normal. The render then comes back as the base model with
+    none of the character in it.
+
+    That is accepted deliberately here: comparing base models is the point. What this change
+    also does is make the fusion count TRUE for the checkpoint actually in use, so a
+    comparison can be read rather than guessed at.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "081"
+down_revision = "080"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ltx_recipes", sa.Column("checkpoint", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("ltx_recipes", "checkpoint")

--- a/alembic/versions/082_worker_checkpoints.py
+++ b/alembic/versions/082_worker_checkpoints.py
@@ -1,0 +1,31 @@
+"""Base models each worker can load
+
+Revision ID: 082
+Revises: 081
+Create Date: 2026-09-03
+
+Reported through the heartbeat, following loras (080) for the same reason: a worker is the
+only thing that can see this. The engine binds to 127.0.0.1 inside the container, so nothing
+upstream can ask it what ComfyUI will load — and "what ComfyUI will load" is the real
+question, since a checkpoint the folder mapping does not cover is invisible to a render
+however present it is on disk.
+
+NULLABLE: never reported is not the same as none available, and a console dropdown should
+not present those identically.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "082"
+down_revision = "081"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("workers", sa.Column("checkpoints", postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "checkpoints")

--- a/app/models.py
+++ b/app/models.py
@@ -417,5 +417,14 @@ class LtxRecipe(Base):
     # hardcode 0.6 for both, which is a configuration, not a default.
     content_s1 = mapped_column(Float, nullable=True)
     content_s2 = mapped_column(Float, nullable=True)
+    # The base model this pose renders on. NULL means the stack's value, as everything else
+    # nullable here does. Exists so two checkpoints can be compared against one pose and one
+    # seed — sulphur vs 10Eros being the first such comparison.
+    #
+    # Note the character LoRA was trained against sulphur: on another base it may fuse
+    # nothing at all, silently, and the render comes back as the base model with none of the
+    # character in it. The engine reports its fusion count per render, which is what makes
+    # that visible rather than a surprise.
+    checkpoint = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), nullable=True)

--- a/app/models.py
+++ b/app/models.py
@@ -297,6 +297,10 @@ class Worker(Base):
     # heartbeat cannot do. NULL means "never reported" (or an older daemon), which is not
     # the same as an empty inventory and should not render the same way. See daemon#165.
     loras: Mapped[dict | None] = mapped_column(JSONB, nullable=True, default=None)
+    # Base models this worker can load, as ComfyUI reports them. Reported rather than
+    # discovered: the engine binds to localhost, so the daemon is the only thing that can
+    # ask. NULL means never reported — not the same as none available. See console#404.
+    checkpoints: Mapped[list | None] = mapped_column(JSONB, nullable=True, default=None)
     drain_after_jobs: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -26,7 +26,7 @@ from app.s3 import list_bucket
 from app.auth import get_current_user, verify_api_key_or_bearer
 from app.database import get_db
 from app.ltx_stack import LTX_STACK
-from app.models import LtxCharacter, LtxRecipe, User
+from app.models import LtxCharacter, LtxRecipe, User, Worker
 from app.schemas.ltx import (
     LtxCharacterCreate,
     LtxCharacterUpdate,
@@ -136,6 +136,34 @@ async def get_recipe_book(
             for c in chars
         ],
     }
+
+
+@router.get("/ltx/checkpoints", dependencies=[Depends(verify_api_key_or_bearer)])
+async def list_checkpoints(db: AsyncSession = Depends(get_db)):
+    """Base models a pose can actually be rendered on (console#404).
+
+    The union of what live workers report, not a list held here. A checkpoint is a 46 GB
+    file on a GPU box; whether one is loadable is a fact about that box, and the engine
+    binds to 127.0.0.1 inside its container so nothing upstream can ask directly. Workers
+    report it through the heartbeat instead.
+
+    OFFLINE WORKERS ARE EXCLUDED. Offering a checkpoint that only exists on a box which is
+    not running means picking it produces a job nothing can claim — a queue that silently
+    stops rather than an error. What is offered should be what can be rendered now.
+
+    The stack's default is always included even when no worker is up, so the dropdown is
+    never empty and always contains the value every existing pose already uses.
+    """
+    rows = (await db.execute(
+        select(Worker.checkpoints).where(Worker.status != "offline")
+    )).scalars().all()
+
+    names: set[str] = {LTX_STACK["checkpoint"]}
+    for row in rows:
+        for name in row or []:
+            if isinstance(name, str) and name.strip():
+                names.add(name.strip())
+    return {"checkpoints": sorted(names), "default": LTX_STACK["checkpoint"]}
 
 
 @router.get("/loras", dependencies=[Depends(verify_api_key_or_bearer)])

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -117,6 +117,9 @@ async def get_recipe_book(
                                else LTX_STACK["content_s1"]),
                 "content_s2": (r.content_s2 if r.content_s2 is not None
                                else LTX_STACK["content_s2"]),
+                # `or` is right here: NULL and "" both mean "not set", and there is no
+                # falsy checkpoint name that means something different.
+                "checkpoint": r.checkpoint or LTX_STACK["checkpoint"],
                 "validated": r.validated,
             }
             for r in poses

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -157,6 +157,11 @@ async def heartbeat(
     # None would erase a good inventory every heartbeat during a rolling upgrade.
     if body.loras is not None:
         worker.loras = body.loras
+    # Same conditional write, same reason: an older daemon omits the field on every
+    # heartbeat, and assigning None would blank a good list seconds after a newer worker
+    # reported it.
+    if body.checkpoints is not None:
+        worker.checkpoints = body.checkpoints
     if worker.status == "offline":
         worker.status = "online-idle"
     # If sd-scripts is actively training, worker can't be idle

--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -67,6 +67,9 @@ class LtxRecipeCreate(BaseModel):
     # minutes into a claimed segment -- the validation has to be the tighter of the two.
     content_s1: Optional[float] = Field(default=None, ge=0, le=2)
     content_s2: Optional[float] = Field(default=None, ge=0, le=2)
+    # Base model for this pose. NULL uses the stack's. A filename as ComfyUI lists it;
+    # the engine appends .safetensors when missing.
+    checkpoint: Optional[str] = Field(default=None, max_length=256)
     validated: bool = False
 
 
@@ -79,6 +82,9 @@ class LtxRecipeUpdate(BaseModel):
     content_lora: Optional[str] = Field(default=None, max_length=256)
     content_s1: Optional[float] = Field(default=None, ge=0, le=2)
     content_s2: Optional[float] = Field(default=None, ge=0, le=2)
+    # Base model for this pose. NULL uses the stack's. A filename as ComfyUI lists it;
+    # the engine appends .safetensors when missing.
+    checkpoint: Optional[str] = Field(default=None, max_length=256)
     validated: Optional[bool] = None
 
 
@@ -94,6 +100,7 @@ class LtxRecipeResponse(BaseModel):
     content_lora: Optional[str]
     content_s1: Optional[float]
     content_s2: Optional[float]
+    checkpoint: Optional[str]
     validated: bool
     created_at: datetime
     updated_at: Optional[datetime]

--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -23,6 +23,8 @@ class WorkerHeartbeat(BaseModel):
     # Cached LoRA inventory from the worker's last sync. Optional so an older daemon still
     # heartbeats successfully rather than 422-ing itself out of the pool on upgrade day.
     loras: dict[str, Any] | None = None
+    # Base models this worker can load. Optional so an older daemon still heartbeats.
+    checkpoints: list[str] | None = None
 
 
 class WorkerRename(BaseModel):
@@ -64,6 +66,7 @@ class WorkerResponse(BaseModel):
     sd_scripts: dict[str, Any] | None = None
     a1111: dict[str, Any] | None = None
     loras: dict[str, Any] | None = None
+    checkpoints: list[str] | None = None
     drain_after_jobs: int | None = None
     last_heartbeat: datetime
     registered_at: datetime

--- a/tests/test_recipe_checkpoint.py
+++ b/tests/test_recipe_checkpoint.py
@@ -1,0 +1,48 @@
+"""Per-pose base model (console#404).
+
+`checkpoint` was a global, so every render used one base model and two could not be
+compared. Four sit on the 3090 and only one was reachable.
+
+THE RISK IS ACCEPTED, NOT ABSENT. Character LoRAs were trained against sulphur. Against
+another base a LoRA whose keys do not line up fuses NOTHING and says nothing about it — the
+engine's own lora_coverage() docstring records that there is no error, no warning and no
+log line. The render comes back as the base model with none of the character in it.
+
+Comparing base models is a legitimate reason to accept that. What must not happen is the
+comparison being unreadable, which is why the engine now measures fusion against the
+checkpoint the job actually renders on rather than an env var.
+"""
+from app.ltx_stack import LTX_STACK
+
+
+class _Pose:
+    def __init__(self, **kw):
+        self.checkpoint = None
+        self.__dict__.update(kw)
+
+
+def _resolve(pose):
+    """The expression the /ltx/recipes resolver uses."""
+    return pose.checkpoint or LTX_STACK["checkpoint"]
+
+
+def test_a_pose_that_says_nothing_still_renders_on_sulphur():
+    """Every existing pose. The migration must change no output."""
+    assert _resolve(_Pose()) == "sulphur_dev_bf16"
+
+
+def test_a_pose_can_name_its_own_base_model():
+    """The point of the change: sulphur vs 10Eros on one pose and one seed."""
+    assert _resolve(_Pose(checkpoint="10Eros_v1.5_bf16")) == "10Eros_v1.5_bf16"
+
+
+def test_clearing_it_falls_back_rather_than_rendering_on_an_empty_name():
+    """"" reaches the resolver when a user clears the field. It must mean "use the stack",
+    not "load a checkpoint called nothing"."""
+    assert _resolve(_Pose(checkpoint="")) == "sulphur_dev_bf16"
+
+
+def test_the_stack_default_is_unchanged():
+    """This is what every validated result to date was produced on. If it moves, the whole
+    rated history stops being comparable to anything new."""
+    assert LTX_STACK["checkpoint"] == "sulphur_dev_bf16"

--- a/tests/test_recipe_checkpoint.py
+++ b/tests/test_recipe_checkpoint.py
@@ -46,3 +46,41 @@ def test_the_stack_default_is_unchanged():
     """This is what every validated result to date was produced on. If it moves, the whole
     rated history stops being comparable to anything new."""
     assert LTX_STACK["checkpoint"] == "sulphur_dev_bf16"
+
+
+class TestCheckpointListing:
+    """What the dropdown offers (console#404).
+
+    The union of what LIVE workers report. A checkpoint is a 46 GB file on a GPU box, so
+    whether one is loadable is a fact about that box — and the engine binds to localhost,
+    so workers report it through the heartbeat rather than the API discovering it.
+    """
+
+    def test_offline_workers_are_excluded_from_the_query(self):
+        """Offering a checkpoint that exists only on a box which is not running produces a
+        job nothing can claim — a queue that silently stops rather than an error."""
+        import inspect
+        from app.routes import ltx_recipes as mod
+        src = inspect.getsource(mod.list_checkpoints)
+        assert 'Worker.status != "offline"' in src
+
+    def test_the_stack_default_is_always_offered(self):
+        """With no worker online the dropdown must still contain the value every existing
+        pose already renders on, or the field looks broken when the fleet is idle."""
+        import inspect
+        from app.routes import ltx_recipes as mod
+        src = inspect.getsource(mod.list_checkpoints)
+        assert 'LTX_STACK["checkpoint"]' in src
+
+    def test_an_older_daemon_still_heartbeats(self):
+        """checkpoints must be optional. Required, every worker on the previous daemon
+        would 422 and drop out of the pool the moment this deployed."""
+        from app.schemas.workers import WorkerHeartbeat
+        assert WorkerHeartbeat(comfyui_running=True).checkpoints is None
+
+    def test_omitting_it_must_not_erase_a_stored_list(self):
+        """An older daemon omits the field on every heartbeat; assigning None would blank a
+        good list seconds after a newer worker reported it."""
+        import inspect
+        from app.routes import workers as mod
+        assert "if body.checkpoints is not None:" in inspect.getsource(mod.heartbeat)


### PR DESCRIPTION
Implements console#404. Four repos; this is the storage and listing half.

`checkpoint` was a global in `LTX_STACK`, so every render used one base model and two could not be compared. Four sit on the 3090 — `sulphur_dev_bf16`, `10Eros_v1.5_bf16`, `ltx-2.3-22b-dev`, `ltx-2.3-22b-distilled-1.1` — and only one was reachable.

**Migration 081** adds a nullable `checkpoint` to `ltx_recipes`. NULL means the stack's value, the same shape as `frames`, `img_compression` and `content_lora`, so every existing pose keeps rendering on sulphur and this changes no output.

**Migration 082** adds `checkpoints` to `workers`, plus `GET /ltx/checkpoints`.

### Why workers report it rather than the API discovering it

A checkpoint is a 46 GB file on a GPU box, so whether one is loadable is a fact about that box — and **"loadable" is the real question, not "present"**: the engine asks ComfyUI, which answers from the folder mapping in `extra_model_paths.yaml`, so a file the mapping doesn't cover is invisible to a render however present it is on disk.

Nothing upstream can ask directly — the engine binds to `127.0.0.1` inside its container. Verified: `3090.zero:8190` from the API host returns `000`. So this follows the LoRA inventory pattern from 080.

**Offline workers are excluded.** Offering a checkpoint that exists only on a box which isn't running produces a job nothing can claim — a queue that silently stops rather than an error. The stack default is always included, so the dropdown is never empty.

### The risk, accepted deliberately

Character LoRAs were trained against sulphur. Against another base, a LoRA whose keys don't line up **fuses nothing and says nothing about it** — the engine's own `lora_coverage()` docstring records there's no error, no warning, no log line, and the run looks completely normal. The render comes back as the base model with none of the character in it.

Comparing base models is a legitimate reason to accept that. What must not happen is the comparison being *unreadable*, which is handled in wanly-gpu-docker: fusion is now measured against the checkpoint the job actually renders on, and a 0-fusion render is called out in both the log and the segment notes.

8 tests, 663 total. Both migrations upgrade and downgrade cleanly.