### PR TITLE
recipes: content LoRAs stack, each with its own per-stage strengths

### DIFF
--- a/alembic/versions/083_content_lora_list.py
+++ b/alembic/versions/083_content_lora_list.py
@@ -1,0 +1,69 @@
+"""Several content LoRAs per pose, each with its own per-stage strengths
+
+Revision ID: 083
+Revises: 082
+Create Date: 2026-09-04
+
+console#410. Replaces the single content_lora + content_s1 + content_s2 with a JSONB list of
+{name, s1, s2}, because three scalar columns do not extend to N.
+
+THE MIGRATION IS THE POINT
+    Every existing pose must render exactly as it does now. The upgrade folds each pose's
+    current three values into a ONE-ELEMENT list, and the downgrade takes the first element
+    back out. A pose with no content LoRA becomes an empty list, which resolves to "none"
+    exactly as NULL did.
+
+ORDER IS SIGNIFICANT
+    A JSONB array preserves order, and that order is the order the LoRAs are applied in the
+    chain. It is not a set. Two poses with the same LoRAs in a different order are different
+    configurations and will render differently.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "083"
+down_revision = "082"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ltx_recipes",
+                  sa.Column("content_loras", postgresql.JSONB(), nullable=True))
+    # Fold the existing single LoRA into a one-element list. "none" and empty are not a
+    # LoRA and become an empty list rather than a list containing nothing useful — the
+    # engine reads both as "render without one", and a [{"name": "none"}] would be a
+    # filename lookup for a file that does not exist.
+    op.execute("""
+        UPDATE ltx_recipes
+           SET content_loras = jsonb_build_array(
+                 jsonb_build_object(
+                   'name', content_lora,
+                   's1', COALESCE(content_s1, 0.6),
+                   's2', COALESCE(content_s2, 0.6)))
+         WHERE content_lora IS NOT NULL
+           AND btrim(content_lora) <> ''
+           AND lower(btrim(content_lora)) <> 'none'
+    """)
+    op.execute("UPDATE ltx_recipes SET content_loras = '[]'::jsonb WHERE content_loras IS NULL")
+    op.drop_column("ltx_recipes", "content_lora")
+    op.drop_column("ltx_recipes", "content_s1")
+    op.drop_column("ltx_recipes", "content_s2")
+
+
+def downgrade() -> None:
+    op.add_column("ltx_recipes", sa.Column("content_lora", sa.Text(), nullable=True))
+    op.add_column("ltx_recipes", sa.Column("content_s1", sa.Float(), nullable=True))
+    op.add_column("ltx_recipes", sa.Column("content_s2", sa.Float(), nullable=True))
+    # Only the FIRST survives — the old shape cannot hold more. Lossy by nature, and that is
+    # the honest behaviour: silently keeping one of four is better than failing the
+    # downgrade, but it is why this direction should be rare.
+    op.execute("""
+        UPDATE ltx_recipes
+           SET content_lora = content_loras->0->>'name',
+               content_s1   = (content_loras->0->>'s1')::float,
+               content_s2   = (content_loras->0->>'s2')::float
+         WHERE jsonb_array_length(COALESCE(content_loras, '[]'::jsonb)) > 0
+    """)
+    op.drop_column("ltx_recipes", "content_loras")

--- a/app/models.py
+++ b/app/models.py
@@ -406,29 +406,19 @@ class LtxRecipe(Base):
     # A video CRF applied to the conditioning frame before it anchors the render;
     # 0 bypasses it. See wanly-api#235.
     img_compression = mapped_column(Integer, nullable=True)
-    # The content LoRA is WHAT IS HAPPENING — motion and act — and so belongs to the POSE,
-    # where the character LoRA is WHO and belongs to the character. The graph has always
-    # chained both (content -> character -> branch); this is the half that had no home
-    # except a single global, which cannot say "sfbehind for the from-behind poses and
-    # nothing for the rest".
+    # Content LoRAs — WHAT IS HAPPENING, motion and act — chained ahead of the character
+    # LoRA, which is WHO. A LIST because they stack: motion, act and framing are separable
+    # and a pose may want several (console#410).
     #
-    # NULL means "use the stack's value", exactly as frames and img_compression do — and the
-    # stack value is still "none". Dropping DR34ML4Y is what removed the motion horror, so
-    # the default must stay off rather than becoming "whatever was last set".
-    content_lora = mapped_column(Text, nullable=True)
-    # Per-stage, never flat — the same reason LtxCharacter carries two. Stage 1 generates at
-    # half size from noise; stage 2 refines the 2x-upscaled latent. resolve() used to
-    # hardcode 0.6 for both, which is a configuration, not a default.
-    content_s1 = mapped_column(Float, nullable=True)
-    content_s2 = mapped_column(Float, nullable=True)
-    # The base model this pose renders on. NULL means the stack's value, as everything else
-    # nullable here does. Exists so two checkpoints can be compared against one pose and one
-    # seed — sulphur vs 10Eros being the first such comparison.
+    # [{"name": str, "s1": float, "s2": float}], and ORDER IS SIGNIFICANT — it is the order
+    # they are applied in the chain. Two poses with the same LoRAs in a different order are
+    # different configurations. Not a set.
     #
-    # Note the character LoRA was trained against sulphur: on another base it may fuse
-    # nothing at all, silently, and the render comes back as the base model with none of the
-    # character in it. The engine reports its fusion count per render, which is what makes
-    # that visible rather than a surprise.
+    # Empty list means none, which is what every pose did before this existed and what most
+    # still do. Per-stage strengths on each because stage 1 generates at half size from
+    # noise and stage 2 refines the 2x-upscaled latent; lowering a competing content LoRA on
+    # stage 2 is a recorded lever and one flat number cannot express it.
+    content_loras = mapped_column(JSONB, nullable=True)
     checkpoint = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), nullable=True)

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -105,18 +105,14 @@ async def get_recipe_book(
                 # would silently replace it with the stack default.
                 "img_compression": (r.img_compression if r.img_compression is not None
                                     else LTX_STACK["img_compression"]),
-                # `or` IS right for the name: NULL and "" both mean "not set", and the stack
-                # value is "none" — which the engine reads as "render without one". There is
-                # no falsy string here that means something different.
-                "content_lora": r.content_lora or LTX_STACK["content_lora"],
-                # ...but `is None` is right for the strengths, for the same reason as
-                # img_compression above: 0 is a REAL setting. It loads the LoRA and gives it
-                # no weight, which is how you measure what it is contributing. `or` would
-                # quietly turn that into 0.6 and the measurement would be of the wrong thing.
-                "content_s1": (r.content_s1 if r.content_s1 is not None
-                               else LTX_STACK["content_s1"]),
-                "content_s2": (r.content_s2 if r.content_s2 is not None
-                               else LTX_STACK["content_s2"]),
+                # In application order, and returned as stored. No stack fallback: the
+                # stack's content_lora is "none", and an empty list already says that more
+                # directly than a one-element list naming "none" would.
+                #
+                # Strengths are whatever was stored, including 0 — which is a REAL setting:
+                # it loads the LoRA and gives it no weight, which is how you measure what it
+                # contributes. Nothing here may silently promote a 0 to 0.6.
+                "content_loras": r.content_loras or [],
                 # `or` is right here: NULL and "" both mean "not set", and there is no
                 # falsy checkpoint name that means something different.
                 "checkpoint": r.checkpoint or LTX_STACK["checkpoint"],

--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -45,6 +45,23 @@ class LtxCharacterUpdate(BaseModel):
     strength_stage_2: Optional[float] = Field(default=None, ge=0)
 
 
+class ContentLora(BaseModel):
+    """One content LoRA in a pose's chain (console#410).
+
+    Per-stage strengths because stage 1 generates at half size from noise and stage 2
+    refines the 2x-upscaled latent. Both default to 0.6 — the value resolve() hardcoded
+    before any of this was configurable — so adding a LoRA and touching nothing renders it
+    at the strength the validated graph already applied.
+    """
+
+    name: str = Field(min_length=1, max_length=256)
+    # Bounded at 2.0 to match the ENGINE's own bound. A wider bound here would accept a
+    # value the console stores happily and the engine then rejects with a 422, ten minutes
+    # into a claimed segment.
+    s1: float = Field(default=0.6, ge=0, le=2)
+    s2: float = Field(default=0.6, ge=0, le=2)
+
+
 class LtxRecipeCreate(BaseModel):
     """A pose. Character-agnostic: the prompt carries <TRIGGER>, not a name."""
 
@@ -57,16 +74,12 @@ class LtxRecipeCreate(BaseModel):
     # it bypasses the encode. Bounded at 51 -- the node accepts 100, but x264's scale ends
     # at 51 and anything above it is nominal.
     img_compression: Optional[int] = Field(default=None, ge=0, le=51)
-    # The motion/act LoRA for this pose. NULL uses the stack's value, which is "none" — so a
-    # pose that says nothing gets no content LoRA, which is the behaviour every existing
-    # pose has today. "none" is also accepted explicitly, to mean "deliberately off".
-    content_lora: Optional[str] = Field(default=None, max_length=256)
-    # Per-stage, like the character strengths. Bounded at 2.0 to match the ENGINE's own
-    # bound on these fields (engine/app.py Lora and content_s1/s2). A wider bound here would
-    # accept a value the console could store and then fail at render time with a 422, ten
-    # minutes into a claimed segment -- the validation has to be the tighter of the two.
-    content_s1: Optional[float] = Field(default=None, ge=0, le=2)
-    content_s2: Optional[float] = Field(default=None, ge=0, le=2)
+    # Motion/act LoRAs for this pose, IN APPLICATION ORDER. Empty or absent means none,
+    # which is what every existing pose does.
+    #
+    # Capped at 4 to match LtxRequest.loras' own max_length. Four LoRAs on one chain is
+    # already a lot of competition for the same weights as the character LoRA.
+    content_loras: Optional[List[ContentLora]] = Field(default=None, max_length=4)
     # Base model for this pose. NULL uses the stack's. A filename as ComfyUI lists it;
     # the engine appends .safetensors when missing.
     checkpoint: Optional[str] = Field(default=None, max_length=256)
@@ -79,9 +92,9 @@ class LtxRecipeUpdate(BaseModel):
     negative_prompt: Optional[str] = None
     frames: Optional[int] = Field(default=None, gt=0)
     img_compression: Optional[int] = Field(default=None, ge=0, le=51)
-    content_lora: Optional[str] = Field(default=None, max_length=256)
-    content_s1: Optional[float] = Field(default=None, ge=0, le=2)
-    content_s2: Optional[float] = Field(default=None, ge=0, le=2)
+    # An empty list CLEARS them; None leaves them alone. Those are different intents and
+    # exclude_none in the route keeps them distinguishable.
+    content_loras: Optional[List[ContentLora]] = Field(default=None, max_length=4)
     # Base model for this pose. NULL uses the stack's. A filename as ComfyUI lists it;
     # the engine appends .safetensors when missing.
     checkpoint: Optional[str] = Field(default=None, max_length=256)
@@ -97,9 +110,7 @@ class LtxRecipeResponse(BaseModel):
     negative_prompt: Optional[str]
     frames: Optional[int]
     img_compression: Optional[int]
-    content_lora: Optional[str]
-    content_s1: Optional[float]
-    content_s2: Optional[float]
+    content_loras: List[ContentLora] = Field(default_factory=list)
     checkpoint: Optional[str]
     validated: bool
     created_at: datetime

--- a/tests/test_content_lora.py
+++ b/tests/test_content_lora.py
@@ -1,116 +1,85 @@
-"""Content LoRA as a per-pose override.
+"""Content LoRAs as a per-pose LIST (console#395, extended by console#410).
 
 The graph has always chained two LoRAs per stage — content, then character. They answer
 different questions: the character LoRA is WHO, the content LoRA is WHAT IS HAPPENING. The
-character half already lived on ltx_characters; this is the pose half, which until now was
-a single global and so could not say "sfbehind for the from-behind poses, nothing for the
-rest".
+character half lives on ltx_characters; this is the pose half.
 
-The risk being guarded here is not a crash. It is a pose quietly acquiring a content LoRA
-it never asked for, or losing a deliberate strength of 0 — both of which render successfully
-and wrongly.
+They STACK, because motion, act and framing are separable. Order is part of the
+configuration, not incidental.
+
+The risk being guarded here is not a crash. It is a pose quietly acquiring a LoRA it never
+asked for, or losing a deliberate strength of 0 — both of which render successfully and
+wrongly.
 """
+from app.joycaption import CAPTION_STYLES  # noqa: F401  (import guard: app package loads)
 from app.ltx_stack import LTX_STACK
+from app.schemas.ltx import ContentLora, LtxRecipeCreate, LtxRecipeUpdate
 
 
-def test_the_default_is_still_none():
-    """Dropping DR34ML4Y is what removed the motion horror.
-
-    Making content LoRAs per-pose must not reintroduce one anywhere it was not asked for.
-    A pose that says nothing gets the stack value, and the stack value stays "none".
-    """
+def test_the_stack_default_is_still_none():
+    """Dropping DR34ML4Y is what removed the motion horror. Making content LoRAs per-pose,
+    and then stackable, must not reintroduce one anywhere it was not asked for. A pose that
+    says nothing gets an empty list."""
     assert LTX_STACK["content_lora"] == "none"
 
 
 def test_the_stage_defaults_are_the_number_resolve_used_to_hardcode():
-    """resolve() applied 0.6 to both stages before this was configurable.
-
-    Keeping that as the default means a pose that names a content LoRA without naming
-    strengths renders at exactly what the graph used to apply — not at some new number
-    chosen while making it configurable.
-    """
+    """resolve() applied 0.6 to both stages before any of this was configurable. Keeping it
+    as the per-entry default means naming a LoRA and touching nothing renders it at exactly
+    what the graph already applied."""
     assert LTX_STACK["content_s1"] == 0.6
     assert LTX_STACK["content_s2"] == 0.6
+    assert ContentLora(name="x").s1 == 0.6
+    assert ContentLora(name="x").s2 == 0.6
 
 
 class _Pose:
-    """The fields the resolver reads. Not the ORM — this is about the fallback rules."""
-    def __init__(self, **kw):
-        self.id = "00000000-0000-0000-0000-000000000000"
-        self.name = "p"
-        self.prompt_template = "t"
-        self.negative_prompt = None
-        self.frames = None
-        self.img_compression = None
-        self.content_lora = None
-        self.content_s1 = None
-        self.content_s2 = None
-        self.validated = False
-        self.__dict__.update(kw)
+    """The field the resolver reads. Not the ORM — this is about the resolution rule."""
+    def __init__(self, content_loras=None):
+        self.content_loras = content_loras
 
 
 def _resolve(pose):
-    """The exact expressions the /ltx/recipes resolver uses, kept in one place."""
-    return {
-        "content_lora": pose.content_lora or LTX_STACK["content_lora"],
-        "content_s1": (pose.content_s1 if pose.content_s1 is not None
-                       else LTX_STACK["content_s1"]),
-        "content_s2": (pose.content_s2 if pose.content_s2 is not None
-                       else LTX_STACK["content_s2"]),
-    }
+    """The expression the /ltx/recipes resolver uses."""
+    return {"content_loras": pose.content_loras or []}
 
 
 def test_a_pose_that_says_nothing_gets_no_content_lora():
-    """Every existing pose is exactly this. The migration must change no output."""
-    assert _resolve(_Pose())["content_lora"] == "none"
+    """Every existing pose. The migration must change no output."""
+    assert _resolve(_Pose())["content_loras"] == []
 
 
-def test_a_pose_can_name_its_own_content_lora():
-    out = _resolve(_Pose(content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.7, content_s2=0.9))
-    assert out["content_lora"] == "sfbehind_LTX2_3_v0_1"
-    assert (out["content_s1"], out["content_s2"]) == (0.7, 0.9)
+def test_a_pose_can_stack_several_in_order():
+    """The point of console#410. Order is preserved because it is the application order."""
+    loras = [{"name": "sfbehind", "s1": 0.3, "s2": 0.9},
+             {"name": "deepthroat", "s1": 0.5, "s2": 1.0}]
+    assert [c["name"] for c in _resolve(_Pose(loras))["content_loras"]] == ["sfbehind", "deepthroat"]
 
 
-def test_a_strength_of_zero_survives_and_is_not_replaced_by_the_default():
-    """The same trap img_compression has: 0 is a REAL setting, not "unset".
-
-    Strength 0 loads the LoRA and gives it no weight, which is how you measure what it is
-    actually contributing. `or` would turn that into 0.6 and the measurement would silently
-    be of something else. This is the assertion that stops `is None` being "simplified".
-    """
-    out = _resolve(_Pose(content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.0, content_s2=0.0))
-    assert out["content_s1"] == 0.0
-    assert out["content_s2"] == 0.0
-
-
-def test_naming_a_lora_without_strengths_uses_the_stack_pair():
-    out = _resolve(_Pose(content_lora="sfbehind_LTX2_3_v0_1"))
-    assert (out["content_s1"], out["content_s2"]) == (0.6, 0.6)
-
-
-def test_the_two_stages_stay_independent():
-    """Stage 1 generates from noise at half size; stage 2 refines the upscaled latent.
-
-    One number for both is a different configuration, not a simplification — the same
-    reasoning already recorded for the character strengths.
-    """
-    out = _resolve(_Pose(content_lora="x", content_s1=0.3, content_s2=1.2))
-    assert out["content_s1"] != out["content_s2"]
+def test_a_strength_of_zero_survives_the_schema():
+    """0 is a REAL setting: the LoRA loads and contributes nothing, which is how you measure
+    what it was contributing. Nothing may quietly promote it to the 0.6 default."""
+    c = ContentLora(name="x", s1=0.0, s2=0.0)
+    assert c.s1 == 0.0 and c.s2 == 0.0
 
 
 def test_the_api_bound_is_not_looser_than_the_engines():
-    """The engine bounds content_s1/s2 at 2.0 (engine/app.py). This must not exceed it.
+    """The engine bounds each strength at 2.0 (engine/app.py ContentLora).
 
     A looser bound here accepts a value the console stores happily and the engine then
     rejects with a 422 — ten minutes into a claimed segment, not in the dialog. Whichever
-    end is stricter is the real limit, so the two have to agree and this is the one that
-    can drift unnoticed.
+    end is stricter is the real limit, and this is the one that can drift unnoticed.
     """
-    from app.schemas.ltx import LtxRecipeCreate, LtxRecipeUpdate
+    ENGINE_MAX = 2.0
+    for field in ("s1", "s2"):
+        le = next(m.le for m in ContentLora.model_fields[field].metadata if hasattr(m, "le"))
+        assert le <= ENGINE_MAX, f"ContentLora.{field} allows {le} > engine {ENGINE_MAX}"
 
-    ENGINE_MAX = 2.0  # engine/app.py: content_s1/content_s2 Field(..., le=2.0)
+
+def test_the_list_is_capped_to_match_the_engine():
+    """LtxRequest.loras caps at 4; the content chain should not exceed it either. Four LoRAs
+    on one chain is already a lot of competition for the same weights."""
     for model in (LtxRecipeCreate, LtxRecipeUpdate):
-        for field in ("content_s1", "content_s2"):
-            meta = model.model_fields[field].metadata
-            le = next(m.le for m in meta if hasattr(m, "le"))
-            assert le <= ENGINE_MAX, f"{model.__name__}.{field} allows {le} > engine {ENGINE_MAX}"
+        meta = model.model_fields["content_loras"].metadata
+        mx = next((m.max_length for m in meta if hasattr(m, "max_length")), None)
+        assert mx == 4, f"{model.__name__}.content_loras is not capped at 4"


### PR DESCRIPTION
Implements console#410. Storage half; pairs with the engine, daemon and console branches.

Motion, act and framing are separable, so a pose may want several. Migration 083 replaces `content_lora` + `content_s1` + `content_s2` with a JSONB list of `{name, s1, s2}` — three scalar columns don't extend to N.

### The migration is the point

Every existing pose must render exactly as it does now. Verified against real rows, both directions:

```
before   content_lora=sfbehind_LTX2_3_v0_1  s1=0.35  s2=1.25
after    [{"name": "sfbehind_LTX2_3_v0_1", "s1": 0.35, "s2": 1.25}]
back     ('sfbehind_LTX2_3_v0_1', 0.35, 1.25)
```

`"none"` and NULL both become `[]`, because the engine reads both as "render without one" and a list containing `"none"` would be a filename lookup for a file that doesn't exist.

The downgrade keeps only the **first** — the old shape can't hold more. Lossy by nature, and stated as such in the migration.

### Order is significant

A JSONB array preserves it, and it *is* the application order. Two poses with the same LoRAs in a different order are different configurations. Not a set.

### Defaults

Each entry defaults to **0.6/0.6** — what `resolve()` hardcoded before any of this was configurable — so naming a LoRA and touching nothing renders it at the strength the validated graph already applied. That's what keeps four LoRAs from being eight decisions.

Capped at 4 to match `LtxRequest.loras`' own `max_length`, pinned by test. Strength bound stays 2.0 to match the engine — a looser bound here would accept a value the console stores happily and the engine then 422s ten minutes into a claimed segment.

662 tests. Migration upgrades and downgrades cleanly.