### PR TITLE
captions: ask Automatic1111 for the GPU back when a caption cannot load

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -39,6 +39,18 @@ class Settings(BaseSettings):
     # Generous next to a 4.5 s cold caption. It is here to stop a wedged or unreachable
     # captioner holding a request open, not to bound normal work.
     joycaption_timeout_s: int = 60
+    # Automatic1111 on the same 2070, so a caption can ask it for the card back.
+    #
+    # The keep_alive above makes JoyCaption yield to A1111. Nothing made A1111 yield back,
+    # and it holds its checkpoint whether or not it is generating — which is enough on its
+    # own to abort a caption. See _yield_the_gpu in app/joycaption.py for the measurements.
+    #
+    # Empty disables it: anywhere the captioner does not share a card with A1111, there is
+    # nothing to ask and nothing to reload.
+    a1111_url: str = "http://2070.zero:7860"
+    # Unloading is a few seconds of torch teardown. Short, because failing to free the card
+    # only costs the caption, which is never fatal to a render.
+    a1111_yield_timeout_s: int = 20
     cors_origins: str = ""
     login_rate_limit: str = "5/minute"
     heartbeat_offline_seconds: int = 120

--- a/app/joycaption.py
+++ b/app/joycaption.py
@@ -17,7 +17,7 @@ WHY AN UNCENSORED MODEL
 WHERE IT RUNS
     The 2070, not a render box. The 3090 sits at ~23 of 24 GB while rendering. The 2070 also
     hosts Automatic1111, which is why keep_alive is short: a resident 5.5 GB model would
-    starve image generation.
+    starve image generation. Sharing goes both ways now — see _yield_the_gpu.
 """
 import base64
 import hashlib
@@ -107,6 +107,59 @@ def image_key(image_bytes: bytes, instruction: str) -> str:
     return h.hexdigest()
 
 
+async def _yield_the_gpu() -> bool:
+    """Ask Automatic1111 for the card back. True if it actually let go.
+
+    The 2070 is shared, and the sharing was one-directional: joycaption_keep_alive is 5s so
+    a caption releases VRAM the moment it is done, while A1111 holds its checkpoint until
+    told otherwise — idle or not. That is enough on its own to abort a caption.
+
+    MEASURED on the 2070, an 8192 MiB card:
+
+        JoyCaption at load    ~5970 MiB   3992 weights + 512 KV + 669 compute + 800 vision
+        A1111 idle, loaded    ~1720-1850 MiB
+
+    They do not fit. The load gets as far as the vision projector, the last 800 MiB
+    cudaMalloc fails, ggml aborts the runner, and ollama reports it as
+
+        llama runner process has terminated: %!w(<nil>)
+
+    which names neither the GPU nor the memory, and reads like a broken model. Both times it
+    happened here the card was NOT busy — A1111 was idle with a checkpoint resident, which
+    is simply its state between generations.
+
+    A1111 reloads its checkpoint from RAM on its next generation, a few seconds. That is the
+    right trade against a caption that cannot run at all — but only when it buys something,
+    which is why this is called on failure rather than before every caption. A burst of
+    captions coalesces inside the 5s keep_alive and never disturbs A1111 at all.
+
+    NOTHING HERE IS FATAL. An absent A1111 is the normal case anywhere else and returns
+    False, exactly like one that refuses: both mean the retry has no reason to behave
+    differently, so there is no retry.
+    """
+    base = settings.a1111_url.rstrip("/")
+    if not base:
+        return False
+    try:
+        async with httpx.AsyncClient(timeout=settings.a1111_yield_timeout_s) as client:
+            # Never interrupt work in progress. Unloading mid-generation would take down
+            # somebody's image to caption a frame, and the caption is the less urgent of the
+            # two — it has a fallback, the generation does not.
+            busy = await client.get(f"{base}/sdapi/v1/progress")
+            if busy.status_code == 200 and (busy.json().get("state") or {}).get("job_count"):
+                logger.info("A1111 is generating; leaving its checkpoint alone")
+                return False
+            resp = await client.post(f"{base}/sdapi/v1/unload-checkpoint")
+            if resp.status_code != 200:
+                logger.warning("A1111 refused to unload: %s", resp.status_code)
+                return False
+    except httpx.HTTPError as e:
+        logger.info("A1111 not reachable at %s (%s) — nothing to free", base, e)
+        return False
+    logger.info("A1111 released its checkpoint; retrying the caption")
+    return True
+
+
 async def describe(image_bytes: bytes, instruction: str) -> str:
     """Caption one image. Raises CaptionError; callers must treat that as non-fatal."""
     payload = {
@@ -120,6 +173,12 @@ async def describe(image_bytes: bytes, instruction: str) -> str:
     try:
         async with httpx.AsyncClient(timeout=settings.joycaption_timeout_s) as client:
             resp = await client.post(url, json=payload)
+            # ollama answers 500 for a runner that died loading, which on this box is
+            # almost always the GPU rather than the model. Ask the other tenant to let go
+            # and try once more; if nothing was freed, the second attempt would fail
+            # identically, so it is not made.
+            if resp.status_code == 500 and await _yield_the_gpu():
+                resp = await client.post(url, json=payload)
     except httpx.HTTPError as e:
         raise CaptionError(f"captioner unreachable at {settings.joycaption_url}: {e}") from e
     if resp.status_code != 200:

--- a/tests/test_caption_gpu_yield.py
+++ b/tests/test_caption_gpu_yield.py
@@ -1,0 +1,146 @@
+"""A caption asks Automatic1111 for the GPU back, once, and only when that would help.
+
+The 2070 hosts both. JoyCaption needs ~5970 MiB of an 8192 MiB card; A1111 sitting idle
+with a checkpoint loaded holds ~1800. The load dies allocating the vision projector and
+ollama reports it as `llama runner process has terminated: %!w(<nil>)` — a 500 that names
+neither the GPU nor the memory, which is why this is worth a test rather than a comment.
+
+Every case here is about NOT overreaching: one retry, never mid-generation, and no retry at
+all when nothing was actually freed.
+"""
+import httpx
+import pytest
+
+from app.config import settings
+from app.joycaption import CaptionError, describe
+
+RUNNER_DIED = '{"error":"llama runner process has terminated: %!w(<nil>)"}'
+
+
+class _Resp:
+    def __init__(self, status=200, payload=None, text=""):
+        self.status_code = status
+        self._payload = payload if payload is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _Client:
+    """Stands in for httpx.AsyncClient. One queue of responses, one log of calls."""
+
+    calls: list = []
+    responses: list = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, json=None):
+        _Client.calls.append(("POST", url))
+        return _Client.responses.pop(0)
+
+    async def get(self, url):
+        _Client.calls.append(("GET", url))
+        return _Client.responses.pop(0)
+
+
+def _install(monkeypatch, *responses):
+    _Client.calls = []
+    _Client.responses = list(responses)
+    monkeypatch.setattr(settings, "a1111_url", "http://2070.test:7860")
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _Client())
+
+
+def _caption(text="a woman on a sofa"):
+    return _Resp(payload={"response": text})
+
+
+def _idle():
+    return _Resp(payload={"state": {"job_count": 0}})
+
+
+def _generating():
+    return _Resp(payload={"state": {"job_count": 1}})
+
+
+def _urls(method=None):
+    return [u for m, u in _Client.calls if method is None or m == method]
+
+
+class TestTheHappyPath:
+    async def test_a_caption_that_works_never_touches_a1111(self, monkeypatch):
+        """The fast path must stay free. A burst of captions coalesces inside the 5s
+        keep_alive, and unloading A1111 before each one would thrash a checkpoint reload for
+        nothing."""
+        _install(monkeypatch, _caption())
+        assert await describe(b"img", "describe this") == "a woman on a sofa"
+        assert all("7860" not in u for u in _urls())
+
+
+class TestYieldingOnFailure:
+    async def test_a_500_frees_the_card_and_retries_once(self, monkeypatch):
+        _install(monkeypatch, _Resp(status=500, text=RUNNER_DIED), _idle(),
+                 _Resp(), _caption())
+        assert await describe(b"img", "d") == "a woman on a sofa"
+        assert _urls() == [
+            "http://2070.test:11434/api/generate",
+            "http://2070.test:7860/sdapi/v1/progress",
+            "http://2070.test:7860/sdapi/v1/unload-checkpoint",
+            "http://2070.test:11434/api/generate",
+        ]
+
+    async def test_the_retry_is_not_a_loop(self, monkeypatch):
+        """A second failure is a real failure. Freeing the card twice would just be two
+        checkpoint reloads for one caption nobody is going to get."""
+        _install(monkeypatch, _Resp(status=500, text=RUNNER_DIED), _idle(),
+                 _Resp(), _Resp(status=500, text=RUNNER_DIED))
+        with pytest.raises(CaptionError, match="500"):
+            await describe(b"img", "d")
+        assert _urls().count("http://2070.test:11434/api/generate") == 2
+
+
+class TestNotOverreaching:
+    async def test_a_generating_a1111_is_left_alone(self, monkeypatch):
+        """Unloading mid-generation takes down somebody's image to caption a frame. The
+        caption has a fallback; the generation does not."""
+        _install(monkeypatch, _Resp(status=500, text=RUNNER_DIED), _generating())
+        with pytest.raises(CaptionError, match="500"):
+            await describe(b"img", "d")
+        assert "http://2070.test:7860/sdapi/v1/unload-checkpoint" not in _urls()
+
+    async def test_no_a1111_configured_means_no_retry(self, monkeypatch):
+        """Anywhere the captioner does not share a card, there is nothing to ask — and a
+        retry against an unchanged GPU would fail identically."""
+        _install(monkeypatch, _Resp(status=500, text=RUNNER_DIED))
+        monkeypatch.setattr(settings, "a1111_url", "")
+        with pytest.raises(CaptionError, match="500"):
+            await describe(b"img", "d")
+        assert _urls() == ["http://2070.test:11434/api/generate"]
+
+    async def test_an_unreachable_a1111_is_not_an_error(self, monkeypatch):
+        """The original 500 is what the caller needs to see, not a connection error to a
+        service that has nothing to do with captioning."""
+        _install(monkeypatch, _Resp(status=500, text=RUNNER_DIED))
+        monkeypatch.setattr(_Client, "get", _boom)
+        with pytest.raises(CaptionError, match="runner process has terminated"):
+            await describe(b"img", "d")
+
+    async def test_a1111_refusing_to_unload_does_not_trigger_a_retry(self, monkeypatch):
+        _install(monkeypatch, _Resp(status=500, text=RUNNER_DIED), _idle(),
+                 _Resp(status=500))
+        with pytest.raises(CaptionError, match="500"):
+            await describe(b"img", "d")
+        assert _urls().count("http://2070.test:11434/api/generate") == 1
+
+
+async def _boom(self, url):
+    raise httpx.ConnectError("connection refused")
+
+
+@pytest.fixture(autouse=True)
+def _point_at_a_test_captioner(monkeypatch):
+    monkeypatch.setattr(settings, "joycaption_url", "http://2070.test:11434")


### PR DESCRIPTION
Fixes the `captioner returned 500: {"error":"llama runner process has terminated: %!w(<nil>)"}` seen twice today in the console.

## What is actually happening

Not a broken model and not a stopped ollama — ollama was up and serving throughout. The per-model *runner* aborted, and the journal on 2070.zero says why:

```
ggml_backend_cuda_buffer_type_alloc_buffer: allocating 800.40 MiB on device 0: cudaMalloc failed: out of memory
alloc_tensor_range: failed to allocate CUDA0 buffer of size 839282176
ggml-backend.cpp:199: GGML_ASSERT(buffer) failed
SIGABRT: abort
```

Measured on that 8192 MiB card:

| | MiB |
|---|---|
| JoyCaption at load — 3992 weights + 512 KV + 669 compute + **800 vision projector** | ~5970 |
| A1111 **idle**, checkpoint resident | ~1800 |

They do not fit. The load gets as far as the vision projector and dies on the last allocation. Ollama surfaces that as a 500 naming neither the GPU nor the memory.

The sharing was one-directional by design — `joycaption_keep_alive` is 5s so a caption gives the card back immediately — but nothing made A1111 yield back, and it holds its checkpoint whether or not it is generating. Both failures today were against an idle A1111 (`job_count 0`).

## The change

A 500 from the captioner now asks A1111 to `unload-checkpoint` and retries once.

- **On failure, not before every caption.** Keeps the fast path free, and a burst of captions inside the 5s keep_alive never disturbs A1111 at all. Same reasoning as `ltx-engine`'s `free_the_gpu` for keyframe-server on the 3090: pay the reload only when it buys something.
- **Never mid-generation.** `/sdapi/v1/progress` first; a busy A1111 is left alone. The caption has a fallback, somebody's in-flight image does not.
- **One retry, not a loop.** No retry at all when nothing was freed — the second attempt would fail identically.
- **Absent A1111 is not an error.** `A1111_URL=""` disables it; unreachable is logged and the original captioner error is what the caller sees.

A1111 reloads its checkpoint from RAM on its next generation, a few seconds.

**Verified:** `python -m pytest -q` → 536 passed, 115 skipped (DB tests, unchanged); 7 new tests in `tests/test_caption_gpu_yield.py` cover the happy path staying clean, the yield-and-retry, the no-loop, the generating case, unconfigured, unreachable, and a refusal. `ruff check` clean on the changed files.

Manual, on the box: unloading A1111's checkpoint dropped the card 1850 → 160 MiB and JoyCaption then loaded and answered in 2.8s.

https://claude.ai/code/session_011m6VWR2d8jn7hMQ2xQthPR