### PR TITLE
claims: a worker is only handed segments whose models it can load

### DIFF
--- a/alembic/versions/085_worker_fetchable_kinds.py
+++ b/alembic/versions/085_worker_fetchable_kinds.py
@@ -1,0 +1,31 @@
+"""Artifact kinds a worker can fetch on demand
+
+Revision ID: 085
+Revises: 084
+Create Date: 2026-09-05
+
+console#422. The claim gate refuses a segment whose models the polling worker cannot load,
+and it needs to know which of those the worker could simply go and GET. The daemon already
+downloads LoRAs a pose names but this worker has never seen, so LoRAs must not gate.
+
+Reported by the worker rather than assumed by the API: when the daemon learns to fetch
+checkpoints (console#423) it starts sending "checkpoint" here and the gate opens with no API
+change. NULL means never reported, read as "fetches nothing" — the direction that keeps an
+older daemon claiming the work it can already run.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "085"
+down_revision = "084"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("workers", sa.Column("fetchable_kinds", postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "fetchable_kinds")

--- a/app/model_requirements.py
+++ b/app/model_requirements.py
@@ -1,0 +1,139 @@
+"""What a segment needs on disk, and whether a given worker has it.
+
+wanly-console#422. A RunPod pod carries `sulphur_dev_bf16` and nothing else. A pose whose
+base model is `10Eros_v1.5_bf16` was handed to it anyway, the start image was uploaded, and
+ComfyUI then rejected the graph across three loaders — after the claim, so the segment
+failed and the job stalled beside a 3090 that had the file all along.
+
+THE REQUIREMENT IS READ, NEVER INFERRED. Nothing here looks for a substring in a recipe
+name, a pose name or a filename. `Segment.ltx_recipe` is a snapshot with explicit keys —
+`checkpoint`, `char_lora`, `content_loras[].name` — and those keys are the entire source.
+A heuristic that recognises `10Eros_v1.5_bf16` today would fail to recognise `10Eros_v2`
+tomorrow, and it would fail as a PASS: the segment would be claimed by a worker that cannot
+run it, which is the bug this exists to remove.
+
+THREE CONCEPTS:
+
+    Requirement   Artifact(kind, name), extracted from declared recipe fields.
+    Inventory     what a worker reports it can load, per kind.
+    Fetchable     kinds a worker can OBTAIN on demand, declared by the worker.
+
+and one rule:
+
+    required - (inventory | artifacts of fetchable kinds) == empty
+
+Fetchability is declared by the worker rather than assumed here. The daemon fetches LoRAs at
+claim time already (daemon/lora_sync.py), so LoRAs must not gate; when it learns to fetch
+checkpoints (console#423) it will say so in its heartbeat and this gate opens on its own,
+with no change here and no coordinated deploy. That seam is the point: the API never holds a
+second opinion about what a daemon can do.
+"""
+from dataclasses import dataclass
+
+from app.ltx_stack import LTX_STACK
+
+CHECKPOINT = "checkpoint"
+LORA = "lora"
+
+_EXT = ".safetensors"
+
+
+@dataclass(frozen=True, order=True)
+class Artifact:
+    """One file a render needs, and what kind of file it is.
+
+    Frozen and ordered so these can live in sets and be reported in a stable order — a
+    blocked segment's message must read the same on every poll.
+    """
+
+    kind: str
+    name: str
+
+    def __str__(self) -> str:
+        return f"{self.kind} '{self.name}'"
+
+
+def canonical(name: str) -> str:
+    """One spelling for a file that is written two ways.
+
+    Recipes and the console store bare stems (`sulphur_dev_bf16`); ComfyUI names files
+    (`sulphur_dev_bf16.safetensors`), and the daemon strips the extension before reporting
+    so the two agree. Both sides are normalised here anyway, because if that convention ever
+    drifts the gate does not fail loudly — it silently matches nothing, and a fleet that
+    claims no work looks exactly like an empty queue.
+    """
+    n = (name or "").strip()
+    return n[: -len(_EXT)] if n.endswith(_EXT) else n
+
+
+def required_artifacts(ltx_recipe: dict | None) -> set[Artifact]:
+    """Everything `ltx_recipe` says this segment needs.
+
+    A NULL recipe means "not a recipe render" — a WAN segment, a free-form LTX one, or a CPU
+    reprocess carrier. Those declare nothing, so they require nothing and are never gated.
+    That is deliberately conservative: this must not withhold work that flows today.
+
+    A recipe with no `checkpoint` key predates per-pose base models and renders on the
+    stack's, so the default is resolved HERE rather than at the call sites, where three
+    copies of `or LTX_STACK["checkpoint"]` would eventually become two.
+    """
+    if not ltx_recipe:
+        return set()
+
+    out: set[Artifact] = set()
+
+    ckpt = canonical(str(ltx_recipe.get("checkpoint") or ""))
+    out.add(Artifact(CHECKPOINT, ckpt or canonical(LTX_STACK["checkpoint"])))
+
+    # "none" is a real, chosen value in this schema — the CHARACTER dropdown offers it
+    # (console#413/#416) and the stack's content_lora is the literal string "none". It means
+    # no LoRA, so it must never become a requirement for a file called "none.safetensors",
+    # which is precisely the bug wanly-gpu-docker#68 fixed downstream.
+    for raw in [ltx_recipe.get("char_lora"), *_content_lora_names(ltx_recipe)]:
+        name = canonical(str(raw or ""))
+        if name and name.lower() != "none":
+            out.add(Artifact(LORA, name))
+
+    return out
+
+
+def _content_lora_names(ltx_recipe: dict) -> list[str]:
+    """Content LoRAs are a list of objects, and have been a list of one string before now.
+
+    Tolerant on read because segments rendered under the older shape are still in the
+    database and still re-rollable; a KeyError here would take down a job page.
+    """
+    out: list[str] = []
+    for entry in ltx_recipe.get("content_loras") or []:
+        if isinstance(entry, dict):
+            out.append(str(entry.get("name") or ""))
+        elif isinstance(entry, str):
+            out.append(entry)
+    return out
+
+
+def unsatisfied(
+    required: set[Artifact],
+    inventory: dict[str, set[str]],
+    fetchable_kinds: list[str] | None,
+) -> set[Artifact]:
+    """What this worker can neither load nor get. Empty means it may claim the segment.
+
+    A kind ABSENT from `inventory` is unknown, not empty, and does not gate. An older daemon
+    reports no checkpoints at all, and starving it of work on an upgrade day would be a
+    worse failure than the one being fixed — it would look like a dead queue. `Worker`
+    stores NULL for never-reported for the same reason.
+    """
+    fetchable = {k.strip() for k in (fetchable_kinds or [])}
+    return {
+        a
+        for a in required
+        if a.kind not in fetchable
+        and a.kind in inventory
+        and canonical(a.name) not in {canonical(n) for n in inventory[a.kind]}
+    }
+
+
+def describe(missing: set[Artifact]) -> str:
+    """One line naming what is missing, for a person reading a stalled job page."""
+    return ", ".join(str(a) for a in sorted(missing))

--- a/app/models.py
+++ b/app/models.py
@@ -293,6 +293,13 @@ class Worker(Base):
     # discovered: the engine binds to localhost, so the daemon is the only thing that can
     # ask. NULL means never reported — not the same as none available. See console#404.
     checkpoints: Mapped[list | None] = mapped_column(JSONB, nullable=True, default=None)
+    # Artifact kinds this worker can FETCH on demand, as it reports them: today ["lora"],
+    # because the daemon downloads a LoRA a pose names but this worker has never seen. It is
+    # declared by the worker rather than assumed by the API so that a daemon which learns to
+    # fetch checkpoints (console#423) opens the claim gate by saying so — no API change, and
+    # no second opinion here about what a daemon can do. NULL means never reported, which
+    # this treats as fetching nothing. See app/model_requirements.py.
+    fetchable_kinds: Mapped[list | None] = mapped_column(JSONB, nullable=True, default=None)
     drain_after_jobs: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -20,7 +20,13 @@ from app.database import get_db
 from app.enums import JOB_VALID_TRANSITIONS, JobStatus, SegmentStatus, VideoStatus
 from app.seeds import new_seed
 from app.estimation import estimate_segment_time, get_estimation_rates, sum_estimated_queue_time
-from app.models import Job, Segment, User, Video
+from app.models import Job, Segment, User, Video, Worker
+from app.model_requirements import (
+    CHECKPOINT,
+    describe,
+    required_artifacts,
+    unsatisfied,
+)
 from app.routes.segments import _resolve_wildcards
 from app.s3 import delete_object, delete_prefix, delete_prefix_except, upload_bytes
 from app.tag_filter import like_escape, tag_clause
@@ -454,6 +460,51 @@ async def reorder_jobs(
     return ordered
 
 
+
+async def _annotate_blocked(db: AsyncSession, segments, seg_responses) -> None:
+    """Say why a PENDING segment is going nowhere, when the answer is "no worker has it".
+
+    console#422. The claim gate turns a loud failure into a silent one: a segment whose base
+    model is on no online worker now sits PENDING forever beside an idle fleet, and that
+    looks exactly like an empty queue. This is the other half of that feature, not a nicety
+    — shipping the gate without it trades a visible failure for an invisible one.
+
+    Computed per request rather than stored. It is a fact about the fleet at this moment: a
+    column would say "blocked" for as long as it took someone to notice a worker with the
+    file had come online, which is the same staleness in a more expensive form.
+
+    Silent when nothing has reported an inventory. An older daemon reports no checkpoints at
+    all, and "no online worker can load X" would then be a guess dressed as a diagnosis.
+    """
+    pending = [s for s in segments
+               if s.status == SegmentStatus.PENDING and s.ltx_recipe]
+    if not pending:
+        return
+
+    workers = (await db.execute(
+        select(Worker).where(Worker.status != "offline")
+    )).scalars().all()
+    fleet = [w for w in workers if w.checkpoints is not None]
+    if not fleet:
+        return
+
+    by_id = {sr.id: sr for sr in seg_responses}
+    for seg in pending:
+        required = required_artifacts(seg.ltx_recipe)
+        misses = [
+            unsatisfied(required, {CHECKPOINT: set(w.checkpoints or [])}, w.fetchable_kinds)
+            for w in fleet
+        ]
+        if any(not m for m in misses):
+            continue
+        # The closest worker's shortfall, not the union of everybody's. "The 3090 is one file
+        # short" is a fix; "the fleet collectively lacks five things" is a shrug.
+        response = by_id.get(seg.id)
+        if response is not None:
+            response.blocked_reason = f"No online worker can load {describe(min(misses, key=len))}"
+
+
+
 @router.get("/jobs/{job_id}", response_model=JobDetailResponse)
 async def get_job(
     job_id: UUID,
@@ -496,6 +547,8 @@ async def get_job(
             seg_responses.append(sr)
     else:
         seg_responses = [SegmentResponse.model_validate(s) for s in segments]
+
+    await _annotate_blocked(db, segments, seg_responses)
 
     return JobDetailResponse(
         id=job.id,
@@ -638,6 +691,8 @@ async def reopen_job(
             seg_responses.append(sr)
     else:
         seg_responses = [SegmentResponse.model_validate(s) for s in segments]
+
+    await _annotate_blocked(db, segments, seg_responses)
 
     return JobDetailResponse(
         id=job.id, name=job.name, width=job.width, height=job.height,

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
-from sqlalchemy import and_, or_, select, text
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -23,6 +23,8 @@ from app.database import get_db
 from app.routes.captions import caption_image_bytes
 from app.seeds import new_seed
 from app.enums import JobStatus, SegmentStatus, VideoStatus
+from app.ltx_stack import LTX_STACK
+from app.model_requirements import CHECKPOINT, canonical
 from app.models import AppSetting, Job, LtxCharacter, Segment, User, Video, Wildcard, Worker
 from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
@@ -295,6 +297,51 @@ async def add_segment(
     return segment
 
 
+def _model_gate(worker: Worker | None) -> tuple:
+    """SQL that hides segments this worker cannot render. console#422.
+
+    A pod carries sulphur and nothing else. Before this, it claimed a 10Eros pose anyway,
+    uploaded the start image, and ComfyUI rejected the graph across three loaders — after the
+    claim, so the segment failed and the job stalled beside a 3090 that had the file.
+
+    IN THE QUERY, not after it. Filtering the selected row in Python would either re-pick the
+    same unrunnable segment on every poll — head-of-line blocking, with the whole queue behind
+    it — or need a second SELECT that breaks the skip-locked concurrency the claim depends on.
+
+    Three things deliberately do NOT gate:
+
+      * a NULL ltx_recipe. Not a recipe render: a WAN segment, a free-form LTX one, or a CPU
+        reprocess carrier. It declares no models, so it requires none. Conservative on
+        purpose — this must not withhold work that flows today.
+      * a worker that has never reported its checkpoints (NULL, not []). An older daemon
+        would otherwise starve on upgrade day, and a fleet claiming nothing looks exactly
+        like an empty queue.
+      * a kind the worker says it can fetch. It already downloads LoRAs at claim time; when
+        it learns to fetch checkpoints (console#423) this stops gating on its own.
+
+    Inventory comes from the last heartbeat rather than the claim request: the poll is
+    frequent and the inventory is not. The staleness window is one heartbeat, and a claim
+    made against a stale one degrades to exactly the old behaviour — a loud engine failure —
+    rather than to something worse.
+    """
+    if worker is None or worker.checkpoints is None:
+        return ()
+    if CHECKPOINT in (worker.fetchable_kinds or []):
+        return ()
+
+    names = {canonical(n) for n in worker.checkpoints if isinstance(n, str) and n.strip()}
+    # Both spellings. Recipes store a bare stem and the daemon strips the extension before
+    # reporting, so these agree today; if that convention ever drifts the gate does not fail
+    # loudly, it silently matches nothing and the worker claims no work at all.
+    names |= {f"{n}.safetensors" for n in names}
+
+    checkpoint = func.coalesce(
+        func.nullif(Segment.ltx_recipe["checkpoint"].astext, ""),
+        canonical(LTX_STACK["checkpoint"]),
+    )
+    return (or_(Segment.ltx_recipe.is_(None), checkpoint.in_(names)),)
+
+
 @router.get("/segments/next", dependencies=[Depends(verify_api_key)])
 async def claim_next_segment(
     worker_id: UUID = Query(...),
@@ -421,10 +468,14 @@ async def claim_next_segment(
                 Segment.reprocess_type.in_(_CPU_REPROCESS_TYPES),
             ),
         )
+    # Read once, used twice: the gate needs this worker's inventory before the query, and the
+    # GPU name is snapshotted off the same row after it.
+    claiming_worker = await db.get(Worker, worker_id)
+
     result = await db.execute(
         select(Segment)
         .join(Job, Segment.job_id == Job.id)
-        .where(*where)
+        .where(*where, *_model_gate(claiming_worker))
         .order_by(Job.priority.asc(), Segment.created_at.asc())
         .limit(1)
         .with_for_update(skip_locked=True)
@@ -442,7 +493,6 @@ async def claim_next_segment(
     # Snapshot the GPU now, not at read time. Worker rows are deleted on deregister — every
     # RunPod pod takes its row with it when it drains — so a later join would silently lose the
     # hardware for every segment a since-terminated pod ran.
-    claiming_worker = await db.get(Worker, worker_id)
     if claiming_worker and claiming_worker.gpu_stats:
         segment.gpu_name = claiming_worker.gpu_stats.get("gpu_name")
 

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -162,6 +162,8 @@ async def heartbeat(
     # reported it.
     if body.checkpoints is not None:
         worker.checkpoints = body.checkpoints
+    if body.fetchable_kinds is not None:
+        worker.fetchable_kinds = body.fetchable_kinds
     if worker.status == "offline":
         worker.status = "online-idle"
     # If sd-scripts is actively training, worker can't be idle

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -99,6 +99,14 @@ class SegmentResponse(BaseModel):
     error_message: Optional[str]
     progress_log: Optional[str]
     estimated_run_time: Optional[float] = None
+    # Why a PENDING segment is not being picked up: the models it names are on no online
+    # worker (console#422). Computed on read, not stored — it is a fact about the fleet right
+    # now, and a column would go stale the moment a worker with the file came online.
+    #
+    # None means "nothing to say", which covers both "somebody can run it" and "nothing has
+    # reported an inventory yet". Only the job detail route fills this in; every other
+    # construction leaves the default, which is why it HAS one.
+    blocked_reason: Optional[str] = None
 
     model_config = {"from_attributes": True}
 

--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -25,6 +25,11 @@ class WorkerHeartbeat(BaseModel):
     loras: dict[str, Any] | None = None
     # Base models this worker can load. Optional so an older daemon still heartbeats.
     checkpoints: list[str] | None = None
+    # Artifact kinds this worker can fetch on demand ("lora" today). Optional, like every
+    # field before it: an older daemon that sends nothing must keep heartbeating rather than
+    # 422 itself out of the pool on upgrade day. Absent is read as "fetches nothing", which
+    # is the safe direction — it can still claim work whose files it already holds.
+    fetchable_kinds: list[str] | None = None
 
 
 class WorkerRename(BaseModel):

--- a/tests/test_claim_model_gate.py
+++ b/tests/test_claim_model_gate.py
@@ -1,0 +1,217 @@
+"""A worker is only handed segments whose models it can load (console#422).
+
+Driven over HTTP against a real database, like test_claim_endpoint.py and for the same
+reason: the gate is a WHERE clause, and a predicate that compiles is not a predicate that
+matches. The failure it guards against is a pod claiming a 10Eros pose it cannot load —
+after the claim, so the segment fails and the job stalls beside a 3090 that has the file.
+
+The failure THIS could introduce is worse, which is why half these tests are about work
+still flowing: a gate that matches nothing turns the whole fleet silent, and a silent fleet
+is indistinguishable from an empty queue.
+"""
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.auth import get_current_user, verify_api_key
+from app.database import get_db
+from app.enums import JobStatus, SegmentStatus
+from app.main import app
+from app.models import Job, Segment, User, Worker
+
+WORKER_ID = uuid.UUID("2f5a3c4e-0b1d-4a7e-9c88-1c2f3a4b5c6d")
+
+
+async def _user(db) -> User:
+    user = User(username=str(uuid.uuid4()), password_hash="x")
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _job(db, user) -> Job:
+    job = Job(user_id=user.id, name="j", width=480, height=832, fps=16, seed=1000,
+              priority=0, status=JobStatus.PENDING, starting_image="s3://b/start.png")
+    db.add(job)
+    await db.flush()
+    return job
+
+
+async def _segment(db, job, *, recipe, index=0) -> Segment:
+    seg = Segment(job_id=job.id, index=index, prompt="p", status=SegmentStatus.PENDING,
+                  discarded=False, ltx_recipe=recipe)
+    db.add(seg)
+    await db.flush()
+    return seg
+
+
+async def _worker(db, *, checkpoints, fetchable=None) -> Worker:
+    worker = Worker(
+        id=WORKER_ID, friendly_name="pod-1", hostname="pod-1", ip_address="10.0.0.9",
+        status="online-idle",
+        last_heartbeat=datetime.now(timezone.utc), checkpoints=checkpoints,
+        fetchable_kinds=fetchable,
+    )
+    db.add(worker)
+    await db.flush()
+    return worker
+
+
+async def _claim(db):
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[verify_api_key] = lambda: None
+    try:
+        for obj in list(db.identity_map.values()):
+            if isinstance(obj, (Job, Segment, Worker)):
+                db.expire(obj)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            return await c.get("/segments/next", params={
+                "worker_id": str(WORKER_ID), "worker_name": "pod-1", "kind": "gpu",
+            })
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def _job_detail(db, owner, job):
+    # Read the id BEFORE expiring: touching an expired attribute outside the route's own
+    # greenlet triggers a synchronous lazy load and raises MissingGreenlet.
+    url = f"/jobs/{job.id}"
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: owner
+    try:
+        for obj in list(db.identity_map.values()):
+            if isinstance(obj, (Job, Segment, Worker)):
+                db.expire(obj)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            return await c.get(url)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+class TestTheGate:
+    async def test_a_pod_is_not_handed_a_checkpoint_it_lacks(self, db):
+        """The incident: a pod holding only sulphur claimed a 10Eros pose, uploaded the start
+        image, and ComfyUI rejected the graph across three loaders."""
+        job = await _job(db, await _user(db))
+        await _segment(db, job, recipe={"checkpoint": "10Eros_v1.5_bf16"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+
+        resp = await _claim(db)
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() is None
+
+    async def test_the_worker_that_has_it_still_gets_it(self, db):
+        job = await _job(db, await _user(db))
+        seg = await _segment(db, job, recipe={"checkpoint": "10Eros_v1.5_bf16"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16", "10Eros_v1.5_bf16"],
+                      fetchable=["lora"])
+
+        assert (await _claim(db)).json()["id"] == str(seg.id)
+
+    async def test_a_blocked_segment_does_not_hide_a_runnable_one_behind_it(self, db):
+        """Head-of-line blocking, which is why the gate is a WHERE clause and not a check on
+        the row the query already picked. The older segment is unrunnable here; the queue
+        must not stop at it."""
+        user = await _user(db)
+        blocked_job = await _job(db, user)
+        await _segment(db, blocked_job, recipe={"checkpoint": "10Eros_v1.5_bf16"})
+        ok_job = await _job(db, user)
+        runnable = await _segment(db, ok_job, recipe={"checkpoint": "sulphur_dev_bf16"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+
+        assert (await _claim(db)).json()["id"] == str(runnable.id)
+
+    async def test_a_lora_it_has_never_seen_does_not_block_the_claim(self, db):
+        """The daemon downloads those at claim time. Gating on one would refuse work the
+        worker would have handled by itself."""
+        job = await _job(db, await _user(db))
+        seg = await _segment(db, job, recipe={"checkpoint": "sulphur_dev_bf16",
+                                              "char_lora": "never_uploaded_v9"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+
+        assert (await _claim(db)).json()["id"] == str(seg.id)
+
+    async def test_a_worker_that_can_fetch_checkpoints_is_not_gated(self, db):
+        """console#423's seam, from the outside."""
+        job = await _job(db, await _user(db))
+        seg = await _segment(db, job, recipe={"checkpoint": "10Eros_v1.5_bf16"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora", "checkpoint"])
+
+        assert (await _claim(db)).json()["id"] == str(seg.id)
+
+
+@pytest.mark.asyncio
+class TestWorkStillFlows:
+    async def test_an_older_daemon_reporting_no_inventory_still_claims(self, db):
+        """NULL checkpoints means never reported, not none available. Starving it would look
+        exactly like a dead queue on upgrade day."""
+        job = await _job(db, await _user(db))
+        seg = await _segment(db, job, recipe={"checkpoint": "10Eros_v1.5_bf16"})
+        await _worker(db, checkpoints=None)
+
+        assert (await _claim(db)).json()["id"] == str(seg.id)
+
+    async def test_a_segment_with_no_recipe_is_never_gated(self, db):
+        """A WAN segment or a free-form render declares no models, so it requires none."""
+        job = await _job(db, await _user(db))
+        seg = await _segment(db, job, recipe=None)
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+
+        assert (await _claim(db)).json()["id"] == str(seg.id)
+
+    async def test_a_recipe_without_a_checkpoint_runs_on_the_stack_default(self, db):
+        """Segments predating per-pose base models must keep flowing."""
+        job = await _job(db, await _user(db))
+        seg = await _segment(db, job, recipe={"recipe": "old", "char_lora": "k3llydw_v2"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+
+        assert (await _claim(db)).json()["id"] == str(seg.id)
+
+    async def test_either_spelling_of_the_checkpoint_matches(self, db):
+        job = await _job(db, await _user(db))
+        seg = await _segment(db, job, recipe={"checkpoint": "sulphur_dev_bf16.safetensors"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+
+        assert (await _claim(db)).json()["id"] == str(seg.id)
+
+
+@pytest.mark.asyncio
+class TestTheStallIsVisible:
+    async def test_a_job_page_says_why_nothing_is_picking_it_up(self, db):
+        """Without this the gate trades a loud failure for a silent one: PENDING forever,
+        beside an idle fleet, looking exactly like an empty queue."""
+        owner = await _user(db)
+        job = await _job(db, owner)
+        await _segment(db, job, recipe={"checkpoint": "10Eros_v1.5_bf16"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+
+        body = (await _job_detail(db, owner, job)).json()
+
+        assert body["segments"][0]["blocked_reason"] == \
+            "No online worker can load checkpoint '10Eros_v1.5_bf16'"
+
+    async def test_a_runnable_segment_says_nothing(self, db):
+        owner = await _user(db)
+        job = await _job(db, owner)
+        await _segment(db, job, recipe={"checkpoint": "sulphur_dev_bf16"})
+        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+
+        body = (await _job_detail(db, owner, job)).json()
+
+        assert body["segments"][0]["blocked_reason"] is None
+
+    async def test_no_reported_inventory_means_no_diagnosis(self, db):
+        """"No online worker can load X" would be a guess dressed as a diagnosis when nothing
+        has said what it holds."""
+        owner = await _user(db)
+        job = await _job(db, owner)
+        await _segment(db, job, recipe={"checkpoint": "10Eros_v1.5_bf16"})
+        await _worker(db, checkpoints=None)
+
+        body = (await _job_detail(db, owner, job)).json()
+
+        assert body["segments"][0]["blocked_reason"] is None

--- a/tests/test_model_requirements.py
+++ b/tests/test_model_requirements.py
@@ -1,0 +1,118 @@
+"""What a segment declares it needs, and whether a worker has it (console#422).
+
+The bug these prevent is silent in both directions. Extract too little and a pod claims a
+render it cannot load, which is the failure this replaced. Extract too much — a requirement
+for a LoRA called "none", say — and a segment nothing can satisfy sits PENDING forever
+beside an idle fleet, which looks exactly like an empty queue.
+"""
+from app.ltx_stack import LTX_STACK
+from app.model_requirements import (
+    CHECKPOINT,
+    LORA,
+    Artifact,
+    canonical,
+    describe,
+    required_artifacts,
+    unsatisfied,
+)
+
+
+class TestWhatARecipeDeclares:
+    def test_the_checkpoint_is_read_from_the_field_not_the_name(self):
+        """The entire point of the ticket: no code may infer a model from a recipe or file
+        name. A heuristic that recognises 10Eros_v1.5_bf16 misses 10Eros_v2 as a PASS."""
+        r = required_artifacts({"recipe": "Doggystyle 10Eros edition",
+                                "checkpoint": "sulphur_dev_bf16"})
+        assert r == {Artifact(CHECKPOINT, "sulphur_dev_bf16")}
+
+    def test_a_recipe_without_a_checkpoint_requires_the_stack_default(self):
+        """Segments predating per-pose base models. They render on the stack's checkpoint, so
+        that is what they require — resolving it here keeps three call sites from each
+        growing their own `or LTX_STACK[...]`."""
+        assert required_artifacts({"char_lora": "none"}) == {
+            Artifact(CHECKPOINT, canonical(LTX_STACK["checkpoint"]))
+        }
+
+    def test_character_and_content_loras_are_requirements_too(self):
+        r = required_artifacts({
+            "checkpoint": "sulphur_dev_bf16",
+            "char_lora": "k3llydw_v2",
+            "content_loras": [{"name": "d0ggyff", "s1": 0.8}, {"name": "SexGod", "s1": 0.6}],
+        })
+        assert r == {
+            Artifact(CHECKPOINT, "sulphur_dev_bf16"),
+            Artifact(LORA, "k3llydw_v2"),
+            Artifact(LORA, "d0ggyff"),
+            Artifact(LORA, "SexGod"),
+        }
+
+    def test_none_is_a_choice_not_a_file(self):
+        """"none" is a real value here — the CHARACTER dropdown offers it and the stack's
+        content_lora IS the string "none". Requiring none.safetensors would block every
+        segment that chose to run without one."""
+        r = required_artifacts({"checkpoint": "c", "char_lora": "none",
+                                "content_loras": [{"name": "None"}]})
+        assert r == {Artifact(CHECKPOINT, "c")}
+
+    def test_the_two_spellings_of_a_file_are_one_requirement(self):
+        """Recipes store a bare stem, ComfyUI names files. If those ever drift apart the gate
+        does not fail loudly — it matches nothing and the worker claims no work."""
+        assert required_artifacts({"checkpoint": "sulphur_dev_bf16.safetensors"}) == \
+               required_artifacts({"checkpoint": "sulphur_dev_bf16"})
+
+    def test_a_non_recipe_segment_requires_nothing(self):
+        """NULL ltx_recipe is a WAN segment, a free-form LTX one, or a CPU reprocess carrier.
+        Declaring nothing must mean requiring nothing — this may not withhold work that
+        already flows."""
+        assert required_artifacts(None) == set()
+        assert required_artifacts({}) == set()
+
+    def test_the_older_content_lora_shape_does_not_raise(self):
+        """Segments rendered before content LoRAs became objects are still in the database and
+        still re-rollable. A KeyError here would take down a job page."""
+        assert Artifact(LORA, "old") in required_artifacts(
+            {"checkpoint": "c", "content_loras": ["old"]}
+        )
+
+
+class TestWhatAWorkerCanRun:
+    CKPT = {CHECKPOINT: {"sulphur_dev_bf16", "ltx-2.3-22b-dev"}}
+
+    def test_a_missing_checkpoint_is_named(self):
+        r = required_artifacts({"checkpoint": "10Eros_v1.5_bf16"})
+        assert unsatisfied(r, self.CKPT, ["lora"]) == {Artifact(CHECKPOINT, "10Eros_v1.5_bf16")}
+
+    def test_a_checkpoint_it_holds_satisfies(self):
+        r = required_artifacts({"checkpoint": "sulphur_dev_bf16"})
+        assert unsatisfied(r, self.CKPT, ["lora"]) == set()
+
+    def test_loras_never_gate_because_the_worker_fetches_them(self):
+        """The daemon downloads a LoRA a pose names but this worker has never seen. Gating on
+        one would refuse work the worker would have handled by itself."""
+        r = required_artifacts({"checkpoint": "sulphur_dev_bf16", "char_lora": "brand_new"})
+        assert unsatisfied(r, self.CKPT, ["lora"]) == set()
+
+    def test_a_worker_that_learns_to_fetch_checkpoints_stops_being_gated(self):
+        """console#423's whole seam: the daemon says "checkpoint" and this opens, with no API
+        change and no coordinated deploy."""
+        r = required_artifacts({"checkpoint": "10Eros_v1.5_bf16"})
+        assert unsatisfied(r, self.CKPT, ["lora", "checkpoint"]) == set()
+
+    def test_an_unreported_kind_does_not_gate(self):
+        """An older daemon reports no checkpoints at all. Starving it on upgrade day would be
+        a worse failure than the one being fixed, and it would look like a dead queue."""
+        r = required_artifacts({"checkpoint": "10Eros_v1.5_bf16"})
+        assert unsatisfied(r, {}, []) == set()
+
+    def test_a_worker_reporting_an_empty_list_is_not_the_same_as_never_reporting(self):
+        r = required_artifacts({"checkpoint": "10Eros_v1.5_bf16"})
+        assert unsatisfied(r, {CHECKPOINT: set()}, []) == {Artifact(CHECKPOINT, "10Eros_v1.5_bf16")}
+
+    def test_either_spelling_in_the_inventory_satisfies(self):
+        r = required_artifacts({"checkpoint": "sulphur_dev_bf16"})
+        assert unsatisfied(r, {CHECKPOINT: {"sulphur_dev_bf16.safetensors"}}, []) == set()
+
+    def test_the_message_names_the_kind_and_the_file(self):
+        """It is read off a stalled job page by someone deciding what to do next."""
+        assert describe({Artifact(CHECKPOINT, "10Eros_v1.5_bf16")}) == \
+               "checkpoint '10Eros_v1.5_bf16'"


### PR DESCRIPTION
Implements the API half of DavidJBarnes/wanly-console#422. Pairs with wanly-gpu-daemon `feat/report-fetchable-kinds` and wanly-console `feat/blocked-segment-reason` — **merge the daemon PR first or alongside**, see Ordering below.

## The failure

A pod carries `sulphur_dev_bf16` and nothing else. A pose whose base model is `10Eros_v1.5_bf16` was claimed by it anyway, the start image uploaded, and ComfyUI then rejected the graph across three loaders — *after* the claim, so the segment failed and the job stalled next to a 3090 that had the file all along.

## What was already here

Nothing needed inventing; the pieces just were not wired together:

- `Segment.ltx_recipe` declares `checkpoint`, `char_lora` and `content_loras[].name` as explicit fields.
- The heartbeat already reports what ComfyUI will actually load (`object_info/CheckpointLoaderSimple`, not a disk glob).
- `Worker.checkpoints` was read in exactly one place — the console's dropdown — and nowhere near the claim path.

## The model

`app/model_requirements.py`, pure and no-I/O:

- **Requirement** — `Artifact(kind, name)` read from declared recipe fields
- **Inventory** — what the worker reports it can load, per kind
- **Fetchable kinds** — what it reports it can *obtain*, declared by the worker

```
required − (inventory ∪ artifacts-of-fetchable-kinds) == ∅
```

**No name matching anywhere.** A heuristic recognising `10Eros_v1.5_bf16` would miss `10Eros_v2` — as a *pass*, which is the dangerous direction.

**Fetchability is the worker's to declare.** The daemon fetches LoRAs at claim time already, so LoRAs must not gate; when it learns to fetch checkpoints (console#423) it says so and this gate opens with no API change and no coordinated deploy.

## The gate is a WHERE clause

Filtering the row the query already picked would either re-select the same unrunnable segment on every poll — head-of-line blocking, the whole queue behind it — or need a second SELECT that breaks the `skip_locked` concurrency the claim depends on. There is a test for exactly that.

Three things deliberately do **not** gate:

| case | why |
|---|---|
| NULL `ltx_recipe` | a WAN segment, a free-form LTX render, or a CPU reprocess carrier — declares nothing, requires nothing |
| worker has never reported checkpoints (NULL, not `[]`) | an older daemon would starve on upgrade day, and a silent fleet looks exactly like an empty queue |
| a kind the worker can fetch | it would refuse work the daemon handles by itself |

Inventory comes from the last heartbeat, not the claim request: the poll is frequent and the inventory is not. Worst case is a claim against a one-heartbeat-stale inventory, which degrades to today's behaviour — a loud engine failure — not to something worse.

## Blocked has to be visible

A gate trades a loud failure for a silent one, so this ships with the other half: `SegmentResponse.blocked_reason` names the file when a PENDING segment is on no online worker — *"No online worker can load checkpoint '10Eros_v1.5_bf16'"*. Computed per request rather than stored, so it clears itself when a worker holding the file comes online, and stays silent when nothing has reported an inventory to judge against.

## Ordering

The daemon PR only *adds* a heartbeat field. Deploying this API first is safe but conservative: until a daemon reports `fetchable_kinds`, a segment naming an unknown LoRA still claims fine (LoRAs are only checked against an inventory the API does not hold), and checkpoint gating is already correct. No coordinated deploy needed.

`085_worker_fetchable_kinds` adds one nullable JSONB column.

**Verified:** 673 passed against a real Postgres (`REQUIRE_DB=1`), 27 new — 15 pure requirement tests and 12 driving `/segments/next` and `/jobs/{id}` over HTTP against real rows, including the head-of-line case and every "work still flows" case above. `ruff check` clean on new files; the pre-existing errors in `segments.py`/`jobs.py` are untouched and present on main.

https://claude.ai/code/session_011m6VWR2d8jn7hMQ2xQthPR