### PR TITLE
segments: re-roll the current segment at any index, optionally with a new prompt

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -1233,7 +1233,27 @@ async def cancel_segment(
     return segment
 
 
-def _roll_new_take(job: Job, old: Segment) -> Segment:
+def _recipe_for_take(old: Segment, prompt: str | None) -> dict | None:
+    """The outgoing take's recipe, marked if this roll changed the prompt.
+
+    A re-roll's premise is that the seed is the ONLY difference, which is what makes two takes
+    comparable. Changing the prompt deliberately breaks that — and six takes later nothing
+    distinguishes a prompt-changed pair from a seed-only one, so a judgement made across them
+    is quietly worthless.
+
+    `edited` already carries exactly this meaning: the console writes it at creation to record
+    which of a pose's defaults the user overrode. A copy, never a mutation — the archived take
+    and its replacement share the dict otherwise, and marking one would rewrite the record of
+    the other.
+    """
+    recipe = old.ltx_recipe
+    if recipe is None or prompt is None or prompt == old.prompt:
+        return recipe
+    return {**recipe, "edited": sorted({*(recipe.get("edited") or []), "prompt"})}
+
+
+def _roll_new_take(job: Job, old: Segment, *, prompt: str | None = None,
+                   prompt_template: str | None = None) -> Segment:
     """Archive `old` and build its replacement.
 
     Was shared by a user-initiated re-roll and an automatic rule-driven one; the rule-driven
@@ -1249,6 +1269,15 @@ def _roll_new_take(job: Job, old: Segment) -> Segment:
     The job's seed then becomes the new take's seed, and the new take derives from it like any
     other segment. This is only safe because the outgoing take was just stamped: the seed being
     replaced is still recorded, on the row it actually produced. See #199 for the full model.
+
+    ANY INDEX, not only 0 (console#424). The replacement takes the index it replaces, and only
+    the LAST live segment may be rolled — a segment with a successor is the frame that
+    successor continues from. The predecessors are untouched, so the new take starts from the
+    same frame the archived one did, which is what keeps the pair comparable.
+
+    An optional `prompt` is the second half of that ticket: "that take was close, let me nudge
+    the wording". It arrives already resolved, because resolution needs the database and this
+    does not touch it.
     """
     if old.seed is None:
         # Exactly what the worker ran: the claim hands out job.seed. This said
@@ -1258,17 +1287,30 @@ def _roll_new_take(job: Job, old: Segment) -> Segment:
         # ran on the first time anyone re-rolled a continuation.
         old.seed = job.seed
     old.discarded = True
+
+    # Every OTHER live take deriving its seed from the job has to be stamped too, before the
+    # job's seed moves out from under it. Rolling index 0 never needed this — there was
+    # nothing else live. Rolling a continuation does: segments 0..n-1 hold seed NULL, which
+    # means "ask the job", and the job is about to answer differently. They would not just be
+    # mislabelled; retrying one re-claims it, the claim hands out job.seed, and it would
+    # render a different take from the one it is retrying.
+    for sibling in job.segments:
+        if sibling is not old and not sibling.discarded and sibling.seed is None:
+            sibling.seed = job.seed
+
     job.seed = new_seed()
 
     fresh = Segment(
         job_id=job.id,
-        index=0,
+        # The index it replaces. Both rows hold it at once — the unique index is partial over
+        # live rows — which is what lets an archived take keep its place in the chain.
+        index=old.index,
         # NULL: derive from the job like every other segment. The job seed WAS just set to this
         # take's seed, so a second copy on the segment would be the same number in two places,
         # free to drift.
         seed=None,
-        prompt=old.prompt,
-        prompt_template=old.prompt_template,
+        prompt=old.prompt if prompt is None else prompt,
+        prompt_template=old.prompt_template if prompt is None else prompt_template,
         duration_seconds=old.duration_seconds,
         speed=old.speed,
         start_image=old.start_image,
@@ -1276,7 +1318,7 @@ def _roll_new_take(job: Job, old: Segment) -> Segment:
         # The recipe is what the take IS. Without it a re-rolled LTX segment renders free-form
         # — no character LoRA, no trigger, no per-stage strengths — and comes back looking like
         # a different shot, which is the opposite of a re-roll's entire purpose.
-        ltx_recipe=old.ltx_recipe,
+        ltx_recipe=_recipe_for_take(old, prompt),
         auto_finalize=old.auto_finalize,
     )
 
@@ -1286,37 +1328,128 @@ def _roll_new_take(job: Job, old: Segment) -> Segment:
     return fresh
 
 
+_REROLL_REFUSED_STATUSES = (JobStatus.FINALIZED, JobStatus.FINALIZING, JobStatus.ARCHIVED)
+
+
+async def _reroll(db: AsyncSession, job: Job, old: Segment,
+                  prompt: str | None) -> Segment:
+    """Archive `old` and queue a fresh take of it. Shared by both routes.
+
+    This is the "show me another take" button. Everything that defines the shot — LoRAs,
+    recipe, start image, duration — is copied verbatim so that the seed is the only thing
+    that differs and the two takes are actually comparable. A wildcard prompt is copied
+    already-resolved for the same reason: re-rolling the wildcards too would change two
+    variables at once and make the comparison worth nothing.
+
+    Unless the caller asks for a different prompt, which is the point of console#424 and is
+    an explicit choice rather than a side effect. The recipe records that it happened.
+
+    ONLY THE LAST LIVE SEGMENT. A segment with a live successor is the frame that successor
+    continues from; replacing it would leave every one of them continuing from a frame that
+    no longer exists. That was expressed as "index must be 0" while re-roll only served
+    single-segment jobs — it is the same protection, stated generally.
+
+    The old take is discarded, not deleted. It keeps its video under its own seed, which is
+    why segments have a seed column at all. Rolling repeatedly is the point, so an archive
+    that relabelled every previous take with the newest seed would destroy exactly the record
+    it exists to accumulate.
+
+    Trim and transition are deliberately NOT copied: they describe the take being archived,
+    not the one about to be generated.
+    """
+    if job.status in _REROLL_REFUSED_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Job is '{job.status}' and cannot be re-rolled. Its stitched output "
+                "describes the takes that were live when it was built; archiving one behind "
+                "that video would make the record wrong."
+            ),
+        )
+
+    live = [s for s in job.segments if not s.discarded]
+    last = max(live, key=lambda s: s.index, default=None)
+    if old.discarded or last is None or old.id != last.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Only the job's current segment can be re-rolled (that is index "
+                f"{last.index if last else '-'}, this is {old.index}). A later segment "
+                "continues from this one's last frame, so replacing it would orphan them."
+            ),
+        )
+
+    if old.status not in (SegmentStatus.FAILED, SegmentStatus.COMPLETED):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Segment {old.index} is '{old.status}'. Cancel it before re-rolling — "
+                "otherwise the worker finishes generating a take that has already been "
+                "archived."
+            ),
+        )
+
+    resolved, template = None, None
+    if prompt is not None:
+        # Exactly the creation path's order. <TRIGGER> first, because it shares syntax with
+        # wildcards and a Wildcard named TRIGGER would otherwise substitute a random option
+        # and the render would quietly name the wrong character.
+        #
+        # <SCENE> is deliberately left alone: for a continuation it describes a frame that
+        # does not exist yet, and the claim resolves it then — the same way a continuation
+        # created through the normal path is handled.
+        triggered = await _resolve_trigger(db, prompt, old.ltx_recipe)
+        resolved, template = await _resolve_wildcards(db, triggered)
+
+    fresh = _roll_new_take(job, old, prompt=resolved, prompt_template=template)
+    db.add(fresh)
+    await db.commit()
+    await db.refresh(fresh)
+    return fresh
+
+
+@router.post("/segments/{segment_id}/reroll", response_model=SegmentResponse)
+async def reroll_segment(
+    segment_id: UUID,
+    body: RerollRequest | None = None,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Another take of this segment, optionally with a different prompt (console#424).
+
+    Addressed by SEGMENT rather than by job. "The job's one segment" was unambiguous while
+    re-roll only served index 0; once any index can be the target, the caller has to be able
+    to say which one it meant — and the API has to be able to refuse when that is no longer
+    the current segment, rather than rolling something the user was not looking at.
+    """
+    result = await db.execute(
+        select(Segment)
+        .join(Job, Segment.job_id == Job.id)
+        .where(Segment.id == segment_id, Job.user_id == user.id)
+    )
+    segment = result.scalar_one_or_none()
+    if segment is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Segment not found")
+
+    job = (await db.execute(
+        select(Job).where(Job.id == segment.job_id).options(selectinload(Job.segments))
+    )).scalar_one()
+
+    return await _reroll(db, job, segment, body.prompt if body else None)
+
+
 @router.post("/jobs/{job_id}/reroll", response_model=SegmentResponse)
-async def reroll_first_segment(
+async def reroll_current_segment(
     job_id: UUID,
     body: RerollRequest | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Archive segment 0 and queue a fresh one, identical except for the seed.
+    """Re-roll whatever the job's current segment is.
 
-    This is the "show me another take" button. Everything that defines the shot -- prompt, LoRAs,
-    recipe, start image, duration -- is copied verbatim so that the seed is the ONLY
-    thing that differs and the two takes are actually comparable. A wildcard prompt is copied
-    already-resolved for the same reason: re-rolling the wildcards as well would change two
-    variables at once and make the comparison worth nothing.
-
-    The old take is discarded, not deleted. It keeps its video under its own seed -- which is why
-    segments have a seed column at all. Rolling repeatedly is the point of this endpoint, so an
-    archive that relabelled every previous take with the newest seed would destroy exactly the
-    record it exists to accumulate.
-
-    Only offered while the job is a single live segment. Once there is a segment 1, segment 0 is
-    the thing it continues from, and replacing it would orphan every successor that was generated
-    from its last frame.
-
-    Trim and transition are deliberately NOT copied: they describe the take being archived,
-    not the one about to be generated.
-
-    The "re-roll until" rule is gone with the metrics it judged (#151) — it compared a
-    threshold against the mean of an identity or motion series, and nothing produces those
-    now. A rule would have been permanently unevaluable, which the old code degraded to by
-    logging "sitting idle" rather than failing. Rolling a take by hand is unaffected.
+    Superseded by POST /segments/{id}/reroll and kept because a browser holding the previous
+    console still calls it — dropping it would break the button for as long as a stale tab
+    lives. For the single-segment job that console offers it on, the two are identical.
     """
     result = await db.execute(
         select(Job)
@@ -1327,35 +1460,13 @@ async def reroll_first_segment(
     if job is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
 
-    # Live segments only. After a re-roll the job holds a discarded segment 0 beside the new one,
-    # and rolling again has to stay available -- that is the whole workflow.
     live = [s for s in job.segments if not s.discarded]
-    if len(live) != 1 or live[0].index != 0:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=(
-                "Re-roll only applies to a job with a single segment. This job has "
-                f"{len(live)} live segments; a later segment continues from segment 0's last "
-                "frame, so replacing it would orphan them."
-            ),
-        )
+    if not live:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Job has no live segment to re-roll.")
 
-    old = live[0]
-    if old.status not in (SegmentStatus.FAILED, SegmentStatus.COMPLETED):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Segment 0 is '{old.status}'. Cancel it before re-rolling — otherwise the "
-                "worker finishes generating a take that has already been archived."
-            ),
-        )
-
-    fresh = _roll_new_take(job, old)
-    db.add(fresh)
-
-    await db.commit()
-    await db.refresh(fresh)
-    return fresh
+    return await _reroll(db, job, max(live, key=lambda s: s.index),
+                         body.prompt if body else None)
 
 
 @router.post("/segments/{segment_id}/discard", response_model=SegmentResponse)

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -231,12 +231,19 @@ class HologramRequest(BaseModel):
 
 
 class RerollRequest(BaseModel):
-    """Body for POST /jobs/{id}/reroll.
+    """Body for POST /segments/{id}/reroll.
 
     Carried a "re-roll until" rule — a metric and a threshold, judged on completion. The
     metrics it judged are gone (#151), so a rule would be permanently unevaluable and the
-    fields with it. Kept as a class because the endpoint still accepts an optional body.
+    fields with it.
+
+    It now carries a prompt instead (console#424): "that take was close, let me nudge the
+    wording". Absent means a seed-only roll, which is what re-roll has always been and still
+    is by default — the two takes then differ in one variable and are comparable. Present is
+    an explicit choice to break that, and the new take's recipe records it.
     """
+
+    prompt: Optional[str] = None
 
 
 class SegmentStatusUpdate(BaseModel):

--- a/tests/test_reroll_any_segment.py
+++ b/tests/test_reroll_any_segment.py
@@ -1,0 +1,214 @@
+"""Re-rolling a continuation, and re-rolling with a different prompt (console#424).
+
+Re-roll served index 0 only, and changed nothing but the seed. Both limits are lifted here,
+and the things that can go wrong are database things — which take gets archived, which index
+the replacement lands on, and what happens to the seeds of takes NOT being rolled. That last
+one is the subtle one: a live segment holds seed NULL, meaning "ask the job", and rolling a
+continuation moves the job's seed out from under it.
+"""
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.enums import JobStatus, SegmentStatus
+from app.main import app
+from app.models import Job, Segment, User, Wildcard
+
+
+async def _user(db) -> User:
+    user = User(username=str(uuid.uuid4()), password_hash="x")
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _chain(db, user, *, length=3, status=JobStatus.AWAITING,
+                 recipe=None) -> tuple[Job, list[Segment]]:
+    """A job of `length` completed segments — the shape re-roll could not touch before."""
+    job = Job(user_id=user.id, name="job", width=480, height=832, fps=16, seed=1234,
+              starting_image="s3://b/start.png", status=status)
+    db.add(job)
+    await db.flush()
+    segments = []
+    for i in range(length):
+        seg = Segment(
+            job_id=job.id, index=i, prompt=f"take {i}",
+            duration_seconds=5.0, speed=1.0, status=SegmentStatus.COMPLETED,
+            output_path=f"s3://b/{i}.mp4", last_frame_path=f"s3://b/{i}.png",
+            ltx_recipe=recipe if recipe is not None else {"recipe": "Missionary Side"},
+        )
+        db.add(seg)
+        segments.append(seg)
+    await db.flush()
+    return job, segments
+
+
+async def _post(db, user, url, json=None):
+    for obj in list(db.identity_map.values()):
+        if isinstance(obj, (Job, Segment)):
+            db.expire(obj)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            return await c.post(url, json=json)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+class TestRollingAContinuation:
+    async def test_the_last_segment_can_be_rolled(self, db):
+        user = await _user(db)
+        job, segs = await _chain(db, user)
+        last_id = segs[-1].id
+
+        resp = await _post(db, user, f"/segments/{last_id}/reroll")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["index"] == 2
+        rows = (await db.execute(
+            select(Segment).where(Segment.job_id == job.id, Segment.index == 2)
+        )).scalars().all()
+        assert {r.discarded for r in rows} == {True, False}
+        assert next(r for r in rows if not r.discarded).status == SegmentStatus.PENDING
+
+    async def test_an_earlier_segment_is_refused(self, db):
+        """The protection that used to read "index must be 0", stated generally: segment 2
+        continues from segment 1's last frame, so replacing 1 would orphan it."""
+        user = await _user(db)
+        _, segs = await _chain(db, user)
+
+        resp = await _post(db, user, f"/segments/{segs[1].id}/reroll")
+
+        assert resp.status_code == 400
+        assert "current segment" in resp.json()["detail"]
+
+    async def test_the_predecessors_keep_the_seed_they_ran_on(self, db):
+        """The subtle one. A live take holds seed NULL, which means "ask the job", and this
+        roll gives the job a new seed. Without stamping them first, retrying segment 0 would
+        re-claim it, be handed the NEW seed, and render a different take from the one it is
+        retrying — silently."""
+        user = await _user(db)
+        job, segs = await _chain(db, user)
+        original = job.seed
+
+        await _post(db, user, f"/segments/{segs[-1].id}/reroll")
+
+        for seg in segs[:-1]:
+            await db.refresh(seg)
+            assert seg.seed == original
+        await db.refresh(job)
+        assert job.seed != original
+
+    async def test_the_archived_take_keeps_its_own_seed(self, db):
+        user = await _user(db)
+        job, segs = await _chain(db, user)
+        original = job.seed
+
+        await _post(db, user, f"/segments/{segs[-1].id}/reroll")
+
+        await db.refresh(segs[-1])
+        assert segs[-1].discarded is True
+        assert segs[-1].seed == original
+
+    async def test_a_finalized_job_is_refused(self, db):
+        """Its stitched output describes the takes that were live when it was built."""
+        user = await _user(db)
+        _, segs = await _chain(db, user, status=JobStatus.FINALIZED)
+
+        resp = await _post(db, user, f"/segments/{segs[-1].id}/reroll")
+
+        assert resp.status_code == 400
+        assert "cannot be re-rolled" in resp.json()["detail"]
+
+    async def test_a_running_segment_is_refused(self, db):
+        user = await _user(db)
+        job, segs = await _chain(db, user)
+        segs[-1].status = SegmentStatus.PROCESSING
+        await db.flush()
+
+        resp = await _post(db, user, f"/segments/{segs[-1].id}/reroll")
+
+        assert resp.status_code == 400
+        assert "Cancel it" in resp.json()["detail"]
+
+    async def test_another_users_segment_is_not_found(self, db):
+        owner = await _user(db)
+        intruder = await _user(db)
+        _, segs = await _chain(db, owner)
+
+        assert (await _post(db, intruder, f"/segments/{segs[-1].id}/reroll")).status_code == 404
+
+
+@pytest.mark.asyncio
+class TestRollingWithANewPrompt:
+    async def test_the_new_take_carries_the_new_prompt(self, db):
+        user = await _user(db)
+        _, segs = await _chain(db, user)
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"prompt": "she turns to face him"})).json()
+
+        assert body["prompt"] == "she turns to face him"
+
+    async def test_the_archived_take_keeps_the_prompt_it_ran(self, db):
+        """Otherwise the archive stops answering the only question it exists for."""
+        user = await _user(db)
+        _, segs = await _chain(db, user)
+
+        await _post(db, user, f"/segments/{segs[-1].id}/reroll", {"prompt": "something else"})
+
+        await db.refresh(segs[-1])
+        assert segs[-1].prompt == "take 2"
+
+    async def test_no_prompt_means_a_seed_only_roll(self, db):
+        """The default, and what re-roll has always been: one variable, two comparable takes."""
+        user = await _user(db)
+        _, segs = await _chain(db, user)
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll")).json()
+
+        assert body["prompt"] == "take 2"
+        assert (body["ltx_recipe"] or {}).get("edited") is None
+
+    async def test_a_changed_prompt_is_recorded_on_the_recipe(self, db):
+        """Six takes later, a prompt-changed pair is indistinguishable from a seed-only one,
+        and a judgement made across them is worthless."""
+        user = await _user(db)
+        _, segs = await _chain(db, user)
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"prompt": "different words"})).json()
+
+        assert "prompt" in body["ltx_recipe"]["edited"]
+
+    async def test_marking_the_new_take_does_not_rewrite_the_archived_one(self, db):
+        """They share the recipe dict; mutating it would rewrite the record of a take that
+        was never edited."""
+        user = await _user(db)
+        _, segs = await _chain(db, user, recipe={"recipe": "Missionary Side", "edited": []})
+
+        await _post(db, user, f"/segments/{segs[-1].id}/reroll", {"prompt": "different"})
+
+        await db.refresh(segs[-1])
+        assert segs[-1].ltx_recipe["edited"] == []
+
+    async def test_wildcards_in_a_new_prompt_are_resolved(self, db):
+        """A prompt typed here must behave exactly like the same words typed into the create
+        dialog. Stored raw, <face> would reach the model as literal text."""
+        user = await _user(db)
+        name = f"face{uuid.uuid4().hex[:6]}"
+        db.add(Wildcard(name=name, options=["smiling"]))
+        _, segs = await _chain(db, user)
+        await db.flush()
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"prompt": f"she is <{name}>"})).json()
+
+        assert body["prompt"] == "she is smiling"
+        assert body["prompt_template"] == f"she is <{name}>"

--- a/tests/test_reroll_segment.py
+++ b/tests/test_reroll_segment.py
@@ -231,16 +231,24 @@ class TestReroll:
             (await db.execute(select(Segment).where(Segment.job_id == job.id))).scalars().all()
         ) == 3
 
-    async def test_a_job_with_a_successor_segment_is_refused(self, db):
-        """Segment 1 was generated from segment 0's last frame. Replacing 0 orphans it."""
+    async def test_the_job_route_rolls_whatever_is_current(self, db):
+        """It used to refuse a job with a successor outright, because re-roll only served
+        index 0. It now targets the job's CURRENT segment (console#424) — segment 1 here —
+        and segment 0 is left alone, since segment 1 continues from its last frame.
+
+        Rolling an earlier segment is still refused; that is the segment-addressed route's
+        job now, and test_reroll_any_segment.py covers it."""
         user = await _user(db)
-        job, _ = await _job_with_segment(db, user)
+        job, first = await _job_with_segment(db, user)
         db.add(Segment(job_id=job.id, index=1, prompt="p", status=SegmentStatus.COMPLETED))
         await db.flush()
 
         resp = await _reroll(db, user, job.id)
-        assert resp.status_code == 400
-        assert "single segment" in resp.json()["detail"]
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["index"] == 1
+        await db.refresh(first)
+        assert first.discarded is False
 
     async def test_a_running_segment_is_refused(self, db):
         # Otherwise the worker keeps generating a take that has already been archived.


### PR DESCRIPTION
API half of DavidJBarnes/wanly-console#424. Pairs with wanly-console#428.

Re-roll served index 0 and changed nothing but the seed, so *"that take was close, let me nudge the wording"* on segment 2 had no path at all.

## Any index

The target is now the job's **current** segment — the highest-index live one. The old guard ("exactly one live segment, at index 0") is the same protection stated generally: a segment with a live successor is the frame that successor continues from, so replacing it would orphan them. Segment 0 stays re-rollable exactly as long as it is the only one, and predecessors are untouched, so the new take starts from the same frame the archived one did.

`_roll_new_take` already anticipated this — its comment noted the old seed derivation "would have recorded a seed the take never ran on the first time anyone re-rolled a continuation."

## The bug that generalizing would have introduced

A live segment holds `seed = NULL`, meaning *derive from the job*, and a roll gives the job a new seed. Rolling index 0 never had a predecessor to mislead. Rolling a continuation does — and it is not just a mislabelled archive:

> `retry` puts a completed segment back to PENDING, the claim hands out `job.seed`, and segment 0 would render a **different take** from the one being retried. Silently.

So every live take still deriving its seed is stamped with the value it actually ran on, before the job's seed moves. There is a test that fails without it.

## Optional prompt

`RerollRequest.prompt`. Absent means today's behaviour exactly — a seed-only roll, one variable, two comparable takes.

Present, it is resolved the way the create path resolves one: `<TRIGGER>` **before** wildcards (a Wildcard named TRIGGER would otherwise substitute a random option and the render would quietly name the wrong character), and `<SCENE>` deliberately left for the claim, where a continuation's frame finally exists. Stored raw, `<face>` would reach the model as literal text.

The new take's recipe records `edited: ["prompt"]` — via a **copy**, since the archived take and its replacement otherwise share the dict, and marking one would rewrite the record of the other. Six takes later nothing else distinguishes a prompt-changed pair from a comparable one.

## Route

`POST /segments/{id}/reroll`. "The job's one segment" stopped being unambiguous once any index can be the target; naming it lets the API 409 rather than roll something the user was not looking at.

`POST /jobs/{id}/reroll` stays as a thin alias targeting the current segment, so a browser holding the previous console keeps working. **Merge order does not matter** for that reason.

## Refusals

| case | why |
|---|---|
| not the current segment | its successor continues from this frame |
| `FINALIZED` / `FINALIZING` / `ARCHIVED` job | the stitched output describes the takes that were live when it was built |
| running segment | otherwise the worker finishes a take that is already archived |

**Verified:** 657 passed against real Postgres (`REQUIRE_DB=1`), 13 new in `tests/test_reroll_any_segment.py` covering rolling a continuation, refusing an earlier one, predecessor seed stamping, finalized/running refusals, the prompt override, wildcard resolution, and the shared-dict case. One existing test changed on purpose: the job route no longer refuses a job with a successor, it rolls the current segment — the refusal it asserted now lives on the segment-addressed route and is tested there.

https://claude.ai/code/session_011m6VWR2d8jn7hMQ2xQthPR