### PR TITLE
segments: only segment 0 redraws the seed; a continuation keeps the chain's

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -1316,9 +1316,13 @@ def _roll_new_take(job: Job, old: Segment, *, prompt: str | None = None,
     answer than a recorded number. Same value the worker used -- this records it, it does not
     change it.
 
-    The job's seed then becomes the new take's seed, and the new take derives from it like any
+    Rolling SEGMENT 0 then gives the job a new seed, and the new take derives from it like any
     other segment. This is only safe because the outgoing take was just stamped: the seed being
     replaced is still recorded, on the row it actually produced. See #199 for the full model.
+
+    Rolling a CONTINUATION keeps the job's seed. The seed is locked across a chain so that
+    segment 3 looks like segment 2 carrying on, and a roll there is asking for a different
+    take of the same shot — not a different shot.
 
     ANY INDEX, not only 0 (console#424). The replacement takes the index it replaces, and only
     the LAST live segment may be rolled — a segment with a successor is the frame that
@@ -1338,17 +1342,22 @@ def _roll_new_take(job: Job, old: Segment, *, prompt: str | None = None,
         old.seed = job.seed
     old.discarded = True
 
-    # Every OTHER live take deriving its seed from the job has to be stamped too, before the
-    # job's seed moves out from under it. Rolling index 0 never needed this — there was
-    # nothing else live. Rolling a continuation does: segments 0..n-1 hold seed NULL, which
-    # means "ask the job", and the job is about to answer differently. They would not just be
-    # mislabelled; retrying one re-claims it, the claim hands out job.seed, and it would
-    # render a different take from the one it is retrying.
-    for sibling in job.segments:
-        if sibling is not old and not sibling.discarded and sibling.seed is None:
-            sibling.seed = job.seed
-
-    job.seed = new_seed()
+    # SEGMENT 0 REDRAWS THE SEED; A CONTINUATION KEEPS IT.
+    #
+    # Segment 0 IS the chain's first frame, so rolling it is asking for a different shot and
+    # a new seed is the whole point. A continuation is not: the seed is locked across a chain
+    # precisely so segment 3 looks like segment 2 carrying on, and redrawing it there would
+    # change the one variable that is supposed to stay fixed for the length of the shot.
+    #
+    # So rolling a continuation varies the PROMPT and nothing else — which is why the prompt
+    # override exists, and why rolling one without editing the prompt will reproduce much the
+    # same take. That is the honest consequence of a locked seed, not a bug in the roll.
+    #
+    # This also removes the need to stamp the other live takes: their seeds only had to be
+    # rescued when the job's seed moved under them, and now it moves only for index 0, where
+    # nothing else is live — the last-live-segment rule makes index 0 the only segment.
+    if old.index == 0:
+        job.seed = new_seed()
 
     fresh = Segment(
         job_id=job.id,

--- a/tests/test_reroll_any_segment.py
+++ b/tests/test_reroll_any_segment.py
@@ -88,20 +88,41 @@ class TestRollingAContinuation:
         assert resp.status_code == 400
         assert "current segment" in resp.json()["detail"]
 
-    async def test_the_predecessors_keep_the_seed_they_ran_on(self, db):
-        """The subtle one. A live take holds seed NULL, which means "ask the job", and this
-        roll gives the job a new seed. Without stamping them first, retrying segment 0 would
-        re-claim it, be handed the NEW seed, and render a different take from the one it is
-        retrying — silently."""
+    async def test_a_continuation_keeps_the_chains_seed(self, db):
+        """The seed is locked across a chain so segment 3 looks like segment 2 carrying on.
+        Rolling a continuation asks for another take of the same shot, not a different shot,
+        so the job's seed must not move."""
         user = await _user(db)
         job, segs = await _chain(db, user)
         original = job.seed
 
         await _post(db, user, f"/segments/{segs[-1].id}/reroll")
 
+        await db.refresh(job)
+        assert job.seed == original
+
+    async def test_a_continuation_roll_leaves_the_predecessors_alone(self, db):
+        """They hold seed NULL, meaning "ask the job", and the job still answers the same.
+        Stamping them would replace that with a copy free to drift."""
+        user = await _user(db)
+        _, segs = await _chain(db, user)
+
+        await _post(db, user, f"/segments/{segs[-1].id}/reroll")
+
         for seg in segs[:-1]:
             await db.refresh(seg)
-            assert seg.seed == original
+            assert seg.seed is None
+
+    async def test_rolling_segment_0_draws_a_new_seed(self, db):
+        """Segment 0 IS the chain's first frame, so rolling it is asking for a different shot
+        — which is what a new seed produces. It can only be the target when it is the only
+        live segment, so nothing else derives from the value being replaced."""
+        user = await _user(db)
+        job, segs = await _chain(db, user, length=1)
+        original = job.seed
+
+        await _post(db, user, f"/segments/{segs[0].id}/reroll")
+
         await db.refresh(job)
         assert job.seed != original
 


### PR DESCRIPTION
Corrects the seed behaviour shipped in #250. Pairs with wanly-console#429.

The requirement:

1. Re-rolling **segment 0** auto-generates a new seed.
2. Re-rolling **segment 1..N** keeps the seed from segment 0.

#250 redrew at every index, which is right for the first and wrong for the rest. Segment 0 *is* the chain's first frame, so rolling it is asking for a different shot. A continuation is not — the seed is locked across a chain precisely so segment 3 looks like segment 2 carrying on, and redrawing it there changes the one variable that is meant to stay fixed for the length of the shot.

## The consequence, stated plainly

A continuation roll now varies the **prompt and nothing else**. Rolling one *without* editing the prompt will reproduce much the same take — same seed, same start frame, same recipe. That is what a locked seed means, not a fault in the roll, and it is why the prompt override exists. The console says so in the dialog.

## What this retires

The predecessor stamping added with the any-index roll goes away. Those seeds only needed rescuing when the job's seed moved out from under them, and it now moves only for index 0 — where the last-live-segment rule guarantees nothing else is live, since index 0 can only be the target when it is the only live segment.

The outgoing take is still stamped with the seed it ran on before being archived. That is unchanged and still load-bearing: the archive has to answer "which seed gave me that one" without recomputing from context.

**Verified:** 695 passed against real Postgres (`REQUIRE_DB=1`). One test replaced by three: a continuation keeps the chain's seed, a continuation roll leaves the predecessors' NULL seeds alone, and rolling segment 0 draws a new one.

https://claude.ai/code/session_011m6VWR2d8jn7hMQ2xQthPR