### PR TITLE
workers: report fetchable_kinds in the worker response, not just store it

### DIFF
--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -72,6 +72,12 @@ class WorkerResponse(BaseModel):
     a1111: dict[str, Any] | None = None
     loras: dict[str, Any] | None = None
     checkpoints: list[str] | None = None
+    # What the worker says it can FETCH, beside what it already holds. Stored since #249 and
+    # missing from this schema until now, so it read as NULL everywhere it was looked at —
+    # including while checking whether a restarted daemon had picked the field up. Pydantic
+    # drops what a response model does not name, silently, which makes a stored value and an
+    # unreported one indistinguishable from outside.
+    fetchable_kinds: list[str] | None = None
     drain_after_jobs: int | None = None
     last_heartbeat: datetime
     registered_at: datetime

--- a/tests/test_worker_fetchable_kinds.py
+++ b/tests/test_worker_fetchable_kinds.py
@@ -1,0 +1,47 @@
+"""The artifact kinds a worker says it can fetch, from heartbeat to response (console#422).
+
+The claim gate reads this to decide that a LoRA the worker has never seen is not a reason to
+refuse it work. Two ways it goes wrong, both silent:
+
+  * a required field would 422 every older daemon off the pool on upgrade day
+  * a field missing from the RESPONSE model reads as NULL from outside, whatever is stored
+
+The second one actually happened: the column and the heartbeat shipped together and the
+response schema did not, so a daemon that was reporting ["lora"] correctly looked like one
+that had never reported at all.
+"""
+from app.schemas.workers import WorkerHeartbeat, WorkerResponse
+
+
+def test_an_older_daemon_still_heartbeats():
+    """Optional, like every field added before it. A required one takes the fleet offline
+    because the API learned a new word."""
+    assert WorkerHeartbeat(comfyui_running=True).fetchable_kinds is None
+
+
+def test_what_the_worker_reports_round_trips():
+    hb = WorkerHeartbeat(comfyui_running=True, fetchable_kinds=["lora"])
+    assert hb.fetchable_kinds == ["lora"]
+
+
+def test_omitting_it_must_not_erase_a_stored_value():
+    """The route writes only when the field is present. Assigning None on every older-daemon
+    heartbeat would blank what a newer one just reported."""
+    import inspect
+
+    from app.routes import workers as mod
+
+    src = inspect.getsource(mod)
+    assert "if body.fetchable_kinds is not None:" in src
+
+
+def test_the_response_reports_it():
+    """Pydantic drops what the response model does not name, silently, which makes a stored
+    value and an unreported one indistinguishable from outside — and the gate's behaviour
+    unexplainable from the API alone."""
+    assert "fetchable_kinds" in WorkerResponse.model_fields
+
+
+def test_the_response_survives_a_worker_that_never_reported():
+    """NULL is a real state here: never reported, which the gate reads as "fetches nothing"."""
+    assert WorkerResponse.model_fields["fetchable_kinds"].default is None


### PR DESCRIPTION
Follow-up to #249.

The column, the heartbeat field and the claim gate shipped together; `WorkerResponse` did not get the field. **Pydantic drops what a response model does not name, silently**, so `/workers` reported `fetchable_kinds: null` for a daemon that was sending `["lora"]` correctly, and a stored value was indistinguishable from a worker that had never reported one.

It cost a wrong conclusion within the hour: the 3090 was restarted specifically to pick the field up, *did* pick it up — `queue_client.py` in the running container has it, and the container is on 6786f86 (#174) — and still read as null, which looked like the restart had not taken.

Same trap as the `video_preset_id` "Custom" bug: the write path and the read path are separate declarations, and only one of them was updated.

**Verified:** 700 passed against real Postgres. Five new tests covering both halves — optional on the way in so an older daemon does not 422 off the pool, present on the way out so what is stored can be seen, and the route still only writes the field when it is present.

Once this deploys, `/workers` should show `fetchable_kinds: ["lora"]` for 3090.zero with no worker restart needed.

https://claude.ai/code/session_011m6VWR2d8jn7hMQ2xQthPR