### PR TITLE
settings: the Settings negative prompt is the default a render actually uses

### DIFF
--- a/alembic/versions/086_unpin_stack_negative.py
+++ b/alembic/versions/086_unpin_stack_negative.py
@@ -1,0 +1,60 @@
+"""Un-pin the poses that hold a verbatim copy of the stack's negative prompt
+
+Revision ID: 086
+Revises: 085
+Create Date: 2026-09-05
+
+console#430. The Settings "negative prompt" field had never once been used. Two things kept
+it out: the recipe book resolved a pose's negative against `LTX_STACK['negative']` rather
+than the setting, and the console's pose editor prefilled its box from that RESOLVED value
+and saved it straight back. Opening a pose and pressing Save therefore turned "inherit the
+default" into a hardcoded copy of the constant, silently.
+
+It has already happened to every pose. Migration 071 seeded all of them NULL; production now
+holds 16 rows whose negative_prompt is byte-identical to the constant -- md5
+bdb2e8d67a0c43e89d5aeee1cce2a0e0, 195 characters, on all 16. Fixing only the resolver would
+change nothing for them: a non-NULL override wins, and every row has one.
+
+MATCHED ON EXACT TEXT, NOT BLANKET-CLEARED
+    A pose whose negative was genuinely hand-written must survive. Only rows equal to the
+    constant are cleared: those carry no information the constant does not already carry, so
+    reading them as "never overridden" loses nothing, and it is what the row meant before an
+    editor round-trip pinned it.
+
+THE TEXT IS FROZEN HERE, not imported from app.ltx_stack. A migration describes the data as
+it was on this date. If the stack constant is edited later this must still match the rows it
+was written for, and an import would quietly stop matching them.
+
+The downgrade writes the constant back into every row it could have cleared. It cannot tell
+those from a pose that always inherited -- but under the OLD resolver both rendered with the
+constant, so the rendered result is identical either way.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "086"
+down_revision = "085"
+branch_labels = None
+depends_on = None
+
+_PINNED = (
+    "static, still image, frozen, no motion, slideshow, identity change, different "
+    "person, face distortion, warped anatomy, extra limbs, deformed hands, merged limbs, "
+    "mangled body, blurry, low quality"
+)
+
+
+def upgrade() -> None:
+    op.get_bind().execute(
+        sa.text("UPDATE ltx_recipes SET negative_prompt = NULL "
+                "WHERE negative_prompt = :pinned"),
+        {"pinned": _PINNED},
+    )
+
+
+def downgrade() -> None:
+    op.get_bind().execute(
+        sa.text("UPDATE ltx_recipes SET negative_prompt = :pinned "
+                "WHERE negative_prompt IS NULL"),
+        {"pinned": _PINNED},
+    )

--- a/app/negative_prompt.py
+++ b/app/negative_prompt.py
@@ -1,0 +1,34 @@
+"""The default negative prompt, resolved in ONE place.
+
+There used to be two answers to "what negative prompt does a render use when nothing sets
+one", and they disagreed. `LTX_STACK['negative']` is a code constant baked into the image;
+`app_settings.negative_prompt` is the Settings page field. The recipe book resolved a pose
+against the constant, the console prefilled its form from that, and every segment was
+therefore created carrying it -- so the claim endpoint's fallback to the setting, the only
+place the setting was ever read, could not fire. The field was dead by construction
+(console#430).
+
+Resolution order is pose override, then the setting, then the constant. The constant is
+demoted to a SEED: it is what a fresh install renders with before anyone opens Settings,
+not a default that outranks a stated preference.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.ltx_stack import LTX_STACK
+from app.models import AppSetting
+
+SETTING_KEY = "negative_prompt"
+
+
+async def default_negative_prompt(db: AsyncSession) -> str:
+    """What a segment or pose that sets no negative prompt of its own renders with.
+
+    Blank means "not set", not "render with no negative at all" -- an empty text box is how
+    the field looks before it is ever used, and reading that as "drop the quality negatives"
+    would silently change every render the first time someone cleared it. Whitespace counts
+    as blank for the same reason.
+    """
+    row = await db.get(AppSetting, SETTING_KEY)
+    configured = (row.value if row else None) or ""
+    return configured if configured.strip() else LTX_STACK["negative"]

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -27,6 +27,7 @@ from app.auth import get_current_user, verify_api_key_or_bearer
 from app.database import get_db
 from app.ltx_stack import LTX_STACK
 from app.models import LtxCharacter, LtxRecipe, User, Worker
+from app.negative_prompt import default_negative_prompt
 from app.schemas.ltx import (
     LtxCharacterCreate,
     LtxCharacterUpdate,
@@ -88,17 +89,32 @@ async def get_recipe_book(
         select(LtxRecipe).order_by(LtxRecipe.name)
     )).scalars().all()
 
+    # The Settings field, not LTX_STACK['negative']. Resolving against the constant is what
+    # made the setting unreachable: the console prefills its form from the resolved value,
+    # so every segment was created carrying the constant and the claim-time fallback to the
+    # setting never had a NULL to fire on (console#430).
+    default_negative = await default_negative_prompt(db)
+
     # Poses are character-agnostic, so EVERY pose is offered for EVERY character. That is the
     # point: a new LoRA is never locked out for want of rows in a table — add the character
     # and all of them work immediately.
     return {
         "stack": LTX_STACK,
+        # What an un-overridden pose resolves to. Returned alongside the stack rather than
+        # folded into it: `stack` is the constant configuration the image ships with, and
+        # this one is a setting that can differ from it.
+        "default_negative_prompt": default_negative,
         "poses": [
             {
                 "id": str(r.id),
                 "name": r.name,
                 "prompt_template": r.prompt_template,
-                "negative_prompt": r.negative_prompt or LTX_STACK["negative"],
+                "negative_prompt": r.negative_prompt or default_negative,
+                # The RAW override, so the editor can tell "inherits the default" from
+                # "overridden". Without it the editor could only show the resolved value,
+                # and saving an untouched pose wrote that back as an override -- which is
+                # how all 16 poses ended up pinned to a copy of the stack constant.
+                "negative_prompt_override": r.negative_prompt,
                 "frames": r.frames or LTX_STACK["frames"],
                 # `or` is wrong here and `is None` is right: img_compression 0 is a REAL
                 # setting -- it bypasses the conditioning-frame encode entirely -- and `or`

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -26,6 +26,7 @@ from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.ltx_stack import LTX_STACK
 from app.model_requirements import CHECKPOINT, canonical
 from app.models import AppSetting, Job, LtxCharacter, Segment, User, Video, Wildcard, Worker
+from app.negative_prompt import default_negative_prompt
 from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
     SegmentPromptUpdate,
@@ -533,12 +534,14 @@ async def claim_next_segment(
                     reference_frames.append(prev_segment.last_frame_path)
                     reference_frames = reference_frames[-3:]
 
-    # Use segment negative_prompt if set, otherwise fall back to global app setting
+    # The segment's own negative if it has one, otherwise the resolved default: the Settings
+    # field, or the stack constant when that is blank. It used to read the setting row
+    # directly and hand the daemon None when there was no row, which left whatever negative
+    # the workflow template happens to bake in — a third answer to the same question.
     if segment.negative_prompt is not None:
         negative_prompt = segment.negative_prompt
     else:
-        neg_setting = await db.get(AppSetting, "negative_prompt")
-        negative_prompt = neg_setting.value if neg_setting else None
+        negative_prompt = await default_negative_prompt(db)
 
     # <SCENE> for a continuation. The start frame is a GENERATED image that exists only now
     # — the previous segment produced it — so this is the first moment it can be described,

--- a/tests/test_default_negative_prompt.py
+++ b/tests/test_default_negative_prompt.py
@@ -1,0 +1,141 @@
+"""The Settings negative prompt is the default a render actually uses (console#430).
+
+It never was. Two defaults existed for one question — `LTX_STACK['negative']`, a constant in
+the image, and `app_settings.negative_prompt`, the Settings field — and the constant won
+every time:
+
+  * `GET /recipes` resolved a pose against the constant, never the setting;
+  * the console prefilled its form from that resolved value, so every segment was created
+    carrying it, so the claim endpoint's fallback — the ONLY reader of the setting — never
+    saw the NULL it needed to fire on;
+  * the pose editor prefilled from the resolved value too and saved it back, which pinned
+    all 16 production poses to a verbatim copy of the constant.
+
+These tests hold the resolution order: pose override, then the setting, then the constant.
+"""
+
+import importlib.util
+import hashlib
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+from app.ltx_stack import LTX_STACK
+from app.models import AppSetting, LtxRecipe
+from app.negative_prompt import SETTING_KEY, default_negative_prompt
+
+
+async def _set(db, value: str) -> None:
+    await db.merge(AppSetting(key=SETTING_KEY, value=value))
+    await db.flush()
+
+
+class TestResolver:
+    @pytest.mark.asyncio
+    async def test_the_setting_wins_when_it_has_one(self, db):
+        await _set(db, "extra fingers, bad anatomy")
+        assert await default_negative_prompt(db) == "extra fingers, bad anatomy"
+
+    @pytest.mark.asyncio
+    async def test_the_stack_constant_is_the_seed_when_nothing_is_set(self, db):
+        await db.execute(sa.delete(AppSetting).where(AppSetting.key == SETTING_KEY))
+        await db.flush()
+        assert await default_negative_prompt(db) == LTX_STACK["negative"]
+
+    @pytest.mark.asyncio
+    async def test_blank_means_not_set_not_render_without_one(self, db):
+        """An empty box is how the field looks before anyone uses it. Reading that as "drop
+        the quality negatives" would silently change every render the first time it was
+        cleared, which is a much worse default than the constant."""
+        for blank in ("", "   ", "\n"):
+            await _set(db, blank)
+            assert await default_negative_prompt(db) == LTX_STACK["negative"]
+
+
+class TestRecipeBook:
+    """The book is where the console reads a pose's negative from, so it is where the
+    setting has to arrive."""
+
+    @staticmethod
+    async def _book(db):
+        from app.routes.ltx_recipes import get_recipe_book
+
+        return await get_recipe_book(user=None, db=db)
+
+    @pytest.mark.asyncio
+    async def test_a_pose_with_no_override_resolves_to_the_setting(self, db):
+        await _set(db, "six fingers")
+        db.add(LtxRecipe(name="inheriting pose", prompt_template="<TRIGGER>, standing"))
+        await db.flush()
+
+        pose = next(p for p in (await self._book(db))["poses"]
+                    if p["name"] == "inheriting pose")
+        assert pose["negative_prompt"] == "six fingers"
+        # And it still reports that it holds no override of its own, which is what stops the
+        # editor from writing one back.
+        assert pose["negative_prompt_override"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_real_override_still_outranks_the_setting(self, db):
+        await _set(db, "six fingers")
+        db.add(LtxRecipe(name="opinionated pose", prompt_template="<TRIGGER>, standing",
+                         negative_prompt="hands"))
+        await db.flush()
+
+        pose = next(p for p in (await self._book(db))["poses"]
+                    if p["name"] == "opinionated pose")
+        assert pose["negative_prompt"] == "hands"
+        assert pose["negative_prompt_override"] == "hands"
+
+    @pytest.mark.asyncio
+    async def test_the_book_states_the_default_so_the_editor_can_show_it(self, db):
+        await _set(db, "six fingers")
+        assert (await self._book(db))["default_negative_prompt"] == "six fingers"
+
+
+class TestUnpinMigration:
+    """086 clears the 16 poses that hold a copy of the constant. Without it the resolver fix
+    changes nothing: a non-NULL override wins, and every production row had one."""
+
+    @staticmethod
+    def _migration():
+        path = Path("alembic/versions/086_unpin_stack_negative.py")
+        spec = importlib.util.spec_from_file_location("m086", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_the_frozen_literal_is_the_text_production_actually_holds(self):
+        """195 characters, md5 bdb2e8d6…, measured on all 16 rows before the fix. Frozen in
+        the migration rather than imported, because a migration describes the data as it was
+        — but a reflow or a typo in that copy would make it match nothing, silently."""
+        pinned = self._migration()._PINNED
+        assert len(pinned) == 195
+        assert hashlib.md5(pinned.encode()).hexdigest() == "bdb2e8d67a0c43e89d5aeee1cce2a0e0"
+
+    @pytest.mark.asyncio
+    async def test_it_clears_the_copies_and_leaves_a_real_override_alone(self, db):
+        pinned = self._migration()._PINNED
+        db.add_all([
+            LtxRecipe(name="pinned pose", prompt_template="<TRIGGER>, a",
+                      negative_prompt=pinned),
+            LtxRecipe(name="hand written pose", prompt_template="<TRIGGER>, b",
+                      negative_prompt="hands, six fingers"),
+            LtxRecipe(name="nearly pinned pose", prompt_template="<TRIGGER>, c",
+                      negative_prompt=pinned + ", cross-eyed"),
+        ])
+        await db.flush()
+
+        await db.execute(
+            sa.text("UPDATE ltx_recipes SET negative_prompt = NULL "
+                    "WHERE negative_prompt = :pinned"),
+            {"pinned": pinned},
+        )
+
+        rows = dict((await db.execute(
+            sa.select(LtxRecipe.name, LtxRecipe.negative_prompt)
+        )).all())
+        assert rows["pinned pose"] is None
+        assert rows["hand written pose"] == "hands, six fingers"
+        assert rows["nearly pinned pose"] == pinned + ", cross-eyed"


### PR DESCRIPTION
The Settings **Default Negative Prompt** field had never been used by a single render. Fixes the API half of DavidJBarnes/wanly-console#430.

## Why it did nothing

Two defaults existed for one question, and the code constant won every time:

- `GET /recipes` resolved a pose as `r.negative_prompt or LTX_STACK["negative"]` — the setting was not consulted.
- The console prefills its form from that resolved value, so **every segment was created with a non-NULL `negative_prompt`** — and the claim endpoint's fallback, the only reader of `app_settings.negative_prompt`, only fires on NULL.
- The console's pose editor prefilled from the resolved value too and saved it back, pinning the constant onto the row as an "override".

Verified against production RDS: all 16 `ltx_recipes` rows hold text byte-identical to the constant (md5 `bdb2e8d67a0c43e89d5aeee1cce2a0e0`, 195 chars), while `app_settings.negative_prompt` holds a different 189-char string that has never reached a render. Migration 071 seeded those rows NULL, so the copies were written later, through the editor.

## What changes

- **`app/negative_prompt.py`** — one resolver: pose override → the setting → `LTX_STACK['negative']`. The constant is demoted to a seed, i.e. what a fresh install renders with before anyone opens Settings. Blank (or whitespace) counts as "not set", never as "render with no negative".
- **`GET /recipes`** resolves through it, and additionally returns the raw `negative_prompt_override` per pose plus a book-level `default_negative_prompt`. The console could only ever see the resolved value, which is exactly why its editor pinned it.
- **Claim endpoint** uses the same resolver. It previously handed the daemon `None` when no setting row existed, leaving whatever negative the workflow template bakes in — a third answer to the same question.
- **Migration 086** clears the 16 pinned copies. Matched on exact text, so a genuinely hand-written override survives. The literal is frozen in the migration rather than imported: a migration describes the data as it was.

## Verification

- 710 tests pass (`REQUIRE_DB=1`), including 8 new ones covering the resolution order, the book shape, and the migration's exact-match rule.
- `alembic upgrade head` run end-to-end on a clean database; 086 exercised both directions against real rows — a pinned copy is cleared, `hands, six fingers` is left alone, and the round trip is stable.

Merge before the console PR: the console reads the two new fields.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J