### PR TITLE
images: keep an image's scene description on its record

### DIFF
--- a/alembic/versions/087_image_scene_description.py
+++ b/alembic/versions/087_image_scene_description.py
@@ -1,0 +1,41 @@
+"""Cache an image's scene description on its row
+
+Revision ID: 087
+Revises: 086
+Create Date: 2026-09-05
+
+console#414. JoyCaption's description of a frame is expensive — 4.5s cold, 1.2s warm on the
+2070, which also hosts Automatic1111 — and the same image starts many jobs. Until now every
+one of them paid for it again: POST /captions/describe is deliberately stateless, so a
+description the user accepted left no trace.
+
+NOT A CACHE THAT CAN BE REBUILT
+    The model is nondeterministic. Re-running it gives different words, and the words are
+    what the person read and accepted before pressing go. That is why this is a stored
+    value with its own "re-roll" action rather than a memoised computation, and why the
+    tags endpoint may no longer delete a row just because its tags were cleared.
+
+scene_instruction records HOW the frame was described. A caption written under "terse" and
+one under "rich" are different artefacts; a row that holds one without saying which is a
+value nobody can interpret later.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "087"
+down_revision = "086"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("image_meta", sa.Column("scene_description", sa.Text(), nullable=True))
+    op.add_column("image_meta", sa.Column("scene_instruction", sa.Text(), nullable=True))
+    op.add_column("image_meta",
+                  sa.Column("scene_described_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("image_meta", "scene_described_at")
+    op.drop_column("image_meta", "scene_instruction")
+    op.drop_column("image_meta", "scene_description")

--- a/app/models.py
+++ b/app/models.py
@@ -259,11 +259,38 @@ class Favorite(Base):
 
 
 class ImageMeta(Base):
+    """What we know about an image in the repo, beyond what S3 itself stores.
+
+    One row per s3:// path, created on first use. A row exists only because something was
+    said about the image — tags, or a description — so the absence of a row is meaningful:
+    `list_untagged_images` reads it as "never tagged".
+    """
     __tablename__ = "image_meta"
 
     path = mapped_column(Text, primary_key=True)
     tags = mapped_column(Text, nullable=True)
+    # JoyCaption's description of this frame, produced once and reused (console#414).
+    #
+    # Cached rather than re-derived because it costs 2070 time — 4.5s cold, 1.2s warm — and
+    # the same image starts many jobs. It is not a derived value that can be recomputed for
+    # free: the model is nondeterministic, so a second call gives DIFFERENT words, and the
+    # words are what the person read and accepted.
+    scene_description = mapped_column(Text, nullable=True)
+    # Which instruction produced it. A caption written under "terse" and one under "rich"
+    # are different artefacts, and the row has to say which one this is — the same reason
+    # CaptionResponse returns it.
+    scene_instruction = mapped_column(Text, nullable=True)
+    scene_described_at = mapped_column(DateTime(timezone=True), nullable=True)
     updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    def is_empty(self) -> bool:
+        """Nothing left worth a row.
+
+        The tags endpoint deletes a row when its tags are cleared. Once a description can
+        also live here that is no longer the same question, and getting it wrong throws away
+        GPU work over a tag edit.
+        """
+        return not (self.tags or "").strip() and not (self.scene_description or "").strip()
 
 
 class Worker(Base):

--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import re
 import uuid
 from datetime import datetime, timezone
@@ -11,8 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
 from app.config import settings
 from app.database import get_db
-from app.models import Favorite, ImageMeta, Job, Segment
-from app.schemas.images import ImageTagsUpdate
+from app.joycaption import CaptionError
+from app.models import Favorite, ImageMeta, Job, Segment, User
+from app.routes.captions import caption_image_bytes
+from app.schemas.images import ImageSceneRequest, ImageSceneResponse, ImageTagsUpdate
 from app.tag_filter import like_escape
 from app.tag_filter import tag_clause as _tag_clause
 from app.s3 import (
@@ -26,9 +29,64 @@ from app.s3 import (
     upload_bytes,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["images"])
 
 _FOLDER_NAME_RE = re.compile(r"^[a-zA-Z0-9 _-]+$")
+
+
+async def _meta_by_path(db: AsyncSession, paths: list[str]) -> dict[str, dict]:
+    """The image_meta fields a listing shows, keyed by path.
+
+    One helper rather than a copy of the same select in each of the four listings. There
+    were three copies when this only had to fetch tags, and adding the scene description
+    would have made four — which is how one listing quietly ends up returning a field the
+    others do not.
+
+    Columns, not entities: a listing needs three values per row and never mutates one, and
+    the whole point of the folder view is that it stays cheap over a few thousand objects.
+    """
+    if not paths:
+        return {}
+    rows = (await db.execute(
+        select(ImageMeta.path, ImageMeta.tags,
+               ImageMeta.scene_description, ImageMeta.scene_described_at)
+        .where(ImageMeta.path.in_(paths))
+    )).all()
+    return {
+        row[0]: {
+            "tags": row[1] or None,
+            "scene_description": row[2] or None,
+            "scene_described_at": row[3],
+        }
+        for row in rows
+    }
+
+
+_NO_META = {"tags": None, "scene_description": None, "scene_described_at": None}
+
+
+def _meta_fields(meta) -> dict:
+    """The image_meta half of a listing row. Every listing returns the same shape.
+
+    Takes either the mapping _meta_by_path builds or an ImageMeta itself — search already
+    holds the entity, and making it re-fetch the same row as columns would be a second
+    query for data it has. None is an image with no row.
+
+    An image with no row is not a different shape from one with a row: it is the same
+    fields, all empty. Returning fewer keys is how a client ends up with `undefined` where
+    it expected null.
+    """
+    if meta is None:
+        return dict(_NO_META)
+    if isinstance(meta, ImageMeta):
+        return {
+            "tags": meta.tags or None,
+            "scene_description": meta.scene_description or None,
+            "scene_described_at": meta.scene_described_at,
+        }
+    return dict(meta)
 
 # Every column that can hold an s3:// path a user could delete through this router.
 # Job.identity_reference_image is deliberately absent: the daemon writes it into the *jobs*
@@ -157,18 +215,12 @@ async def list_folder_images(
 
     paths = [f"s3://{bucket}/{obj['Key']}" for obj in objects if not obj["Key"].endswith("/.folder")]
     in_use_set: set[str] = set()
-    tags_map: dict[str, str] = {}
+    meta_map: dict[str, dict] = {}
     if paths:
         # Same helper the delete endpoint gates on. When these two disagree the UI is the one
         # that gets believed, which is how referenced images got deleted in the first place.
         in_use_set = set(await find_image_references(db, paths))
-
-        meta_result = await db.execute(
-            select(ImageMeta.path, ImageMeta.tags).where(ImageMeta.path.in_(paths))
-        )
-        for row in meta_result.all():
-            if row[1]:
-                tags_map[row[0]] = row[1]
+        meta_map = await _meta_by_path(db, paths)
 
     return [
         {
@@ -178,7 +230,7 @@ async def list_folder_images(
             "size": obj["Size"],
             "last_modified": obj["LastModified"],
             "in_use": f"s3://{bucket}/{obj['Key']}" in in_use_set,
-            "tags": tags_map.get(f"s3://{bucket}/{obj['Key']}"),
+            **_meta_fields(meta_map.get(f"s3://{bucket}/{obj['Key']}")),
         }
         for obj in objects
         if not obj["Key"].endswith("/.folder")
@@ -214,14 +266,10 @@ async def list_favorite_images(
     items = await asyncio.gather(*[_meta(ref) for ref in refs])
 
     uris = [item["path"] for item in items if item is not None]
-    if uris:
-        meta_result = await db.execute(
-            select(ImageMeta.path, ImageMeta.tags).where(ImageMeta.path.in_(uris))
-        )
-        tags_map = {row[0]: row[1] for row in meta_result.all() if row[1]}
-        for item in items:
-            if item is not None:
-                item["tags"] = tags_map.get(item["path"])
+    meta_map = await _meta_by_path(db, uris)
+    for item in items:
+        if item is not None:
+            item.update(_meta_fields(meta_map.get(item["path"])))
 
     return [item for item in items if item is not None]
 
@@ -251,14 +299,15 @@ async def list_untagged_images(
 
     tagged: set[str] = set()
     in_use_set: set[str] = set()
+    meta_map: dict[str, dict] = {}
     if paths:
-        meta_result = await db.execute(
-            select(ImageMeta.path, ImageMeta.tags).where(ImageMeta.path.in_(paths))
-        )
-        tagged = {row[0] for row in meta_result.all() if row[1] and row[1].strip()}
+        meta_map = await _meta_by_path(db, paths)
+        tagged = {p for p, m in meta_map.items() if (m["tags"] or "").strip()}
 
         in_use_set = set(await find_image_references(db, paths))
 
+    # An untagged image can still carry a description — describing one is offered in the
+    # modal whether or not it has tags — so the row is read here rather than assumed empty.
     untagged = [
         {
             "key": obj["Key"],
@@ -267,7 +316,7 @@ async def list_untagged_images(
             "size": obj["Size"],
             "last_modified": obj["LastModified"],
             "in_use": f"s3://{bucket}/{obj['Key']}" in in_use_set,
-            "tags": None,
+            **_meta_fields(meta_map.get(f"s3://{bucket}/{obj['Key']}")),
         }
         for obj in objects
         if f"s3://{bucket}/{obj['Key']}" not in tagged
@@ -277,8 +326,14 @@ async def list_untagged_images(
 
 
 @router.post("/images/move", dependencies=[Depends(get_current_user)])
-async def move_images(body: dict):
-    """Move one or more images to a target folder (S3 copy + delete)."""
+async def move_images(body: dict, db: AsyncSession = Depends(get_db)):
+    """Move one or more images to a target folder (S3 copy + delete).
+
+    The image_meta row moves WITH the object. It did not before, so a move silently dropped
+    an image's tags — survivable when a tag is five seconds of typing, not when the row also
+    holds a scene description that cost GPU time and cannot be reproduced word for word
+    (console#414). The path is that row's primary key, so this is a rename, not a copy.
+    """
     keys: list[str] = body.get("keys", [])
     target_folder: str = body.get("target_folder", "").strip()
     if not keys:
@@ -287,13 +342,41 @@ async def move_images(body: dict):
         raise HTTPException(status_code=400, detail="target_folder is required")
     bucket = settings.s3_images_bucket
 
-    async def _move_one(src_key: str) -> str:
+    async def _move_one(src_key: str) -> tuple[str, str]:
         filename = src_key.split("/", 1)[1] if "/" in src_key else src_key
         dst_key = f"{target_folder}/{filename}"
         await asyncio.to_thread(move_object, bucket, src_key, dst_key)
-        return dst_key
+        return src_key, dst_key
 
     moved = await asyncio.gather(*[_move_one(k) for k in keys])
+
+    # After the objects, deliberately. If a move fails the metadata must still describe
+    # where the image actually is, and a row pointing at the old key is right in that case.
+    for src_key, dst_key in moved:
+        src = f"s3://{bucket}/{src_key}"
+        dst = f"s3://{bucket}/{dst_key}"
+        if src == dst:
+            continue
+        meta = await db.get(ImageMeta, src)
+        if meta is None:
+            continue
+        # The path is the primary key, so this is a delete plus an insert. A row already at
+        # the destination — the same filename moved back into a folder it came from — is
+        # overwritten by the one that travelled with the object.
+        existing = await db.get(ImageMeta, dst)
+        if existing is not None:
+            await db.delete(existing)
+            await db.flush()
+        db.add(ImageMeta(
+            path=dst,
+            tags=meta.tags,
+            scene_description=meta.scene_description,
+            scene_instruction=meta.scene_instruction,
+            scene_described_at=meta.scene_described_at,
+        ))
+        await db.delete(meta)
+    await db.commit()
+
     return {"moved": len(moved)}
 
 
@@ -348,18 +431,109 @@ async def update_image_tags(
     else:
         tags_val = None
 
-    if tags_val is None:
-        if meta:
+    if meta:
+        meta.tags = tags_val
+        # Deleting the row on a cleared tag was fine when tags were all it held. A scene
+        # description costs 2070 time to produce and cannot be regenerated identically, so
+        # the row goes only when nothing is left on it at all (console#414).
+        if meta.is_empty():
             await db.delete(meta)
-    else:
-        if meta:
-            meta.tags = tags_val
-        else:
-            meta = ImageMeta(path=path, tags=tags_val)
-            db.add(meta)
+    elif tags_val is not None:
+        db.add(ImageMeta(path=path, tags=tags_val))
 
     await db.commit()
     return {"path": path, "tags": tags_val}
+
+
+# ---------------------------------------------------------------------------------------
+# Scene descriptions (console#414)
+#
+# JoyCaption's description of a frame, stored on the image rather than re-derived per job.
+# POST /captions/describe stays as it is: a stateless preview for bytes nobody has committed
+# to. This is the other case — an image that lives in the repo, described once, by a person
+# who is looking at it.
+# ---------------------------------------------------------------------------------------
+
+
+def _scene_response(path: str, meta: ImageMeta | None) -> ImageSceneResponse:
+    description = (meta.scene_description if meta else None) or None
+    return ImageSceneResponse(
+        path=path,
+        scene_description=description,
+        scene_instruction=(meta.scene_instruction if meta else None) or None,
+        scene_described_at=meta.scene_described_at if meta else None,
+        words=len(description.split()) if description else 0,
+    )
+
+
+def _require_images_bucket(path: str) -> None:
+    bucket = settings.s3_images_bucket
+    if not path.startswith(f"s3://{bucket}/"):
+        raise HTTPException(status_code=400, detail="Path must be in the images bucket")
+
+
+@router.get("/images/scene", response_model=ImageSceneResponse,
+            dependencies=[Depends(get_current_user)])
+async def get_image_scene(path: str = Query(...), db: AsyncSession = Depends(get_db)):
+    """This image's saved description, or nulls if it has never been described.
+
+    Nulls rather than a 404: "no description yet" is an ordinary state of a perfectly good
+    image, and the caller — the New Job modal — has to render it either way.
+    """
+    _require_images_bucket(path)
+    return _scene_response(path, await db.get(ImageMeta, path))
+
+
+@router.post("/images/scene", response_model=ImageSceneResponse,
+             dependencies=[Depends(get_current_user)])
+async def describe_image_scene(
+    path: str = Query(...),
+    body: ImageSceneRequest | None = None,
+    db: AsyncSession = Depends(get_db),
+):
+    """Describe this image now and store the result, replacing any previous description.
+
+    ALWAYS regenerates. This one call is both the first description and the re-roll, because
+    they are the same act — the caller decides which it is by deciding whether to call. Any
+    "only if missing" rule here would be a second opinion about a decision the UI has
+    already made, and would make re-roll impossible to express.
+    """
+    _require_images_bucket(path)
+    body = body or ImageSceneRequest()
+
+    try:
+        # boto3 is synchronous; off the event loop so one slow fetch cannot stall the API.
+        image = await asyncio.to_thread(download_bytes, path)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"could not read {path}: {e}") from e
+
+    try:
+        caption, instruction = await caption_image_bytes(
+            db, image, style=body.style, instruction=body.instruction)
+    except CaptionError as e:
+        # 503, as /captions/describe does: the captioner being down is a temporary condition
+        # on another host, not a bug in this request. "Try again" is honest advice.
+        logger.warning("scene description failed for %s: %s", path, e)
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+    caption = caption.strip()
+    if not caption:
+        # A blank caption is a failure wearing a success's clothes. Storing it would mark the
+        # image described and stop anything ever asking again.
+        raise HTTPException(status_code=503,
+                            detail="the captioner returned nothing for this image")
+
+    meta = await db.get(ImageMeta, path)
+    if meta is None:
+        meta = ImageMeta(path=path)
+        db.add(meta)
+    meta.scene_description = caption
+    meta.scene_instruction = instruction
+    meta.scene_described_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(meta)
+
+    return _scene_response(path, meta)
 
 
 def search_pattern(q: str) -> str:
@@ -462,7 +636,7 @@ async def search_images(
             "filename": key.split("/", 1)[1] if "/" in key else key,
             "size": obj["Size"],
             "last_modified": obj["LastModified"],
-            "tags": meta.tags,
+            **_meta_fields(meta),
         }
 
     # Concurrently, because this is the page's real cost. Each row needs one S3 HEAD, and a

--- a/app/schemas/images.py
+++ b/app/schemas/images.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -5,3 +6,28 @@ from pydantic import BaseModel, Field
 
 class ImageTagsUpdate(BaseModel):
     tags: Optional[str] = Field(None, max_length=500, description="Comma-separated tags")
+
+
+class ImageSceneRequest(BaseModel):
+    """Describe this image now. Both "first description" and "re-roll" are this call.
+
+    Style and instruction mirror CaptionRequest so a one-off "try it shorter" is possible
+    without moving the global setting.
+    """
+
+    style: Optional[str] = None
+    instruction: Optional[str] = Field(default=None, max_length=2000)
+
+
+class ImageSceneResponse(BaseModel):
+    path: str
+    # None means never described. Distinct from "" which nothing writes -- a blank caption
+    # is a captioner failure, not a description.
+    scene_description: Optional[str] = None
+    # HOW it was described. A caption written under "terse" and one under "rich" are
+    # different artefacts and the row has to say which this is.
+    scene_instruction: Optional[str] = None
+    scene_described_at: Optional[datetime] = None
+    # Length is the thing being judged: the description sits beside a ~100-word arc, and
+    # whether it is 25 or 80 words changes the balance between scene and motion.
+    words: int = 0

--- a/tests/test_image_scene_description.py
+++ b/tests/test_image_scene_description.py
@@ -1,0 +1,229 @@
+"""An image's scene description is produced once and kept (console#414).
+
+JoyCaption costs 2070 time — 4.5s cold, 1.2s warm, on the box that also serves
+Automatic1111 — and the same image starts many jobs. POST /captions/describe is
+deliberately stateless, so until now every job paid for the same frame again.
+
+The value is NOT a cache that can be rebuilt. The model is nondeterministic: describing the
+frame again gives different words, and the words are what the person read and accepted. That
+is why re-describing is an explicit action, and why nothing may throw the row away as a side
+effect of an unrelated edit.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+
+from app.models import ImageMeta
+
+BUCKET = "wanly-images"
+PATH = f"s3://{BUCKET}/2026-09-05/00001.png"
+OTHER = f"s3://{BUCKET}/2026-09-05/00002.png"
+
+
+class TestRowLifetime:
+    """The row outlives the tags on it."""
+
+    def test_a_row_holding_only_a_description_is_not_empty(self):
+        meta = ImageMeta(path=PATH, tags=None, scene_description="a woman on a sofa")
+        assert not meta.is_empty()
+
+    def test_a_row_holding_only_tags_is_not_empty(self):
+        assert not ImageMeta(path=PATH, tags="Kelly").is_empty()
+
+    def test_a_row_holding_neither_is_empty(self):
+        assert ImageMeta(path=PATH, tags="   ", scene_description="").is_empty()
+
+    @pytest.mark.asyncio
+    async def test_clearing_tags_keeps_the_description(self, db):
+        """The tags endpoint used to delete the row outright. That threw away GPU work as a
+        side effect of removing a tag."""
+        db.add(ImageMeta(path=PATH, tags="Kelly", scene_description="a woman on a sofa",
+                         scene_described_at=datetime.now(timezone.utc)))
+        await db.flush()
+
+        resp = await _patch_tags(db, PATH, None)
+        assert resp.status_code == 200
+
+        meta = await db.get(ImageMeta, PATH)
+        assert meta is not None, "the row was deleted and the description with it"
+        assert meta.tags is None
+        assert meta.scene_description == "a woman on a sofa"
+
+    @pytest.mark.asyncio
+    async def test_clearing_tags_on_a_bare_row_still_removes_it(self, db):
+        """`list_untagged_images` reads "no row" as "never tagged", so a row that says
+        nothing must not survive and make an untagged image look handled."""
+        db.add(ImageMeta(path=PATH, tags="Kelly"))
+        await db.flush()
+
+        await _patch_tags(db, PATH, None)
+        assert await db.get(ImageMeta, PATH) is None
+
+
+class TestDescribeEndpoint:
+    @pytest.mark.asyncio
+    async def test_it_stores_what_the_captioner_said(self, db):
+        resp = await _post_scene(db, PATH, caption="a woman in a red dress on a sofa")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["scene_description"] == "a woman in a red dress on a sofa"
+        assert body["words"] == 9
+        assert body["scene_described_at"] is not None
+
+        meta = await db.get(ImageMeta, PATH)
+        assert meta.scene_description == "a woman in a red dress on a sofa"
+        # HOW it was described, not only what was said.
+        assert meta.scene_instruction
+
+    @pytest.mark.asyncio
+    async def test_describing_again_replaces_the_previous(self, db):
+        """This endpoint IS the re-roll. It always regenerates — an "only if missing" rule
+        here would make re-roll impossible to express."""
+        await _post_scene(db, PATH, caption="first words")
+        await _post_scene(db, PATH, caption="second words")
+
+        meta = await db.get(ImageMeta, PATH)
+        assert meta.scene_description == "second words"
+
+    @pytest.mark.asyncio
+    async def test_describing_does_not_disturb_the_tags(self, db):
+        db.add(ImageMeta(path=PATH, tags="Kelly, Sofa"))
+        await db.flush()
+
+        await _post_scene(db, PATH, caption="a woman on a sofa")
+
+        meta = await db.get(ImageMeta, PATH)
+        assert meta.tags == "Kelly, Sofa"
+        assert meta.scene_description == "a woman on a sofa"
+
+    @pytest.mark.asyncio
+    async def test_a_blank_caption_is_a_failure_not_a_description(self, db):
+        """Storing "" would mark the image described and stop anything ever asking again."""
+        resp = await _post_scene(db, PATH, caption="   ")
+        assert resp.status_code == 503
+        assert await db.get(ImageMeta, PATH) is None
+
+    @pytest.mark.asyncio
+    async def test_a_captioner_that_is_down_is_a_503(self, db):
+        from app.joycaption import CaptionError
+
+        resp = await _post_scene(db, PATH, error=CaptionError("2070 unreachable"))
+        assert resp.status_code == 503
+        assert await db.get(ImageMeta, PATH) is None
+
+    @pytest.mark.asyncio
+    async def test_a_path_outside_the_images_bucket_is_refused(self, db):
+        resp = await _post_scene(db, "s3://wanly-jobs/x/seg0-last.png", caption="nope")
+        assert resp.status_code == 400
+
+
+class TestGetEndpoint:
+    @pytest.mark.asyncio
+    async def test_never_described_returns_nulls_not_404(self, db):
+        """"No description yet" is an ordinary state of a perfectly good image, and the New
+        Job modal has to render it either way."""
+        resp = await _get_scene(db, PATH)
+        assert resp.status_code == 200
+        assert resp.json()["scene_description"] is None
+        assert resp.json()["words"] == 0
+
+    @pytest.mark.asyncio
+    async def test_it_returns_what_was_stored(self, db):
+        db.add(ImageMeta(path=PATH, scene_description="a woman on a sofa",
+                         scene_instruction="describe it", 
+                         scene_described_at=datetime.now(timezone.utc)))
+        await db.flush()
+
+        body = (await _get_scene(db, PATH)).json()
+        assert body["scene_description"] == "a woman on a sofa"
+        assert body["scene_instruction"] == "describe it"
+        assert body["words"] == 5
+
+
+class TestMoveCarriesTheRow:
+    """A move used to drop the row, and with it the tags. Survivable for a tag; not for a
+    description that cost GPU time and cannot be reproduced word for word."""
+
+    @pytest.mark.asyncio
+    async def test_the_description_follows_the_object(self, db):
+        db.add(ImageMeta(path=PATH, tags="Kelly", scene_description="a woman on a sofa"))
+        await db.flush()
+
+        resp = await _move(db, ["2026-09-05/00001.png"], "2026-09-06")
+        assert resp.status_code == 200
+
+        assert await db.get(ImageMeta, PATH) is None
+        moved = await db.get(ImageMeta, f"s3://{BUCKET}/2026-09-06/00001.png")
+        assert moved is not None
+        assert moved.tags == "Kelly"
+        assert moved.scene_description == "a woman on a sofa"
+
+    @pytest.mark.asyncio
+    async def test_an_image_with_no_row_moves_without_inventing_one(self, db):
+        resp = await _move(db, ["2026-09-05/00001.png"], "2026-09-06")
+        assert resp.status_code == 200
+        count = (await db.execute(sa.select(sa.func.count()).select_from(ImageMeta))).scalar()
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------------------
+# Harness. The routes are exercised through the app so the response models are covered too,
+# with S3 and the captioner patched out — neither is reachable from a test run.
+# ---------------------------------------------------------------------------------------
+
+async def _client(db):
+    from httpx import ASGITransport, AsyncClient
+    from app.auth import get_current_user
+    from app.database import get_db
+    from app.main import app
+
+    app.dependency_overrides[get_current_user] = lambda: object()
+    app.dependency_overrides[get_db] = lambda: db
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+async def _patch_tags(db, path, tags):
+    client, app = await _client(db)
+    try:
+        async with client as c:
+            return await c.patch("/images/tags", params={"path": path}, json={"tags": tags})
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def _get_scene(db, path):
+    client, app = await _client(db)
+    try:
+        async with client as c:
+            return await c.get("/images/scene", params={"path": path})
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def _post_scene(db, path, caption=None, error=None):
+    client, app = await _client(db)
+    describe = (
+        patch("app.routes.images.caption_image_bytes", side_effect=error) if error
+        else patch("app.routes.images.caption_image_bytes",
+                   return_value=(caption, "an instruction"))
+    )
+    try:
+        with patch("app.routes.images.download_bytes", return_value=b"png"), describe:
+            async with client as c:
+                return await c.post("/images/scene", params={"path": path}, json={})
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def _move(db, keys, target):
+    client, app = await _client(db)
+    try:
+        with patch("app.routes.images.move_object"):
+            async with client as c:
+                return await c.post("/images/move",
+                                    json={"keys": keys, "target_folder": target})
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
API half of DavidJBarnes/wanly-console#414. The console half is DavidJBarnes/wanly-console#433, which must merge after this.

## Why

JoyCaption costs 2070 time — 4.5s cold, 1.2s warm, on the box that also serves Automatic1111 — and the same image starts many jobs. `POST /captions/describe` is deliberately stateless ("a preview the user rejects must leave no trace"), so every job paid for the same frame again.

This is **not a cache that can be rebuilt.** The model is nondeterministic: describing a frame twice gives different words, and the words are what the person read and accepted. So it is a stored value with an explicit re-roll — and two existing behaviours that quietly throw metadata away had to stop.

## What changes

- **Migration 087** — `scene_description`, `scene_instruction`, `scene_described_at` on `image_meta`. The instruction is stored because a caption written under `terse` and one under `rich` are different artefacts; a row holding one without saying which is uninterpretable later.
- **`GET /images/scene`** — the saved description, or nulls. Nulls rather than 404: an image with no description is a perfectly good image and every caller renders that case anyway.
- **`POST /images/scene`** — describe now, store, return. Always regenerates: this one call is both the first description and the re-roll, because they are the same act, and an "only if missing" rule would make re-roll impossible to express. A blank caption is a 503, not a stored value — storing `""` would mark the image described forever.
- **`PATCH /images/tags` no longer deletes the row on a cleared tag.** Correct when tags were all it held; now it drops GPU work as a side effect of a tag edit. The row goes only when nothing is left on it, so `list_untagged_images` still reads "no row" as "never tagged".
- **`POST /images/move` carries the row.** It never did, so a move silently lost an image's tags. Survivable for a tag; not for a description.
- The four listings return the description, through one shared meta helper — there were three copies of that select and this would have made four.

## Verification

- 725 tests pass (`REQUIRE_DB=1`), 15 new covering row lifetime, the endpoints, the blank/503 cases and the move.
- Migration 087 applied and rolled back against a clean database; the full chain to head runs.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J