### PR TITLE
segments: resolve <SCENE> from the image's saved description

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -27,7 +27,7 @@ from app.model_requirements import (
     required_artifacts,
     unsatisfied,
 )
-from app.routes.segments import _resolve_wildcards
+from app.routes.segments import _resolve_wildcards, _unwrap_scene
 from app.s3 import delete_object, delete_prefix, delete_prefix_except, upload_bytes
 from app.tag_filter import like_escape, tag_clause
 
@@ -187,7 +187,10 @@ async def create_job(
         job.lynx_subject_image = job.starting_image
 
     seg = body.first_segment
-    resolved_prompt, prompt_template = await _resolve_wildcards(db, seg.prompt)
+    # The console fills and strips its own <scene>…</scene> markers (console#427). Stripped
+    # again here because this path stores the prompt without going through _resolve_scene,
+    # and a marker left in it would reach the text encoder as literal tokens.
+    resolved_prompt, prompt_template = await _resolve_wildcards(db, _unwrap_scene(seg.prompt))
     segment = Segment(
         job_id=job.id,
         index=0,

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -19,13 +19,16 @@ from sqlalchemy.orm import selectinload
 
 from app.auth import get_current_user, verify_api_key, verify_api_key_or_bearer
 from app import s3
+from app.config import settings
 from app.database import get_db
 from app.routes.captions import caption_image_bytes
 from app.seeds import new_seed
 from app.enums import JobStatus, SegmentStatus, VideoStatus
 from app.ltx_stack import LTX_STACK
 from app.model_requirements import CHECKPOINT, canonical
-from app.models import AppSetting, Job, LtxCharacter, Segment, User, Video, Wildcard, Worker
+from app.models import (
+    AppSetting, ImageMeta, Job, LtxCharacter, Segment, User, Video, Wildcard, Worker,
+)
 from app.negative_prompt import default_negative_prompt
 from app.s3 import delete_object, download_file, move_object, parse_s3_uri
 from app.schemas.segments import (
@@ -106,6 +109,10 @@ async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None,
     (final=True) the start image is as known as it will ever be, so an unresolved
     placeholder is dropped rather than shipped to the encoder.
     """
+    # Before anything else: a prompt may arrive with a region the console filled and failed
+    # to strip, and the words inside it are the scene — there is nothing left to resolve.
+    prompt = _unwrap_scene(prompt)
+
     if SCENE_PLACEHOLDER not in prompt:
         return prompt
 
@@ -127,9 +134,18 @@ async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None,
         logger.info("Deferring %s: start image not known until claim", SCENE_PLACEHOLDER)
         return prompt
 
+    # A repo image may already have been described, by the person who tagged it or by an
+    # earlier claim (console#414). Reusing those words costs a SELECT instead of 1.2-4.5s on
+    # the 2070, and it means the render uses the description that was read and accepted
+    # rather than a fresh, different one the model happened to produce this time.
+    cached = await _cached_scene(db, image_uri)
+    if cached:
+        logger.info("Resolved %s from %s (saved description)", SCENE_PLACEHOLDER, image_uri)
+        return prompt.replace(SCENE_PLACEHOLDER, cached)
+
     try:
         image = await asyncio.to_thread(s3.download_bytes, image_uri)
-        caption, _ = await caption_image_bytes(db, image)
+        caption, instruction = await caption_image_bytes(db, image)
     except Exception as e:
         # Never fatal. A captioner that is down must not stop a render — the pose still has
         # its arc, and a generic scene is what every pose used before this existed.
@@ -137,8 +153,66 @@ async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None,
                        SCENE_PLACEHOLDER, image_uri, e)
         return _drop_scene(prompt)
 
+    await _save_scene(db, image_uri, caption, instruction)
     logger.info("Resolved %s from %s: %r", SCENE_PLACEHOLDER, image_uri, caption[:80])
     return prompt.replace(SCENE_PLACEHOLDER, caption)
+
+
+def _is_repo_image(uri: str | None) -> bool:
+    """Is this an image in the repo, as opposed to a frame a render produced?
+
+    Only repo images get image_meta rows. A continuation starts from a generated frame in
+    the JOBS bucket, and giving those rows would leak them into the Image Repo's filename
+    search — /images/search selects FROM image_meta and HEADs whatever path it finds.
+    """
+    return bool(uri) and uri.startswith(f"s3://{settings.s3_images_bucket}/")
+
+
+async def _cached_scene(db: AsyncSession, image_uri: str) -> str | None:
+    if not _is_repo_image(image_uri):
+        return None
+    meta = await db.get(ImageMeta, image_uri)
+    return (meta.scene_description or None) if meta else None
+
+
+async def _save_scene(db: AsyncSession, image_uri: str, caption: str, instruction: str) -> None:
+    """Keep what this claim just paid for, so the next job starting here gets it free.
+
+    Best-effort: a segment that rendered must not fail over bookkeeping, and the caption is
+    already in hand either way.
+    """
+    if not _is_repo_image(image_uri) or not caption.strip():
+        return
+    try:
+        meta = await db.get(ImageMeta, image_uri)
+        if meta is None:
+            meta = ImageMeta(path=image_uri)
+            db.add(meta)
+        meta.scene_description = caption
+        meta.scene_instruction = instruction
+        meta.scene_described_at = datetime.now(timezone.utc)
+        await db.flush()
+    except Exception as e:  # noqa: BLE001 - never fatal to a render
+        logger.warning("Could not save the description for %s (%s)", image_uri, e)
+
+
+# `<scene>…</scene>` — a scene the console has already filled in (console#427).
+#
+# The console marks the filled region so it can be rewritten in place: re-describe, or
+# change the start frame, and only the inside changes. It strips the markers before it
+# sends. This strips them AGAIN, because a marker reaching the text encoder is garbage
+# tokens for exactly the reason _drop_scene exists, and "the client promised not to" is not
+# a guarantee — the daemon, a retry of an older prompt, and anything not the console all
+# post here too.
+#
+# Paired form first, then any leftover bare tag. That pairing, not letter case, is what
+# separates a filled region from the unfilled <SCENE> placeholder.
+_SCENE_REGION = re.compile(r"<scene>(.*?)</scene>", re.IGNORECASE | re.DOTALL)
+
+
+def _unwrap_scene(prompt: str) -> str:
+    """Keep the words, drop the markers. Leaves the bare <SCENE> placeholder alone."""
+    return _SCENE_REGION.sub(r"\1", prompt)
 
 
 def _drop_scene(prompt: str) -> str:
@@ -553,7 +627,9 @@ async def claim_next_segment(
     # runs for a prompt that actually carries the placeholder. An earlier draft of this work
     # avoided the claim path on the strength of a 60-90s estimate that turned out to be
     # wall-clock on a multi-prompt script, and was wrong.
-    if SCENE_PLACEHOLDER in (segment.prompt or ""):
+    # Either form: an unfilled placeholder to resolve, or a filled region whose markers must
+    # come off before the prompt reaches the encoder.
+    if SCENE_PLACEHOLDER in (segment.prompt or "") or _SCENE_REGION.search(segment.prompt or ""):
         resolved = await _resolve_scene(db, segment.prompt, resolved_start_image, final=True)
         if resolved != segment.prompt:
             # Persisted, not just returned: the segment must record what it actually ran, so
@@ -786,7 +862,7 @@ async def update_segment_prompt(
             ),
         )
 
-    source = body.prompt
+    source = _unwrap_scene(body.prompt)
 
     resolved, template = await _resolve_wildcards(db, source)
     segment.prompt = resolved

--- a/tests/test_scene_cache_and_markers.py
+++ b/tests/test_scene_cache_and_markers.py
@@ -1,0 +1,142 @@
+"""The claim path reads the same saved description the console does (console#427).
+
+Two things meet here. A repo image that was already described must not be described again —
+that is 1.2-4.5s of 2070 time for words that already exist, and the model is
+nondeterministic, so a second call would render with a DIFFERENT description from the one
+the person read. And the console's `<scene>…</scene>` markers, which make a filled scene
+rewritable while composing, must never reach the text encoder.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.config import settings
+from app.models import ImageMeta
+from app.routes.segments import (
+    SCENE_PLACEHOLDER,
+    _is_repo_image,
+    _resolve_scene,
+    _unwrap_scene,
+)
+
+REPO = f"s3://{settings.s3_images_bucket}/2026-09-05/00001.png"
+GENERATED = "s3://wanly-jobs/some-job/seg0-last.png"
+TEMPLATE = f"k3llydw, {SCENE_PLACEHOLDER}, she grips the edge of the sofa"
+
+
+class TestUnwrapMarkers:
+    """The console strips these before sending. This is the guarantee, not the promise —
+    the daemon, a retried older prompt and anything that is not the console post here too."""
+
+    def test_it_keeps_the_words_and_drops_the_markers(self):
+        assert _unwrap_scene("k3llydw, <scene>a woman on a sofa</scene>, she grips") == (
+            "k3llydw, a woman on a sofa, she grips"
+        )
+
+    def test_it_leaves_an_unfilled_placeholder_alone(self):
+        # That one is _resolve_scene's job: it gets described, or dropped.
+        assert _unwrap_scene(TEMPLATE) == TEMPLATE
+
+    def test_it_is_case_insensitive_and_spans_newlines(self):
+        assert _unwrap_scene("a <SCENE>two\nlines</SCENE> b") == "a two\nlines b"
+
+    def test_two_regions_do_not_merge_into_one(self):
+        # A greedy match would swallow everything between the first open and the last close,
+        # taking the words in between with it.
+        assert _unwrap_scene("<scene>a</scene> and <scene>b</scene>") == "a and b"
+
+    def test_a_prompt_with_no_markers_is_untouched(self):
+        assert _unwrap_scene("k3llydw, a woman on a sofa") == "k3llydw, a woman on a sofa"
+
+
+class TestWhichImagesGetRows:
+    """Only repo images. /images/search selects FROM image_meta and HEADs whatever path it
+    finds, so a row for a generated frame would put that frame in the Image Repo."""
+
+    def test_a_repo_image_does(self):
+        assert _is_repo_image(REPO)
+
+    def test_a_generated_continuation_frame_does_not(self):
+        assert not _is_repo_image(GENERATED)
+
+    def test_nothing_does(self):
+        assert not _is_repo_image(None)
+        assert not _is_repo_image("")
+
+
+class TestResolveUsesTheCache:
+    @pytest.mark.asyncio
+    async def test_a_described_image_is_not_described_again(self, db):
+        db.add(ImageMeta(path=REPO, scene_description="a woman in a red dress on a sofa",
+                         scene_described_at=datetime.now(timezone.utc)))
+        await db.flush()
+
+        with patch("app.routes.segments.caption_image_bytes",
+                   new=AsyncMock()) as captioner:
+            out = await _resolve_scene(db, TEMPLATE, REPO, final=True)
+
+        captioner.assert_not_called()
+        assert out == "k3llydw, a woman in a red dress on a sofa, she grips the edge of the sofa"
+
+    @pytest.mark.asyncio
+    async def test_describing_a_repo_image_saves_it_for_next_time(self, db):
+        with patch("app.routes.segments.s3.download_bytes", return_value=b"png"), \
+             patch("app.routes.segments.caption_image_bytes",
+                   new=AsyncMock(return_value=("a woman on a sofa", "an instruction"))):
+            out = await _resolve_scene(db, TEMPLATE, REPO, final=True)
+
+        assert "a woman on a sofa" in out
+        meta = await db.get(ImageMeta, REPO)
+        assert meta is not None
+        assert meta.scene_description == "a woman on a sofa"
+        assert meta.scene_instruction == "an instruction"
+
+    @pytest.mark.asyncio
+    async def test_a_generated_frame_is_described_but_never_stored(self, db):
+        """Every continuation is this case. It still gets a description; it just does not
+        get a row, because a row would put it in the Image Repo."""
+        with patch("app.routes.segments.s3.download_bytes", return_value=b"png"), \
+             patch("app.routes.segments.caption_image_bytes",
+                   new=AsyncMock(return_value=("a woman by a pool", "an instruction"))):
+            out = await _resolve_scene(db, TEMPLATE, GENERATED, final=True)
+
+        assert "a woman by a pool" in out
+        assert await db.get(ImageMeta, GENERATED) is None
+
+    @pytest.mark.asyncio
+    async def test_a_row_with_tags_but_no_description_still_describes(self, db):
+        """A tagged image from before this existed. An empty description is not a
+        description, and must not read as "already done"."""
+        db.add(ImageMeta(path=REPO, tags="Kelly"))
+        await db.flush()
+
+        with patch("app.routes.segments.s3.download_bytes", return_value=b"png"), \
+             patch("app.routes.segments.caption_image_bytes",
+                   new=AsyncMock(return_value=("a woman on a sofa", "an instruction"))):
+            out = await _resolve_scene(db, TEMPLATE, REPO, final=True)
+
+        assert "a woman on a sofa" in out
+        meta = await db.get(ImageMeta, REPO)
+        assert meta.tags == "Kelly", "describing must not disturb the tags"
+
+    @pytest.mark.asyncio
+    async def test_a_filled_region_needs_no_captioner_at_all(self, db):
+        """The words are already there. Resolving is just taking the markers off."""
+        filled = "k3llydw, <scene>a woman on a sofa</scene>, she grips"
+        with patch("app.routes.segments.caption_image_bytes", new=AsyncMock()) as captioner:
+            out = await _resolve_scene(db, filled, REPO, final=True)
+
+        captioner.assert_not_called()
+        assert out == "k3llydw, a woman on a sofa, she grips"
+
+    @pytest.mark.asyncio
+    async def test_a_captioner_that_is_down_still_drops_the_placeholder(self, db):
+        """Unchanged, and the reason it matters is unchanged: a literal <SCENE> is garbage
+        tokens, while dropping it leaves a valid if generic prompt."""
+        with patch("app.routes.segments.s3.download_bytes", side_effect=RuntimeError("down")):
+            out = await _resolve_scene(db, TEMPLATE, REPO, final=True)
+
+        assert SCENE_PLACEHOLDER not in out
+        assert await db.get(ImageMeta, REPO) is None


### PR DESCRIPTION
API half of DavidJBarnes/wanly-console#427. Builds on #254.

## What changes

**The claim path reads the cache.** `_resolve_scene` checks the image's saved description before calling the captioner. That is a SELECT instead of 1.2–4.5s on the 2070 — but the stronger reason is correctness: the model is nondeterministic, so describing the frame again renders with *different words from the ones the person read and accepted*.

**And warms it.** When a claim does describe a repo image, the result is saved, so the next job starting from that frame gets it free. Best-effort — a segment that rendered must not fail over bookkeeping.

**Only repo images get rows.** Every continuation starts from a generated frame in the jobs bucket. `/images/search` selects FROM `image_meta` and HEADs whatever path it finds, so giving those frames rows would put them in the Image Repo. They are still described; they are just never stored.

**`<scene>…</scene>` markers are stripped server-side.** The console marks a filled scene so it can be rewritten in place while composing, and strips the markers before sending. This strips them again at every point a prompt enters — `_resolve_scene`, the job-create path (which stores a first segment without going through it), and the prompt edit. "The client promised not to" is not a guarantee: the daemon, a retried older prompt, and anything that is not the console post here too, and a marker reaching the text encoder is garbage tokens for the same reason `_drop_scene` exists.

## Verification

739 tests pass (`REQUIRE_DB=1`), 14 new: the unwrap rules (case, newlines, two regions not merging into one), which paths get rows, cache hit/miss, a tagged-but-undescribed row, a filled region needing no captioner at all, and the captioner-down path still dropping the placeholder.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J