### PR TITLE
segments: hold a filled <scene> region out of the wildcard resolver's reach

### DIFF
--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -27,7 +27,7 @@ from app.model_requirements import (
     required_artifacts,
     unsatisfied,
 )
-from app.routes.segments import _resolve_wildcards, _unwrap_scene
+from app.routes.segments import _resolve_wildcards_outside_scene
 from app.s3 import delete_object, delete_prefix, delete_prefix_except, upload_bytes
 from app.tag_filter import like_escape, tag_clause
 
@@ -187,10 +187,11 @@ async def create_job(
         job.lynx_subject_image = job.starting_image
 
     seg = body.first_segment
-    # The console fills and strips its own <scene>…</scene> markers (console#427). Stripped
-    # again here because this path stores the prompt without going through _resolve_scene,
-    # and a marker left in it would reach the text encoder as literal tokens.
-    resolved_prompt, prompt_template = await _resolve_wildcards(db, _unwrap_scene(seg.prompt))
+    # The console fills and strips its own <scene>…</scene> markers (console#427). Handled
+    # again here because this path stores the prompt without going through _resolve_scene:
+    # the markers come off, and the caption inside them is held back from the wildcard
+    # resolver rather than fed to it.
+    resolved_prompt, prompt_template = await _resolve_wildcards_outside_scene(db, seg.prompt)
     segment = Segment(
         job_id=job.id,
         index=0,

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -215,6 +215,50 @@ def _unwrap_scene(prompt: str) -> str:
     return _SCENE_REGION.sub(r"\1", prompt)
 
 
+# A stand-in the wildcard resolver cannot see. Its pattern is <([^<>]+)>, and this has no
+# angle brackets at all.
+def _scene_mask(i: int) -> str:
+    return f"\x00wanly-scene-{i}\x00"
+
+
+async def _resolve_wildcards_outside_scene(
+    db: AsyncSession, prompt: str
+) -> tuple[str, str | None]:
+    """Resolve wildcards with any filled <scene> region held out of reach.
+
+    THE CAPTION MUST NEVER BE SCANNED FOR WILDCARDS. It is model output, and a description
+    that happened to contain <colour> would have a random option spliced into it. The API's
+    own ordering used to guarantee that for free — <SCENE> is filled AFTER wildcards, so the
+    words were not there yet — but the console now fills the region before it sends
+    (console#427), so the caption arrives inside the prompt and the guarantee has to be
+    enforced rather than inherited.
+
+    Masking also keeps the MARKERS away from the resolver. `<scene>` and `</scene>` both
+    match its pattern, as names "scene" and "/scene". Neither can be substituted today —
+    "scene" is reserved case-insensitively, and nothing is named "/scene" — but a match with
+    no substitution still makes _resolve_wildcards return a non-NULL template, which is the
+    record of "this prompt had wildcards in it" and would then be wrong.
+
+    Returns the caption UNWRAPPED in both the resolved prompt and the template: the markers
+    are a console editing affordance and have no meaning once a segment is stored.
+    """
+    captions: list[str] = []
+
+    def take(m: re.Match) -> str:
+        captions.append(m.group(1))
+        return _scene_mask(len(captions) - 1)
+
+    masked = _SCENE_REGION.sub(take, prompt)
+    resolved, template = await _resolve_wildcards(db, masked)
+
+    def restore(text: str) -> str:
+        for i, caption in enumerate(captions):
+            text = text.replace(_scene_mask(i), caption)
+        return text
+
+    return restore(resolved), (restore(template) if template is not None else None)
+
+
 def _drop_scene(prompt: str) -> str:
     """Remove the placeholder and the comma-space that would be left dangling beside it.
 
@@ -337,7 +381,7 @@ async def add_segment(
     next_index = max((s.index for s in job.segments), default=-1) + 1
 
     prompt = await _resolve_trigger(db, body.prompt, body.ltx_recipe)
-    resolved_prompt, prompt_template = await _resolve_wildcards(db, prompt)
+    resolved_prompt, prompt_template = await _resolve_wildcards_outside_scene(db, prompt)
     # After wildcards, deliberately — see _resolve_scene. The console resolves this itself
     # for segment 0, where a person can review the caption first; this catches a prompt that
     # arrives still carrying the placeholder, which is every continuation and any caller
@@ -862,9 +906,9 @@ async def update_segment_prompt(
             ),
         )
 
-    source = _unwrap_scene(body.prompt)
+    source = body.prompt
 
-    resolved, template = await _resolve_wildcards(db, source)
+    resolved, template = await _resolve_wildcards_outside_scene(db, source)
     segment.prompt = resolved
     segment.prompt_template = template
     await db.commit()
@@ -1537,7 +1581,7 @@ async def _reroll(db: AsyncSession, job: Job, old: Segment,
         # does not exist yet, and the claim resolves it then — the same way a continuation
         # created through the normal path is handled.
         triggered = await _resolve_trigger(db, prompt, old.ltx_recipe)
-        resolved, template = await _resolve_wildcards(db, triggered)
+        resolved, template = await _resolve_wildcards_outside_scene(db, triggered)
 
     fresh = _roll_new_take(job, old, prompt=resolved, prompt_template=template)
     db.add(fresh)

--- a/tests/test_scene_cache_and_markers.py
+++ b/tests/test_scene_cache_and_markers.py
@@ -140,3 +140,87 @@ class TestResolveUsesTheCache:
 
         assert SCENE_PLACEHOLDER not in out
         assert await db.get(ImageMeta, REPO) is None
+
+
+class TestSceneAndWildcardsDoNotCollide:
+    """A filled scene must be invisible to the wildcard resolver.
+
+    <SCENE> is filled AFTER wildcards precisely so the caption is never re-scanned — a
+    description is model output, and one containing <color> would otherwise have a random
+    option spliced into it. The console filling the region before it sends (console#427)
+    moved the caption into the prompt BEFORE the API sees it, so that ordering no longer
+    protects anything on its own and the region has to be held out of reach explicitly.
+    """
+
+    @staticmethod
+    async def _wildcard(db, name, options):
+        from app.models import Wildcard
+
+        db.add(Wildcard(name=name, options=options))
+        await db.flush()
+
+    @pytest.mark.asyncio
+    async def test_a_caption_containing_a_wildcard_name_is_left_alone(self, db):
+        from app.routes.segments import _resolve_wildcards_outside_scene
+
+        await self._wildcard(db, "color", ["scarlet"])
+        prompt = "k3llydw, <scene>a woman in a <color> dress</scene>, she grips"
+
+        resolved, _ = await _resolve_wildcards_outside_scene(db, prompt)
+
+        assert resolved == "k3llydw, a woman in a <color> dress, she grips"
+        assert "scarlet" not in resolved, "the caption was scanned for wildcards"
+
+    @pytest.mark.asyncio
+    async def test_a_wildcard_OUTSIDE_the_scene_still_resolves(self, db):
+        """The masking must not cost the feature it is protecting."""
+        from app.routes.segments import _resolve_wildcards_outside_scene
+
+        await self._wildcard(db, "color", ["scarlet"])
+        prompt = "k3llydw, <scene>a woman on a sofa</scene>, a <color> light"
+
+        resolved, _ = await _resolve_wildcards_outside_scene(db, prompt)
+
+        assert resolved == "k3llydw, a woman on a sofa, a scarlet light"
+
+    @pytest.mark.asyncio
+    async def test_the_markers_do_not_count_as_wildcards(self, db):
+        """`<scene>` and `</scene>` both match the resolver's pattern, as "scene" and
+        "/scene". A match that substitutes nothing still sets the template, which is the
+        record of "this prompt had wildcards in it"."""
+        from app.routes.segments import _resolve_wildcards_outside_scene
+
+        resolved, template = await _resolve_wildcards_outside_scene(
+            db, "k3llydw, <scene>a woman on a sofa</scene>, she grips")
+
+        assert resolved == "k3llydw, a woman on a sofa, she grips"
+        assert template is None, "the markers were counted as wildcards"
+
+    @pytest.mark.asyncio
+    async def test_an_unfilled_placeholder_still_reaches_the_resolver_untouched(self, db):
+        """<SCENE> is not a region and must survive to be described later."""
+        from app.routes.segments import _resolve_wildcards_outside_scene
+
+        resolved, _ = await _resolve_wildcards_outside_scene(db, TEMPLATE)
+        assert SCENE_PLACEHOLDER in resolved
+
+    @pytest.mark.asyncio
+    async def test_the_template_records_the_prompt_with_its_wildcards_intact(self, db):
+        from app.routes.segments import _resolve_wildcards_outside_scene
+
+        await self._wildcard(db, "color", ["scarlet"])
+        prompt = "k3llydw, <scene>a woman on a sofa</scene>, a <color> light"
+
+        _, template = await _resolve_wildcards_outside_scene(db, prompt)
+
+        # The scene comes back unwrapped -- the markers are a console affordance and mean
+        # nothing to a stored segment -- while <color> is still there to be re-drawn.
+        assert template == "k3llydw, a woman on a sofa, a <color> light"
+
+    @pytest.mark.asyncio
+    async def test_two_regions_keep_their_own_captions(self, db):
+        from app.routes.segments import _resolve_wildcards_outside_scene
+
+        resolved, _ = await _resolve_wildcards_outside_scene(
+            db, "<scene>first</scene> then <scene>second</scene>")
+        assert resolved == "first then second"


### PR DESCRIPTION
Closes DavidJBarnes/wanly-console#437. Found by David asking whether `<scene></scene>` interferes with wildcards. It did.

## The rule that broke

`_resolve_scene`'s docstring:

> ORDER: this runs AFTER `_resolve_wildcards` … A caption is model output that may contain bracketed tokens, and running the wildcard resolver over it afterwards would expand them.

That held because the **API** filled `<SCENE>`, after wildcards — the caption words were not in the prompt yet. console#427 moved the fill to the **console**, which sends `<scene>a description</scene>` already filled. The caption now arrives inside the prompt, so the ordering protects nothing on its own, and the entry points that change added fed it straight to the resolver.

Same input, both paths:

```
input : k3llydw, <scene>a woman in a <color> dress</scene>, she grips
OLD   : k3llydw, a woman in a scarlet dress, she grips | template: 'k3llydw, a woman in a <color> dress, she grips'
NEW   : k3llydw, a woman in a <color> dress, she grips | template: None
```

Second, smaller effect: `<scene>` and `</scene>` match `<([^<>]+)>` as the names `scene` and `/scene`. Neither can be substituted — `scene` is reserved case-insensitively, nothing is named `/scene` — but a match that substitutes nothing still returns a non-NULL `prompt_template`, the record of "this prompt had wildcards in it". OLD invented one, NEW returns None.

## The fix

`_resolve_wildcards_outside_scene` masks each filled region with a sentinel the resolver cannot match — its pattern needs angle brackets, the sentinel has none — resolves wildcards on the rest, then restores the captions unwrapped. Used at every point a client-supplied prompt is resolved: segment create, job create, prompt edit, re-roll.

A wildcard **outside** the scene still resolves normally. That is why this masks rather than skipping resolution.

## Severity

Low in practice, and I'd rather say so than oversell it. Production has four wildcards (`color`, `cumshot`, `face`, `pov_actions`), and corrupting a caption needs JoyCaption to emit one of those names in literal angle brackets — under an instruction that says "state only what is visible". The console also strips the markers before sending, so the normal path never reaches any of this.

But the invariant is documented, it exists because the ordering mattered, and it is one plausible new wildcard away from mattering again. It should hold by construction rather than by luck.

## Verification

745 tests pass (`REQUIRE_DB=1`), 6 new: a caption containing a wildcard name is left alone, a wildcard outside the scene still resolves, the markers do not count as wildcards, a bare `<SCENE>` still survives to be described, the template keeps its real wildcards, and two regions keep their own captions. The old/new comparison above was run directly against both code paths.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J