### PR TITLE
images: keep a description for a generated frame, and keep it out of the repo

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -466,10 +466,23 @@ def _scene_response(path: str, meta: ImageMeta | None) -> ImageSceneResponse:
     )
 
 
-def _require_images_bucket(path: str) -> None:
-    bucket = settings.s3_images_bucket
-    if not path.startswith(f"s3://{bucket}/"):
-        raise HTTPException(status_code=400, detail="Path must be in the images bucket")
+def _describable_buckets() -> tuple[str, ...]:
+    """Where a frame this API will describe may live.
+
+    The images bucket is the repo. The jobs bucket holds generated frames — a segment's last
+    frame is the start frame of the one after it, and describing it is how a continuation
+    shows the words before they are used (console#438). Both are ours; anything else is not
+    a path this endpoint should be fetching.
+    """
+    return tuple(b for b in (settings.s3_images_bucket, settings.s3_jobs_bucket) if b)
+
+
+def _require_known_bucket(path: str) -> None:
+    if not any(path.startswith(f"s3://{b}/") for b in _describable_buckets()):
+        raise HTTPException(
+            status_code=400,
+            detail="Path must be in the images bucket or the jobs bucket",
+        )
 
 
 @router.get("/images/scene", response_model=ImageSceneResponse,
@@ -480,7 +493,7 @@ async def get_image_scene(path: str = Query(...), db: AsyncSession = Depends(get
     Nulls rather than a 404: "no description yet" is an ordinary state of a perfectly good
     image, and the caller — the New Job modal — has to render it either way.
     """
-    _require_images_bucket(path)
+    _require_known_bucket(path)
     return _scene_response(path, await db.get(ImageMeta, path))
 
 
@@ -498,7 +511,7 @@ async def describe_image_scene(
     "only if missing" rule here would be a second opinion about a decision the UI has
     already made, and would make re-roll impossible to express.
     """
-    _require_images_bucket(path)
+    _require_known_bucket(path)
     body = body or ImageSceneRequest()
 
     try:
@@ -586,6 +599,22 @@ def image_filter(q: str | None, tags: list[str], exclude: list[str]) -> list:
     return clauses
 
 
+def repo_images_only():
+    """Restrict a query over image_meta to the repo.
+
+    image_meta is keyed by s3:// path and now also holds descriptions of GENERATED frames —
+    a segment's last frame, described so a continuation can show the words before they are
+    used (console#438). Those live in the jobs bucket and are not repo images. Without this,
+    a filename search would HEAD one, find it, and put a render's intermediate frame in the
+    Image Repo, which is why console#427 refused to store them at all.
+
+    Separate from image_filter deliberately: that function returns the USER's criteria, and
+    an empty list is how the route knows nothing was asked for and answers 400 rather than
+    serving the whole repo. Folding this in would make it never empty.
+    """
+    return ImageMeta.path.like(f"s3://{settings.s3_images_bucket}/%")
+
+
 @router.get("/images/search", dependencies=[Depends(get_current_user)])
 async def search_images(
     q: str | None = Query(None, max_length=500),
@@ -613,12 +642,12 @@ async def search_images(
             detail="Provide q, or at least one tag — an unfiltered search is the folder listing.",
         )
 
-    count_q = select(func.count()).select_from(ImageMeta).where(*clauses)
+    count_q = select(func.count()).select_from(ImageMeta).where(repo_images_only(), *clauses)
     total = (await db.execute(count_q)).scalar() or 0
 
     meta_q = (
         select(ImageMeta)
-        .where(*clauses)
+        .where(repo_images_only(), *clauses)
         .order_by(ImageMeta.updated_at.desc())
         .offset(offset)
         .limit(limit)
@@ -683,7 +712,7 @@ async def image_tag_counts(
         select(tag_expr.label("tag"), func.count().label("count"))
         .select_from(ImageMeta)
         .join(tag_rows, true())
-        .where(*clauses, tag_expr != "")
+        .where(repo_images_only(), *clauses, tag_expr != "")
         .group_by(tag_expr)
         .order_by(func.count().desc(), tag_expr)
     )

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -134,10 +134,10 @@ async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None,
         logger.info("Deferring %s: start image not known until claim", SCENE_PLACEHOLDER)
         return prompt
 
-    # A repo image may already have been described, by the person who tagged it or by an
-    # earlier claim (console#414). Reusing those words costs a SELECT instead of 1.2-4.5s on
-    # the 2070, and it means the render uses the description that was read and accepted
-    # rather than a fresh, different one the model happened to produce this time.
+    # The frame may already have been described — by the person who tagged it, by the Next
+    # Segment dialog opening, or by an earlier claim (console#414, #438). Reusing those words
+    # costs a SELECT instead of 1.2-4.5s on the 2070, and it means the render uses the
+    # description that was actually shown rather than a fresh, different one.
     cached = await _cached_scene(db, image_uri)
     if cached:
         logger.info("Resolved %s from %s (saved description)", SCENE_PLACEHOLDER, image_uri)
@@ -158,18 +158,28 @@ async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None,
     return prompt.replace(SCENE_PLACEHOLDER, caption)
 
 
-def _is_repo_image(uri: str | None) -> bool:
-    """Is this an image in the repo, as opposed to a frame a render produced?
+def _is_describable(uri: str | None) -> bool:
+    """May this frame's description be kept?
 
-    Only repo images get image_meta rows. A continuation starts from a generated frame in
-    the JOBS bucket, and giving those rows would leak them into the Image Repo's filename
-    search — /images/search selects FROM image_meta and HEADs whatever path it finds.
+    Both buckets now. console#427 restricted this to the repo because /images/search selects
+    FROM image_meta and HEADs whatever path it finds, so a jobs-bucket row would have put a
+    generated frame in the Image Repo. That leak is fixed at its source — the search and
+    tag-count filters are constrained to the images bucket — so the restriction has been
+    lifted rather than worked around.
+
+    Keeping them matters: a segment's last frame is the start frame of the next one, the
+    console describes it when the Next Segment dialog opens (console#438), and without a
+    stored copy the claim would describe it AGAIN and render with different words from the
+    ones that were shown.
     """
-    return bool(uri) and uri.startswith(f"s3://{settings.s3_images_bucket}/")
+    if not uri:
+        return False
+    buckets = (settings.s3_images_bucket, settings.s3_jobs_bucket)
+    return any(uri.startswith(f"s3://{b}/") for b in buckets if b)
 
 
 async def _cached_scene(db: AsyncSession, image_uri: str) -> str | None:
-    if not _is_repo_image(image_uri):
+    if not _is_describable(image_uri):
         return None
     meta = await db.get(ImageMeta, image_uri)
     return (meta.scene_description or None) if meta else None
@@ -181,7 +191,7 @@ async def _save_scene(db: AsyncSession, image_uri: str, caption: str, instructio
     Best-effort: a segment that rendered must not fail over bookkeeping, and the caption is
     already in hand either way.
     """
-    if not _is_repo_image(image_uri) or not caption.strip():
+    if not _is_describable(image_uri) or not caption.strip():
         return
     try:
         meta = await db.get(ImageMeta, image_uri)

--- a/tests/test_image_scene_description.py
+++ b/tests/test_image_scene_description.py
@@ -115,8 +115,8 @@ class TestDescribeEndpoint:
         assert await db.get(ImageMeta, PATH) is None
 
     @pytest.mark.asyncio
-    async def test_a_path_outside_the_images_bucket_is_refused(self, db):
-        resp = await _post_scene(db, "s3://wanly-jobs/x/seg0-last.png", caption="nope")
+    async def test_a_path_in_neither_of_our_buckets_is_refused(self, db):
+        resp = await _post_scene(db, "s3://someone-elses-bucket/x.png", caption="nope")
         assert resp.status_code == 400
 
 
@@ -227,3 +227,69 @@ async def _move(db, keys, target):
                                     json={"keys": keys, "target_folder": target})
     finally:
         app.dependency_overrides.clear()
+
+
+class TestGeneratedFramesStayOutOfTheRepo:
+    """image_meta now holds descriptions of generated frames too (console#438).
+
+    That is only safe because the search is constrained to the images bucket. /images/search
+    selects FROM image_meta and HEADs whatever path it finds, so without the predicate a
+    filename search would put a render's intermediate frame in the Image Repo — which is the
+    reason console#427 refused to store them at all.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_search_filter_excludes_the_jobs_bucket(self, db):
+        from app.routes.images import image_filter, repo_images_only
+        from app.models import ImageMeta as IM
+
+        db.add_all([
+            IM(path=f"s3://{BUCKET}/2026-09-05/pool-party.png", tags="Kelly"),
+            IM(path="s3://wanly-jobs/j1/pool-party-seg0-last.png",
+               scene_description="a woman by a pool"),
+        ])
+        await db.flush()
+
+        # A filename fragment both rows match.
+        rows = (await db.execute(
+            sa.select(IM.path).where(repo_images_only(), *image_filter("pool-party", [], []))
+        )).scalars().all()
+
+        assert rows == [f"s3://{BUCKET}/2026-09-05/pool-party.png"]
+
+    @pytest.mark.asyncio
+    async def test_a_generated_frame_row_is_invisible_even_with_no_query(self, db):
+        from app.routes.images import image_filter, repo_images_only
+        from app.models import ImageMeta as IM
+
+        db.add(IM(path="s3://wanly-jobs/j1/seg0-last.png", tags="Kelly"))
+        await db.flush()
+
+        rows = (await db.execute(
+            sa.select(IM.path).where(repo_images_only(), *image_filter(None, ["Kelly"], []))
+        )).scalars().all()
+
+        assert rows == []
+
+
+class TestSceneEndpointsAcceptAGeneratedFrame:
+    """A segment's last frame is the start frame of the next one, so the Next Segment dialog
+    has to be able to read and describe it (console#438)."""
+
+    @pytest.mark.asyncio
+    async def test_get_accepts_a_jobs_bucket_path(self, db):
+        resp = await _get_scene(db, "s3://wanly-jobs/j1/seg0-last.png")
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_post_describes_and_stores_a_jobs_bucket_path(self, db):
+        path = "s3://wanly-jobs/j1/seg0-last.png"
+        resp = await _post_scene(db, path, caption="a woman kneeling on a bed")
+        assert resp.status_code == 200
+        meta = await db.get(ImageMeta, path)
+        assert meta.scene_description == "a woman kneeling on a bed"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_bucket_is_still_refused(self, db):
+        resp = await _post_scene(db, "s3://someone-elses-bucket/x.png", caption="nope")
+        assert resp.status_code == 400

--- a/tests/test_scene_cache_and_markers.py
+++ b/tests/test_scene_cache_and_markers.py
@@ -16,7 +16,7 @@ from app.config import settings
 from app.models import ImageMeta
 from app.routes.segments import (
     SCENE_PLACEHOLDER,
-    _is_repo_image,
+    _is_describable,
     _resolve_scene,
     _unwrap_scene,
 )
@@ -51,19 +51,27 @@ class TestUnwrapMarkers:
         assert _unwrap_scene("k3llydw, a woman on a sofa") == "k3llydw, a woman on a sofa"
 
 
-class TestWhichImagesGetRows:
-    """Only repo images. /images/search selects FROM image_meta and HEADs whatever path it
-    finds, so a row for a generated frame would put that frame in the Image Repo."""
+class TestWhichFramesMayBeKept:
+    """Both buckets, since console#438.
 
-    def test_a_repo_image_does(self):
-        assert _is_repo_image(REPO)
+    console#427 restricted this to the repo because a jobs-bucket row would surface in the
+    Image Repo's filename search. That leak is now fixed where it lives — the search filter
+    is constrained to the images bucket — so the restriction is lifted rather than worked
+    around, and a generated frame's description survives instead of being paid for twice.
+    """
 
-    def test_a_generated_continuation_frame_does_not(self):
-        assert not _is_repo_image(GENERATED)
+    def test_a_repo_image_may_be_kept(self):
+        assert _is_describable(REPO)
 
-    def test_nothing_does(self):
-        assert not _is_repo_image(None)
-        assert not _is_repo_image("")
+    def test_a_generated_continuation_frame_may_be_kept(self):
+        assert _is_describable(GENERATED)
+
+    def test_nothing_may_be_kept(self):
+        assert not _is_describable(None)
+        assert not _is_describable("")
+
+    def test_somebody_elses_bucket_may_not(self):
+        assert not _is_describable("s3://someone-elses-bucket/x.png")
 
 
 class TestResolveUsesTheCache:
@@ -94,16 +102,30 @@ class TestResolveUsesTheCache:
         assert meta.scene_instruction == "an instruction"
 
     @pytest.mark.asyncio
-    async def test_a_generated_frame_is_described_but_never_stored(self, db):
-        """Every continuation is this case. It still gets a description; it just does not
-        get a row, because a row would put it in the Image Repo."""
+    async def test_a_generated_frame_is_kept_too(self, db):
+        """Every continuation is this case. The console describes the previous segment's
+        last frame when the dialog opens; if the claim did not reuse that, it would describe
+        the same frame again and render with DIFFERENT words from the ones shown."""
         with patch("app.routes.segments.s3.download_bytes", return_value=b"png"), \
              patch("app.routes.segments.caption_image_bytes",
                    new=AsyncMock(return_value=("a woman by a pool", "an instruction"))):
             out = await _resolve_scene(db, TEMPLATE, GENERATED, final=True)
 
         assert "a woman by a pool" in out
-        assert await db.get(ImageMeta, GENERATED) is None
+        meta = await db.get(ImageMeta, GENERATED)
+        assert meta is not None
+        assert meta.scene_description == "a woman by a pool"
+
+    @pytest.mark.asyncio
+    async def test_a_kept_generated_frame_is_reused_rather_than_re_described(self, db):
+        db.add(ImageMeta(path=GENERATED, scene_description="a woman by a pool"))
+        await db.flush()
+
+        with patch("app.routes.segments.caption_image_bytes", new=AsyncMock()) as captioner:
+            out = await _resolve_scene(db, TEMPLATE, GENERATED, final=True)
+
+        captioner.assert_not_called()
+        assert "a woman by a pool" in out
 
     @pytest.mark.asyncio
     async def test_a_row_with_tags_but_no_description_still_describes(self, db):


### PR DESCRIPTION
API half of DavidJBarnes/wanly-console#438. Console half is DavidJBarnes/wanly-console#439, which must merge after this.

## Why

A segment's last frame is the start frame of the one after it. The Next Segment dialog now describes it **when the dialog opens**, so the words are on screen before the segment is submitted. That needs somewhere to keep the description — otherwise reopening the dialog pays for it again, and worse, the **claim describes the same frame a second time** and renders with different words from the ones that were shown.

console#427 refused to store those, because `/images/search` selects FROM `image_meta` and HEADs whatever path it finds, so a jobs-bucket row would put a render's intermediate frame in the Image Repo. **Fixed where it lives instead:** the search and tag-count queries are constrained to the images bucket, so the restriction is lifted rather than worked around.

## What changes

- `repo_images_only()` on the search and tag-count queries. Deliberately **not** folded into `image_filter` — an empty clause list from that function is how the route knows nothing was asked for and answers 400 rather than serving the whole repo. My first attempt did fold it in, which turned an unfiltered search into a full listing; the existing tests caught it.
- `GET`/`POST /images/scene` accept a frame from either of our buckets. Anything else is still a 400.
- `_is_repo_image` → `_is_describable`: the claim path now keeps and reuses a description for both buckets.

## Verification

752 tests pass (`REQUIRE_DB=1`). New ones cover the leak directly — a jobs-bucket row is invisible to a filename search that matches it and to a tag search that matches it — plus the widened endpoints, the reuse-rather-than-re-describe path, and that an unknown bucket is still refused. The tests that asserted "generated frames are never stored" are updated with the reason for the reversal.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J