### PR TITLE
ltx: default the base model to 10Eros, and fix the gate it exposed

### DIFF
--- a/app/ltx_stack.py
+++ b/app/ltx_stack.py
@@ -12,7 +12,17 @@ NOT app/seeds.py, which is about NOISE seeds. Different sense of the word entire
 # It was a third LoRA competing for the same layers as the character LoRA, and the
 # checkpoint already carries the NSFW training it was providing.
 LTX_STACK = {
-    'checkpoint': 'sulphur_dev_bf16',
+    # The base model every pose falls back to (console#431). 10Eros is what the work
+    # actually runs on -- 9 of 16 poses named it and it took 115 of the last 30 days' 145
+    # segments, while the six sulphur poses are the originals those nine were cloned from.
+    #
+    # TWO OTHER PLACES ANSWER THIS and must move with it, both in wanly-gpu-docker:
+    # engine/recipe.py's DEFAULT_CHECKPOINT (what actually renders when a segment arrives
+    # naming no checkpoint) and download_models.sh's _WANTED (what a cold container or pod
+    # actually HAS). A pod holding a different checkpoint reports it through the heartbeat
+    # and _model_gate() then hides every default pose from it -- it claims nothing, and an
+    # idle pod is indistinguishable from an empty queue.
+    'checkpoint': '10Eros_v1.5_bf16',
     'content_lora': 'none',
     # What resolve() hardcoded for BOTH stages before content LoRAs became per-pose. Kept as
     # the default so a pose that names a content LoRA without naming strengths renders at

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -439,9 +439,21 @@ def _model_gate(worker: Worker | None) -> tuple:
 
     Three things deliberately do NOT gate:
 
-      * a NULL ltx_recipe. Not a recipe render: a WAN segment, a free-form LTX one, or a CPU
-        reprocess carrier. It declares no models, so it requires none. Conservative on
-        purpose — this must not withhold work that flows today.
+      * a recipe that is not a JSON OBJECT. Not a recipe render: a WAN segment, a free-form
+        LTX one, or a CPU reprocess carrier. It declares no models, so it requires none.
+        Conservative on purpose — this must not withhold work that flows today.
+
+        BOTH spellings of "no recipe" count, and that is not pedantry (console#431).
+        `ltx_recipe` is JSONB with SQLAlchemy's default none_as_null=False, so assigning
+        None stores the JSON value `null` rather than SQL NULL — and `.is_(None)` is FALSE
+        against it. Production holds both: 21 rows SQL NULL, 12 rows JSONB null.
+
+        Written as `is_(None)` alone, this exemption never actually worked for the JSONB
+        half. Nothing showed, because the coalesce below then fell through to the stack
+        default and every worker happened to carry it — so the row was claimable by
+        accident, via the checkpoint branch, rather than by the exemption. Moving the
+        default to a checkpoint some pod lacks is exactly what turns that into a segment
+        nothing will pick up, silently.
       * a worker that has never reported its checkpoints (NULL, not []). An older daemon
         would otherwise starve on upgrade day, and a fleet claiming nothing looks exactly
         like an empty queue.
@@ -468,7 +480,13 @@ def _model_gate(worker: Worker | None) -> tuple:
         func.nullif(Segment.ltx_recipe["checkpoint"].astext, ""),
         canonical(LTX_STACK["checkpoint"]),
     )
-    return (or_(Segment.ltx_recipe.is_(None), checkpoint.in_(names)),)
+    # Only a JSON object declares models. SQL NULL and JSONB `null` both mean "no recipe";
+    # jsonb_typeof covers the second, which `is_(None)` cannot see.
+    declares_nothing = or_(
+        Segment.ltx_recipe.is_(None),
+        func.jsonb_typeof(Segment.ltx_recipe) != "object",
+    )
+    return (or_(declares_nothing, checkpoint.in_(names)),)
 
 
 @router.get("/segments/next", dependencies=[Depends(verify_api_key)])

--- a/tests/test_claim_model_gate.py
+++ b/tests/test_claim_model_gate.py
@@ -19,9 +19,16 @@ from app.auth import get_current_user, verify_api_key
 from app.database import get_db
 from app.enums import JobStatus, SegmentStatus
 from app.main import app
+from app.ltx_stack import LTX_STACK
 from app.models import Job, Segment, User, Worker
+from sqlalchemy import text as sa_text
 
 WORKER_ID = uuid.UUID("2f5a3c4e-0b1d-4a7e-9c88-1c2f3a4b5c6d")
+
+# A real checkpoint that is deliberately NOT the stack default, so a test cannot pass
+# through the checkpoint branch when it means to be testing the no-recipe exemption.
+_NOT_THE_DEFAULT = next(c for c in ("sulphur_dev_bf16", "ltx-2.3-22b-dev")
+                        if c != LTX_STACK["checkpoint"])
 
 
 async def _user(db) -> User:
@@ -156,20 +163,55 @@ class TestWorkStillFlows:
         assert (await _claim(db)).json()["id"] == str(seg.id)
 
     async def test_a_segment_with_no_recipe_is_never_gated(self, db):
-        """A WAN segment or a free-form render declares no models, so it requires none."""
+        """A WAN segment or a free-form render declares no models, so it requires none.
+
+        The worker deliberately carries a checkpoint that is NOT the stack default
+        (console#431). This test used to hand it the default, so it passed through the
+        checkpoint branch rather than through the exemption it claims to be testing, and
+        went on passing while the exemption itself was broken.
+        """
         job = await _job(db, await _user(db))
         seg = await _segment(db, job, recipe=None)
-        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+        await _worker(db, checkpoints=[_NOT_THE_DEFAULT], fetchable=["lora"])
 
+        assert (await _claim(db)).json()["id"] == str(seg.id)
+
+    async def test_no_recipe_means_json_null_too(self, db):
+        """`ltx_recipe` is JSONB with none_as_null=False, so assigning None stores the JSON
+        value `null`, not SQL NULL — and `.is_(None)` is FALSE against it (console#431).
+
+        Production holds 12 such rows next to 21 genuinely-SQL-NULL ones. Asserted on the
+        stored shape rather than trusted, because the whole bug was that the two look
+        identical from Python.
+        """
+        job = await _job(db, await _user(db))
+        seg = await _segment(db, job, recipe=None)
+        shape = (await db.execute(sa_text(
+            "select ltx_recipe is null as sql_null, jsonb_typeof(ltx_recipe) as jtype "
+            "from segments where id = :i"), {"i": seg.id})).mappings().one()
+        assert shape["sql_null"] is False and shape["jtype"] == "null", (
+            f"expected a JSONB null to reproduce the bug, got {dict(shape)}")
+
+        await _worker(db, checkpoints=[_NOT_THE_DEFAULT], fetchable=["lora"])
         assert (await _claim(db)).json()["id"] == str(seg.id)
 
     async def test_a_recipe_without_a_checkpoint_runs_on_the_stack_default(self, db):
-        """Segments predating per-pose base models must keep flowing."""
+        """Segments predating per-pose base models must keep flowing — on whatever the
+        stack default currently is, which is the point of the coalesce."""
         job = await _job(db, await _user(db))
         seg = await _segment(db, job, recipe={"recipe": "old", "char_lora": "k3llydw_v2"})
-        await _worker(db, checkpoints=["sulphur_dev_bf16"], fetchable=["lora"])
+        await _worker(db, checkpoints=[LTX_STACK["checkpoint"]], fetchable=["lora"])
 
         assert (await _claim(db)).json()["id"] == str(seg.id)
+
+    async def test_a_recipe_without_a_checkpoint_is_gated_on_the_default(self, db):
+        """The other half: the fallback is a real requirement, not a free pass. A worker
+        without the default cannot take a segment that leaves the checkpoint unset."""
+        job = await _job(db, await _user(db))
+        await _segment(db, job, recipe={"recipe": "old", "char_lora": "k3llydw_v2"})
+        await _worker(db, checkpoints=[_NOT_THE_DEFAULT], fetchable=["lora"])
+
+        assert (await _claim(db)).json() is None
 
     async def test_either_spelling_of_the_checkpoint_matches(self, db):
         job = await _job(db, await _user(db))

--- a/tests/test_recipe_checkpoint.py
+++ b/tests/test_recipe_checkpoint.py
@@ -3,8 +3,9 @@
 `checkpoint` was a global, so every render used one base model and two could not be
 compared. Four sit on the 3090 and only one was reachable.
 
-THE RISK IS ACCEPTED, NOT ABSENT. Character LoRAs were trained against sulphur. Against
-another base a LoRA whose keys do not line up fuses NOTHING and says nothing about it — the
+THE RISK IS ACCEPTED, NOT ABSENT. Character LoRAs were trained against sulphur, which is no
+longer the default (console#431). Against another base a LoRA whose keys do not line up
+fuses NOTHING and says nothing about it — the
 engine's own lora_coverage() docstring records that there is no error, no warning and no
 log line. The render comes back as the base model with none of the character in it.
 
@@ -26,9 +27,14 @@ def _resolve(pose):
     return pose.checkpoint or LTX_STACK["checkpoint"]
 
 
-def test_a_pose_that_says_nothing_still_renders_on_sulphur():
-    """Every existing pose. The migration must change no output."""
-    assert _resolve(_Pose()) == "sulphur_dev_bf16"
+def test_a_pose_that_says_nothing_renders_on_the_stack_default():
+    """The fallback itself, stated against the stack rather than against a literal.
+
+    Which checkpoint is default is a policy decision and it has moved once already
+    (console#431); that it falls back at all is the invariant. Pinning the literal here as
+    well as in test_the_stack_default_is() only produced two failures for one change.
+    """
+    assert _resolve(_Pose()) == LTX_STACK["checkpoint"]
 
 
 def test_a_pose_can_name_its_own_base_model():
@@ -39,13 +45,22 @@ def test_a_pose_can_name_its_own_base_model():
 def test_clearing_it_falls_back_rather_than_rendering_on_an_empty_name():
     """"" reaches the resolver when a user clears the field. It must mean "use the stack",
     not "load a checkpoint called nothing"."""
-    assert _resolve(_Pose(checkpoint="")) == "sulphur_dev_bf16"
+    assert _resolve(_Pose(checkpoint="")) == LTX_STACK["checkpoint"]
 
 
-def test_the_stack_default_is_unchanged():
-    """This is what every validated result to date was produced on. If it moves, the whole
-    rated history stops being comparable to anything new."""
-    assert LTX_STACK["checkpoint"] == "sulphur_dev_bf16"
+def test_the_stack_default_is_10eros():
+    """THE policy pin, and the only place the literal belongs.
+
+    Moved from sulphur in console#431. 10Eros is what the work already ran on -- 9 of 16
+    poses named it and it took 115 of the last 30 days' 145 segments, while the six sulphur
+    poses are the originals those nine were hand-cloned from to escape this default.
+
+    Two other places answer this same question and must move with it, both in
+    wanly-gpu-docker: engine/recipe.py's DEFAULT_CHECKPOINT and download_models.sh's
+    _WANTED. They are covered by that repo's own test; this one exists so the value cannot
+    drift here unnoticed.
+    """
+    assert LTX_STACK["checkpoint"] == "10Eros_v1.5_bf16"
 
 
 class TestCheckpointListing:

--- a/tests/test_runpod_disk.py
+++ b/tests/test_runpod_disk.py
@@ -21,7 +21,9 @@ DOCKER_REPO = pathlib.Path(__file__).parent.parent.parent / "wanly-gpu-docker"
 # not of the script; the NAMES are cross-checked against the script below so the two cannot
 # drift apart silently.
 MODEL_SIZES_GB = {
-    "sulphur_dev_bf16.safetensors": 43,
+    # The default base model (console#431). 46,139,886,366 bytes = 43 GiB, within a few
+    # hundred KB of the sulphur checkpoint it replaced, so the volume maths is unchanged.
+    "10Eros_v1.5_bf16.safetensors": 43,
     "gemma_3_12B_it_fp8_scaled.safetensors": 13,
     "ltx-2.3-spatial-upscaler-x2-1.1.safetensors": 1,
     "sulphur_distill_lora_condsafe.safetensors": 1,


### PR DESCRIPTION
Part of DavidJBarnes/wanly-console#431. Pairs with wanly-gpu-docker#70, **which should merge first** so no pod can want a checkpoint it doesn't fetch.

## The change asked for

`LTX_STACK['checkpoint']` → `10Eros_v1.5_bf16`.

Measured, not assumed:

| | |
|---|---|
| poses naming `10Eros_v1.5_bf16` | **9** |
| poses naming `sulphur_dev_bf16` | 6 |
| poses naming nothing | 1 (`Handjob`) |
| segments last 30d, 10Eros | **115** |
| segments last 30d, sulphur | 30 |

The nine are hand-cloned duplicates of the sulphur poses (`Doggystyle` / `Doggystyle - 10eros`), and that duplication exists *only* to escape this default. `Handjob` is the one pose whose output changes.

## The bug it exposed — the more important half

`_model_gate()` documents an exemption: a segment with no `ltx_recipe` declares no models, so it requires none. **That exemption never worked for half the rows.**

`ltx_recipe` is `JSONB` and SQLAlchemy's `none_as_null` defaults to `False`, so assigning `None` stores the JSON value `null` rather than SQL `NULL` — and `.is_(None)` is `FALSE` against it. Production holds both shapes:

```
jsonb object | 350
SQL NULL     |  21
jsonb null   |  12
```

Nothing ever surfaced because the `coalesce` below fell through to the stack default, and every worker happened to carry sulphur — so those rows were claimable **by accident, through the checkpoint branch**, not through the exemption. Moving the default to a checkpoint some pod lacks is precisely what converts that latent bug into work that nothing picks up, with no error anywhere.

The gate now asks `jsonb_typeof(...) != 'object'` alongside `is_(None)`, so both spellings of "no recipe" count.

### Why the existing test didn't catch it

`test_a_segment_with_no_recipe_is_never_gated` handed the worker `sulphur_dev_bf16` — the default at the time — so it also passed through the checkpoint branch. It was green while testing nothing.

It now uses a checkpoint deliberately chosen *not* to be the default, and a companion test (`test_no_recipe_means_json_null_too`) asserts the stored shape really is a JSONB `null` before claiming, because the whole bug is that the two shapes are indistinguishable from Python. **Both were run against the old gate and both fail there.**

A fourth test pins the other direction: an unset checkpoint really is a requirement, so a worker without the default cannot take it.

## Test hygiene

The remaining checkpoint tests now assert against `LTX_STACK["checkpoint"]` instead of a literal. Which base model is default is a policy decision that has now moved once; *that it falls back at all* is the invariant. `test_the_stack_default_is_10eros` keeps the literal deliberately, as the single policy pin.

`test_runpod_disk` correctly failed — it reads the sibling `download_models.sh` — and its size table now names 10Eros. Same 43 GiB, so the volume maths is unchanged. Note it self-skips when the sibling checkout is absent, so it does not run in CI.

## Risk

Checked rather than assumed, twice, at the time of writing: **no PENDING, CLAIMED or PROCESSING segments**, and the only online worker (`3090.zero`) carries all four checkpoints including 10Eros. Nothing queued can be stranded.

## Verification

`pytest` — **761 passed**, 0 failed (758 before, plus 3 new tests).

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J