### PR TITLE
runpod: authenticate model staging, and build the pod env once

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -88,6 +88,18 @@ class Settings(BaseSettings):
     # deliberately absent because the workflow does not run on it.
     runpod_gpu_type_ids: str = "NVIDIA GeForce RTX 4090,NVIDIA GeForce RTX 3090"
     runpod_image: str = "davidjbarnes/wanly-gpu-docker:latest"
+    # Passed to pods as HF_TOKEN so model staging is authenticated (#260). huggingface_hub
+    # reads it from the environment on its own, so download_models.sh and the image are
+    # untouched -- the whole job is getting the variable into the pod.
+    #
+    # Empty means not configured, and the key is then OMITTED rather than sent blank: an
+    # empty HF_TOKEN is worse than none, because huggingface_hub would try to authenticate
+    # with it. Same shape as runpod_api_key above.
+    #
+    # Anonymous staging works today -- the repos are public and measured 14 MB/s -- so this
+    # is about the cases where it stops working: HF's anonymous limits are per-IP and pods
+    # share datacenter egress, and a gated repo 401s outright rather than warning.
+    hf_token: str = ""
     # Writable container disk. Holds /jobs — every render's graph, keyframe and mp4, roughly
     # 30-60 MB a piece — plus ComfyUI's scratch. NOT the image, which RunPod accounts for
     # separately: a pod with a 30 GB container disk reports 30 GB free before anything runs.

--- a/app/reservation_monitor.py
+++ b/app/reservation_monitor.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 from sqlalchemy import select, update
 
 from app import runpod_client
-from app.config import settings
 from app.database import async_session
 from app.models import GpuReservation
 from app.reservations import Action, ReservationStatus, decide
@@ -110,13 +109,7 @@ async def _apply(session, reservation: GpuReservation, decision, now) -> None:
         return
 
     reservation.attempts = (reservation.attempts or 0) + 1
-    env = {
-        "FRIENDLY_NAME": reservation.name,
-        "QUEUE_URL": settings.runpod_worker_queue_url,
-        "QUEUE_API_KEY": settings.api_key,
-    }
-    if settings.runpod_api_key:
-        env["RUNPOD_API_KEY"] = settings.runpod_api_key
+    env = runpod_client.worker_env(reservation.name)
 
     try:
         pod = await runpod_client.launch_worker(reservation.name, env, reservation.gpu_type_id)

--- a/app/routes/runpod.py
+++ b/app/routes/runpod.py
@@ -150,17 +150,7 @@ async def launch_runpod_worker(body: RunPodLaunchRequest):
             ),
         )
 
-    # The worker needs the queue to claim from, and its own name so it registers legibly rather
-    # than as runpod-<podid>. QUEUE_API_KEY is this server's own daemon key.
-    env = {
-        "FRIENDLY_NAME": name,
-        "QUEUE_URL": body.queue_url or settings.runpod_worker_queue_url,
-        "QUEUE_API_KEY": settings.api_key,
-    }
-    if settings.runpod_api_key:
-        # Lets the worker stop its own pod when drained. Without it a drain leaves the pod
-        # running and the container simply respawns.
-        env["RUNPOD_API_KEY"] = settings.runpod_api_key
+    env = runpod_client.worker_env(name, body.queue_url)
 
     try:
         return await runpod_client.launch_worker(name, env, gpu)

--- a/app/runpod_client.py
+++ b/app/runpod_client.py
@@ -126,6 +126,37 @@ async def get_availability(gpu_type_id: str | None = None) -> dict:
     }
 
 
+def worker_env(name: str, queue_url: str | None = None) -> dict[str, str]:
+    """The environment a launched pod gets. ONE builder, deliberately (#260).
+
+    This was built twice -- once in routes/runpod.py for the manual launch and once in
+    reservation_monitor.py for the scheduled one -- with the same four keys and the same
+    guard on RUNPOD_API_KEY. Two copies of "what a worker needs to know" is how a pod
+    launched overnight quietly ends up with a different environment from one launched by
+    hand, and that difference presents as "it works when I click the button", which is a
+    horrible thing to debug from a pod that has already been terminated.
+
+    Adding HF_TOKEN as a fifth key to two dicts is exactly the edit that would have started
+    it, so the copies were collapsed first.
+    """
+    env = {
+        # So the worker registers legibly rather than as runpod-<podid>.
+        "FRIENDLY_NAME": name,
+        "QUEUE_URL": queue_url or settings.runpod_worker_queue_url,
+        # This server's own daemon key -- what the worker claims segments with.
+        "QUEUE_API_KEY": settings.api_key,
+    }
+    if settings.runpod_api_key:
+        # Lets the worker stop its own pod when drained. Without it a drain leaves the pod
+        # running and the container simply respawns.
+        env["RUNPOD_API_KEY"] = settings.runpod_api_key
+    if settings.hf_token:
+        # Authenticates model staging. Omitted rather than blank when unset -- see the
+        # setting's own note; huggingface_hub would try to use an empty token.
+        env["HF_TOKEN"] = settings.hf_token
+    return env
+
+
 async def launch_worker(name: str, env: dict[str, str], gpu_type_id: str | None = None) -> dict:
     """Create a pod, attached to the configured network volume.
 

--- a/tests/test_worker_env.py
+++ b/tests/test_worker_env.py
@@ -1,0 +1,79 @@
+"""The environment a launched pod gets (#260).
+
+Model staging ran unauthenticated on every pod -- ~58 GB fetched anonymously, with HF's own
+warning in the boot log. That works today (public repos, measured 14 MB/s) and stops working
+in two ways: HF's anonymous limits are per-IP and pods share datacenter egress, and a gated
+repo 401s outright rather than warning.
+
+huggingface_hub reads HF_TOKEN from the environment itself, so nothing in the image or in
+download_models.sh changes. The whole job is getting the variable into the pod -- and doing
+that without leaving two different answers to "what does a worker need to know".
+"""
+import inspect
+
+import pytest
+
+from app import reservation_monitor, runpod_client
+from app.config import settings
+from app.routes import runpod as runpod_routes
+
+
+@pytest.fixture
+def clean_settings():
+    """Settings is a singleton shared across the suite; restore whatever was there."""
+    before = (settings.hf_token, settings.runpod_api_key, settings.api_key)
+    yield settings
+    (settings.hf_token, settings.runpod_api_key, settings.api_key) = before
+
+
+def test_the_token_is_omitted_when_not_configured(clean_settings):
+    """Not sent blank. An empty HF_TOKEN is worse than none: huggingface_hub would try to
+    authenticate with it, turning a warning into a 401 partway through a 46 GB stage."""
+    settings.hf_token = ""
+    assert "HF_TOKEN" not in runpod_client.worker_env("pod-1")
+
+
+def test_the_token_is_passed_when_configured(clean_settings):
+    settings.hf_token = "hf_notarealtoken"
+    assert runpod_client.worker_env("pod-1")["HF_TOKEN"] == "hf_notarealtoken"
+
+
+def test_the_worker_still_gets_what_it_always_did(clean_settings):
+    """The keys that existed before must survive the extraction — a pod without QUEUE_URL
+    or QUEUE_API_KEY boots and claims nothing."""
+    settings.api_key = "queue-key"
+    settings.runpod_api_key = "rp-key"
+    env = runpod_client.worker_env("pod-1")
+    assert env["FRIENDLY_NAME"] == "pod-1"
+    assert env["QUEUE_API_KEY"] == "queue-key"
+    assert env["RUNPOD_API_KEY"] == "rp-key"
+    assert env["QUEUE_URL"] == settings.runpod_worker_queue_url
+
+
+def test_an_explicit_queue_url_overrides_the_configured_one(clean_settings):
+    """The manual launch can point a pod at a different queue; the reservation path cannot
+    and passes nothing."""
+    assert runpod_client.worker_env("pod-1", "http://elsewhere:8001")["QUEUE_URL"] \
+        == "http://elsewhere:8001"
+
+
+def test_runpod_key_omitted_when_unset(clean_settings):
+    settings.runpod_api_key = ""
+    assert "RUNPOD_API_KEY" not in runpod_client.worker_env("pod-1")
+
+
+@pytest.mark.parametrize("mod,label", [
+    (runpod_routes.launch_runpod_worker, "the manual launch"),
+    (reservation_monitor, "the reservation monitor"),
+])
+def test_both_launch_paths_use_the_shared_builder(mod, label):
+    """The point of the extraction, asserted rather than trusted.
+
+    Both paths built the same dict by hand. Adding HF_TOKEN to one and not the other is the
+    edit this guards: a pod launched overnight would then differ from one launched by hand,
+    which presents as "the token works when I click the button" — debugged against a pod
+    that has already been terminated.
+    """
+    src = inspect.getsource(mod)
+    assert "worker_env(" in src, f"{label} no longer uses the shared builder"
+    assert '"QUEUE_API_KEY"' not in src, f"{label} has grown its own env dict again"


### PR DESCRIPTION
Closes #260.

## The warning

```
Warning: You are sending unauthenticated requests to the HF Hub.
Please set a HF_TOKEN to enable higher rate limits and faster downloads.
```

**Not new, and not from the 10Eros default.** `HF_TOKEN` has never been handled in `wanly-api`, `wanly-gpu-docker` or `wanly-gpu-daemon`; sulphur came down the same anonymous path on every previous pod. Only the filename changed.

**Not currently harmful either.** Measured against the exact URL `download_models.sh` uses, unauthenticated: `HTTP 206`, **14.2 MB/s**, no `x-ratelimit` headers, no 429. The repos are public, ungated and CloudFront-served.

## So why close it

1. **Anonymous limits are per-IP** and RunPod pods share datacenter egress. One pod is nothing; several booting together is where a 429 becomes plausible — and a 429 mid-stage costs a 46 GB restart twenty minutes into a boot.
2. **A gated repo 401s outright** rather than warning. Plumbing already in place makes that a config change rather than a code change made under pressure.
3. **Boot staging is where pods fail.** A standing warning there trains the eye to skim the one log that matters.

## What changed

`huggingface_hub` reads `HF_TOKEN` from the environment itself, so **`download_models.sh` and the image are untouched**. The whole job is getting the variable into the pod.

- `Settings.hf_token: str = ""`. Empty means not configured and the key is **omitted, not sent blank** — an empty `HF_TOKEN` is worse than none, because `huggingface_hub` would try to authenticate with it. Same shape as `runpod_api_key`.

### The part worth doing properly

The pod environment was built **twice**:

| | |
|---|---|
| `routes/runpod.py:155` | manual launch from the Workers page |
| `reservation_monitor.py:112` | scheduled reservation launch |

Same four keys, same `RUNPOD_API_KEY` guard, two copies. Adding a fifth key to both is exactly how a pod launched overnight ends up with a different environment from one launched by hand — presenting as *"the token works when I click the button but not on a reservation"*, debugged against a pod that has already been terminated.

Both now call one `worker_env(name, queue_url=None)` in `runpod_client.py`, which already owns `launch_worker`. `HF_TOKEN` is added once.

`test_both_launch_paths_use_the_shared_builder` asserts neither path has grown its own dict again. **Verified it fails** when the env dict is re-inlined into `routes/runpod.py`.

## Deploy step — needs you

The token is deliberately not in the repo. After merge, add to `/opt/wanly-api/.env`:

```
HF_TOKEN=hf_xxxxxxxx
```

A **read**-scoped token from https://huggingface.co/settings/tokens is sufficient. Until it's set, behaviour is exactly as today — the key is omitted and staging stays anonymous. I'll confirm the container picks it up once you've added it.

## Security note

Confirmed `launch_worker` returns a whitelisted dict (`id`, `name`, `status`, `cost_per_hr`), so no pod environment — `QUEUE_API_KEY` and `RUNPOD_API_KEY` included — is echoed back to the console.

## Verification

`pytest` — **768 passed** (761 before, plus 7 new).

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J