### PR TITLE
api: let uvicorn outlive the worker's connection pool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,11 @@ EXPOSE 8001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:8001/health || exit 1
 
-CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8001"]
+# --timeout-keep-alive MUST exceed the daemon's httpx pool expiry (30s, wanly-gpu-daemon
+# queue_client.py). uvicorn's default is 5s, so every worker was handed pooled sockets the
+# server had already closed and found out only after writing the request -- a steady drip of
+# RemoteProtocolError on /segments/next and /workers/*/heartbeat (#262).
+#
+# Server longer than client is the correct direction: whichever end expires first decides,
+# and that should be the end which can retire a connection with no request in flight.
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8001 --timeout-keep-alive 65"]

--- a/tests/test_keepalive.py
+++ b/tests/test_keepalive.py
@@ -1,0 +1,70 @@
+"""The API must outlive the worker's connection pool (#262).
+
+Every worker logged RemoteProtocolError on /segments/next and /workers/*/heartbeat every few
+minutes, on every pod. It was first read as CPU starvation on a community host at load
+average 251 -- but the same rate appeared on a secure-cloud pod at load 2.11, which ruled
+that out.
+
+The cause was a mismatch: uvicorn's default keep-alive is 5s, while the daemon's httpx pool
+holds connections for 30s. httpx handed out sockets uvicorn had already closed and found out
+only after writing the request. The daemon's own comment (wanly-gpu-daemon#105) states that
+its expiry must sit BELOW the far end's idle timeout; it was six times above it.
+
+Nothing broke -- the daemon retries once on a fresh socket and no claim was ever lost. What
+it cost was legibility: a genuine transport failure looks exactly like the routine one, so
+the claim loop's log could not answer "is this worker healthy?".
+"""
+import pathlib
+import re
+
+DOCKERFILE = pathlib.Path(__file__).parent.parent / "Dockerfile"
+
+# wanly-gpu-daemon/daemon/queue_client.py: httpx.Limits(keepalive_expiry=30.0).
+# Restated rather than imported: it lives in another repo that is not checked out in CI.
+DAEMON_POOL_EXPIRY_S = 30
+
+
+def _keepalive_from_dockerfile() -> int | None:
+    m = re.search(r"--timeout-keep-alive\s+(\d+)", DOCKERFILE.read_text())
+    return int(m.group(1)) if m else None
+
+
+def test_uvicorn_is_given_an_explicit_keepalive():
+    """The default is 5s and it is wrong here, so the flag must be present at all.
+
+    Asserted separately from the comparison below so that dropping the flag reports "you
+    removed it" rather than a confusing None comparison.
+    """
+    assert _keepalive_from_dockerfile() is not None, (
+        "Dockerfile does not pass --timeout-keep-alive; uvicorn would default to 5s, which "
+        "is below the daemon's 30s pool expiry and reintroduces #262"
+    )
+
+
+def test_the_server_outlives_the_workers_connection_pool():
+    """The RELATIONSHIP is the thing that was wrong, so pin that, not the number.
+
+    A bare `== 65` would be re-edited by anyone who wanted a different value, without
+    learning why it cannot go under 30.
+    """
+    keepalive = _keepalive_from_dockerfile()
+    # `or 0` for the same reason as below: a missing flag should fail with this message
+    # rather than a TypeError comparing None to an int.
+    assert (keepalive or 0) > DAEMON_POOL_EXPIRY_S, (
+        f"uvicorn --timeout-keep-alive={keepalive}s is not above the daemon's "
+        f"{DAEMON_POOL_EXPIRY_S}s httpx pool expiry. Workers will be handed sockets this "
+        f"server has already closed, and every claim poll can fail with RemoteProtocolError "
+        f"before its retry (#262)."
+    )
+
+
+def test_there_is_real_margin_not_a_race():
+    """31 would satisfy the rule and still have the two expiring together. The point of the
+    margin is that neither end is deciding at the same moment."""
+    keepalive = _keepalive_from_dockerfile()
+    # `or 0` so a missing flag fails with this test's message rather than a TypeError from
+    # comparing None -- the reason a reader reaches for is in the assertion, not a traceback.
+    assert (keepalive or 0) >= DAEMON_POOL_EXPIRY_S * 2, (
+        f"--timeout-keep-alive is {keepalive!r}; wanted at least "
+        f"{DAEMON_POOL_EXPIRY_S * 2}s so the two ends are not expiring together"
+    )


### PR DESCRIPTION
Closes #262.

## Symptom

Every worker, every few minutes, on every pod:

```
GET /segments/next failed at the transport layer (RemoteProtocolError); retrying once on a fresh connection
POST /workers/<id>/heartbeat failed at the transport layer (RemoteProtocolError); retrying once on a fresh connection
```

## It is not host load

First seen on a community pod at load average **251**, which made CPU starvation the obvious read. That's ruled out: the same rate appears on a secure-cloud pod at load **2.11**, and on the 3090.

## Cause, verified on both ends

| | value |
|---|---|
| daemon `queue_client.py:81` `keepalive_expiry` | **30.0 s** |
| uvicorn `timeout_keep_alive` | **5 s** (default — read from `Config.__init__`, not docs) |
| daemon poll interval | 5 s |

Neither the Dockerfile nor `deploy.yml` passed `--timeout-keep-alive`. uvicorn closed idle connections at 5 s while httpx pooled them for 30 s, so the daemon was handed sockets the server had already closed and found out only after writing the request.

The daemon's own comment states the rule and then breaks it:

> *`keepalive_expiry` below the far end's idle timeout: httpx otherwise hands out a connection the server has already closed... See #105.*

30 s is not below 5 s — it's six times above. wanly-gpu-daemon#105 fixed this in the right place with the wrong number, and the retry has masked it ever since. With a 5 s poll interval the connection idles right at uvicorn's cutoff, which is why it's intermittent.

## Why fix it if nothing breaks

Nothing does break — `_request_with_retry` catches every one and no claim is lost. The cost is legibility:

- The claim loop's log is what you read when a pod misbehaves, and a genuine transport failure looks identical to the routine one. **This is what made the first pod's real wedge get read as ordinary noise.**
- `_REBUILD_AFTER = 6` / `_GIVE_UP_AFTER = 40` count *consecutive* failures, so the noise doesn't trip them — but it does make "is this worker healthy?" unanswerable from the log.
- A connection is discarded and rebuilt each time, for nothing.

## The fix

```
uvicorn app.main:app --host 0.0.0.0 --port 8001 --timeout-keep-alive 65
```

**Server-side, not client-side.** Whichever end expires first decides, and that should be the end that can retire a connection with no request in flight. Dropping the daemon to 4 s also works, at the cost of much more connection churn and a redeploy to every worker. At 65 s the daemon's 30 s is finally *below* the far end's idle timeout — what its comment always asked for.

65 rather than 31: real margin, so the two aren't deciding at the same moment, and it clears the conventional 60 s idle timeout of anything that might later front the API. Nothing fronts it today — `QUEUE_URL` is `http://api.wanly22.com:8001`, straight to the container on `--network host`.

## Tests

Three, pinning the **relationship** rather than the number — the relationship is what was wrong, and a bare `== 65` invites re-editing without learning why it can't go under 30.

Verified against both failure modes: flag removed, and flag set to 20. Each fails with a message naming the cause rather than a `TypeError`.

They read this repo's own Dockerfile rather than the sibling daemon checkout — deliberately, since the cross-repo test added in console#431 self-skips when the sibling is absent and so doesn't run in CI.

## Verification

`pytest` — **771 passed** (768 before, plus 3). After deploy I'll confirm the running container carries the flag and watch a live worker's log for the errors stopping.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J