### PR TITLE
ltx: publish where each checkpoint can be fetched from

### DIFF
--- a/app/checkpoint_sources.py
+++ b/app/checkpoint_sources.py
@@ -1,0 +1,62 @@
+"""Where a checkpoint can be fetched from, so a worker never has to guess a URL.
+
+console#423. A worker that lacks a base model downloads it rather than being routed around
+(console#422). To do that it needs one thing this repo owns: the mapping from a checkpoint
+NAME, as a pose stores it, to a place the file actually lives.
+
+WHY THE API HOLDS THIS
+    The daemon could carry its own copy, and then adding a checkpoint would mean redeploying
+    every worker. Held here, a new base model is one entry and every worker learns about it
+    on its next claim. The API already answers "which checkpoints exist" (/ltx/checkpoints);
+    this answers "and where does one come from".
+
+THIS MUST AGREE WITH download_models.sh
+    wanly-gpu-docker's _WANTED manifest stages the DEFAULT checkpoint at boot. This catalogue
+    covers the same files plus the ones a pod does not carry. If the two disagree about a
+    repo or a filename, a cold pod stages one file and fetches a different one under the same
+    name -- two different base models sharing a name is the worst possible outcome, because
+    every render still succeeds.
+"""
+
+# name (as a pose stores it, no extension) -> where to get it
+#
+# Verified 2026-09-06 by byte count against the copies on the 3090, not by filename:
+#   10Eros_v1.5_bf16   46,139,886,366   matches TenStrip/LTX2.3-10Eros
+#   sulphur_dev_bf16   46,139,885,414   matches SulphurAI/Sulphur-2-base
+# A same-named file of a different size is a different model, and that is the failure this
+# catalogue exists to prevent -- so entries are added by verifying bytes, never by matching
+# a name that looks right.
+CHECKPOINT_SOURCES: dict[str, dict[str, str | int]] = {
+    "10Eros_v1.5_bf16": {
+        "repo": "TenStrip/LTX2.3-10Eros",
+        "path": "10Eros_v1.5_bf16.safetensors",
+        "size_bytes": 46_139_886_366,
+    },
+    "sulphur_dev_bf16": {
+        "repo": "SulphurAI/Sulphur-2-base",
+        "path": "sulphur_dev_bf16.safetensors",
+        "size_bytes": 46_139_885_414,
+    },
+}
+
+# Deliberately absent: ltx-2.3-22b-dev and ltx-2.3-22b-distilled-1.1. Both sit on the 3090 and
+# no pose names either -- adding them would invite a pod to spend 20 minutes fetching 46 GB
+# for a base model nothing renders on. An entry here is a statement that the file is worth a
+# cold pod's time.
+
+
+def canonical_name(name: str) -> str:
+    """Strip the extension, matching how recipes store a checkpoint and how the daemon
+    reports one. Both spellings reach this module, and they mean the same file."""
+    n = (name or "").strip()
+    return n[: -len(".safetensors")] if n.endswith(".safetensors") else n
+
+
+def source_for(name: str) -> dict[str, str | int] | None:
+    """Where to fetch `name`, or None if this checkpoint has no recorded source.
+
+    None is a real answer, not an error: a checkpoint can exist on a box without this repo
+    knowing where it came from, and the caller should route to a worker that holds it rather
+    than invent a download.
+    """
+    return CHECKPOINT_SOURCES.get(canonical_name(name))

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -25,6 +25,7 @@ from app.config import settings
 from app.s3 import list_bucket
 from app.auth import get_current_user, verify_api_key_or_bearer
 from app.database import get_db
+from app.checkpoint_sources import CHECKPOINT_SOURCES
 from app.ltx_stack import LTX_STACK
 from app.models import LtxCharacter, LtxRecipe, User, Worker
 from app.negative_prompt import default_negative_prompt
@@ -176,6 +177,27 @@ async def list_checkpoints(db: AsyncSession = Depends(get_db)):
             if isinstance(name, str) and name.strip():
                 names.add(name.strip())
     return {"checkpoints": sorted(names), "default": LTX_STACK["checkpoint"]}
+
+
+@router.get("/ltx/checkpoints/catalog", dependencies=[Depends(verify_api_key_or_bearer)])
+async def checkpoint_catalog():
+    """Where each known checkpoint can be fetched from (console#423).
+
+    Asked by a WORKER, not the console: a worker handed a pose whose base model it does not
+    hold downloads it rather than failing the claim. It must not guess a URL, so the mapping
+    from name to {repo, path} lives here -- one entry adds a base model for the whole fleet,
+    against redeploying every worker to teach it a new name.
+
+    Separate from /ltx/checkpoints, which answers "what can be rendered NOW" from live worker
+    inventory. This answers "where does one come from", which is a fact about the file and
+    true whether any worker is up.
+
+    `size_bytes` is the point of the response as much as the URL. A partial safetensors is a
+    valid header over missing data -- it passes every existence check and fails only at load,
+    inside a claimed segment -- so the fetcher needs the expected length to verify against
+    before it renames the file into place.
+    """
+    return {"sources": CHECKPOINT_SOURCES}
 
 
 @router.get("/loras", dependencies=[Depends(verify_api_key_or_bearer)])

--- a/tests/test_checkpoint_catalog.py
+++ b/tests/test_checkpoint_catalog.py
@@ -1,0 +1,96 @@
+"""Where a checkpoint comes from (console#423).
+
+A worker that lacks a base model fetches it instead of being routed around (#422). The
+mapping from a checkpoint NAME to a place the file lives is the one piece of that only this
+repo can own -- held in the daemon it would mean redeploying every worker to add a model.
+
+Everything here guards a silent failure. A wrong repo or filename does not error: the worker
+downloads a DIFFERENT model under the expected name, ComfyUI loads it, the render succeeds,
+and the result is not comparable to anything. That is why entries are verified by byte count
+rather than by a name that looks right.
+"""
+import pathlib
+import re
+
+from app.checkpoint_sources import CHECKPOINT_SOURCES, canonical_name, source_for
+from app.ltx_stack import LTX_STACK
+
+DOCKER_REPO = pathlib.Path(__file__).parent.parent.parent / "wanly-gpu-docker"
+
+
+def test_the_stack_default_has_a_source():
+    """THE one that matters. Without this, a cold pod handed a default-checkpoint pose can
+    neither render it nor fetch it, and simply claims nothing -- which looks like an empty
+    queue rather than a missing entry."""
+    assert source_for(LTX_STACK["checkpoint"]) is not None, (
+        f"the stack default {LTX_STACK['checkpoint']!r} has no entry in CHECKPOINT_SOURCES, "
+        f"so no worker can fetch it on demand"
+    )
+
+
+def test_every_entry_is_complete():
+    """A half-filled entry is worse than a missing one: the fetcher would build a URL from
+    None and 404 inside a claimed segment."""
+    for name, src in CHECKPOINT_SOURCES.items():
+        assert src.get("repo"), f"{name} has no repo"
+        assert src.get("path"), f"{name} has no path"
+        assert isinstance(src.get("size_bytes"), int) and src["size_bytes"] > 0, (
+            f"{name} has no usable size_bytes — the fetcher cannot verify a truncated "
+            f"download without it, and a partial safetensors fails only at load"
+        )
+
+
+def test_paths_carry_the_extension_and_keys_do_not():
+    """Recipes store a bare stem; the file on disk has .safetensors. Mixing the two is how a
+    lookup silently misses and a worker decides it cannot fetch something it can."""
+    for name, src in CHECKPOINT_SOURCES.items():
+        assert not name.endswith(".safetensors"), f"key {name!r} should be a bare stem"
+        assert src["path"].endswith(".safetensors"), f"{name} path should name a real file"
+
+
+def test_both_spellings_resolve_to_the_same_entry():
+    """The daemon strips the extension before reporting and recipes store it stripped, but
+    the engine names files. Both reach this module."""
+    for name in CHECKPOINT_SOURCES:
+        assert source_for(name) is source_for(f"{name}.safetensors")
+    assert canonical_name("x.safetensors") == "x"
+    assert canonical_name("  x  ") == "x"
+
+
+def test_an_unknown_checkpoint_returns_none_rather_than_guessing():
+    """None means "route to a worker that holds it". Inventing a URL from the name would
+    produce a confident 404 twenty minutes into a boot."""
+    assert source_for("ltx-2.3-22b-dev") is None
+    assert source_for("") is None
+    assert source_for("not_a_real_model") is None
+
+
+def test_the_catalogue_agrees_with_what_a_cold_pod_stages():
+    """The catalogue and download_models.sh must not disagree about the same name.
+
+    If they do, a cold pod stages one file and later fetches a different one under the same
+    name. Two different base models sharing a name is the worst case here, because every
+    render still succeeds and nothing is comparable afterwards.
+
+    Skips when the sibling checkout is absent, so it does not run in CI -- a known weakness
+    (noted in api#262). It is still worth having locally, because the failure it catches is
+    invisible at runtime.
+    """
+    script = DOCKER_REPO / "download_models.sh"
+    if not script.exists():
+        return
+    text = script.read_text()
+    rows = re.findall(r'^\s*"([^"]*diffusion_models\|[^"]*)"\s*$', text, re.MULTILINE)
+    for row in rows:
+        _dest, filename, repo, path = (row.split("|") + [""])[:4]
+        stem = canonical_name(filename)
+        src = CHECKPOINT_SOURCES.get(stem)
+        if src is None:
+            raise AssertionError(
+                f"download_models.sh stages {stem!r} but the catalogue has no entry — a pod "
+                f"that lost the file could not re-fetch it"
+            )
+        assert src["repo"] == repo, f"{stem}: catalogue says {src['repo']}, script says {repo}"
+        assert src["path"] == (path or filename), (
+            f"{stem}: catalogue path {src['path']!r} vs script {(path or filename)!r}"
+        )


### PR DESCRIPTION
The API half of DavidJBarnes/wanly-console#423. The daemon half follows.

## Context: #423's two blockers are now cleared

**"The file has no recorded source"** — it's `TenStrip/LTX2.3-10Eros`, verified byte-exact against the 3090's copy (46,139,886,366), public and ungated. Added to `download_models.sh` in console#431 tonight and since staged by a real cold pod at 61 MB/s. So the ticket's cost table collapses to *Hugging Face / free*, which removes the "routing is cheaper than fetching" argument against building this.

**"The unknown to test first"** — tested on the live pod, mid-render: a probe file dropped into `diffusion_models/` appeared in both ComfyUI's `object_info` and the engine's `/checkpoints` within 3 seconds. **ComfyUI re-scans per request.** No restart needed, so the largest risk in the ticket doesn't apply.

## What this adds

`app/checkpoint_sources.py` — name → `{repo, path, size_bytes}` — and `GET /ltx/checkpoints/catalog`.

**Why the API owns it:** in the daemon, adding a base model means redeploying every worker. Here it's one entry and the fleet learns on its next claim.

**Why it's separate from `/ltx/checkpoints`:** that endpoint answers *what can be rendered now*, from live worker inventory. This answers *where one comes from* — a fact about the file, true whether any worker is up.

**Why `size_bytes` is in the response:** a partial safetensors is a valid header over missing data. It passes every existence check and fails only at load, inside a claimed segment — `download_models.sh` records one arriving at 14.40 of 27.16 GiB reporting nothing. The fetcher needs the expected length to verify before renaming into place.

## Entries are verified by bytes, not by name

```
10Eros_v1.5_bf16   46,139,886,366   TenStrip/LTX2.3-10Eros
sulphur_dev_bf16   46,139,885,414   SulphurAI/Sulphur-2-base
```

Both matched against the 3090's copies. A same-named file of a different size is a different model, and that failure is **silent**: the worker downloads it, ComfyUI loads it, the render succeeds, and nothing is comparable afterwards. So the module documents byte-verification as the rule for adding an entry.

`ltx-2.3-22b-dev` and `ltx-2.3-22b-distilled-1.1` are deliberately **absent** — both sit on the 3090 and no pose names either, so an entry would only invite a pod to spend 20 minutes fetching 46 GB for a model nothing renders on. An entry is a statement that the file is worth a cold pod's time.

## Tests

Six. The one that matters most asserts **the stack default has a source** — without it, a cold pod handed a default-checkpoint pose can neither render nor fetch it, and just claims nothing, which looks like an empty queue.

Another asserts the catalogue **agrees with `download_models.sh`** about any shared name, because a disagreement means a pod stages one file and later fetches a different one under the same name. That one self-skips without the sibling checkout, so it doesn't run in CI — the same weakness I flagged in api#262; called out in the test's own docstring rather than left implicit.

`pytest` — **779 passed** (773 before, plus 6).

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J