### PR TITLE
workers: a re-registering worker holds nothing, so free its old claims

### DIFF
--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -1,8 +1,9 @@
+import logging
 import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import verify_api_key, verify_api_key_or_bearer
@@ -11,6 +12,8 @@ from app.enums import JobStatus, SegmentStatus
 from app.models import Job, Segment, Worker
 from app.queue_health import assess
 from app.schemas.workers import QueueHealthResponse, WorkerDrain, WorkerHeartbeat, WorkerRegister, WorkerRename, WorkerResponse, WorkerStatusUpdate
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -59,6 +62,9 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
         )
         db.add(worker)
 
+    # A worker that is registering holds nothing. Release anything still assigned to it.
+    await _release_orphaned_claims(db, worker)
+
     # A reservation may have asked for a drain policy up front. Apply it the moment the worker
     # it was waiting for appears.
     #
@@ -71,6 +77,56 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
     await db.commit()
     await db.refresh(worker)
     return worker
+
+
+async def _release_orphaned_claims(db: AsyncSession, worker: Worker) -> None:
+    """Free any segment still assigned to a worker that has just registered.
+
+    Registration means the daemon has started fresh: it happens once, before the claim loop,
+    so a worker reaching this point is by definition rendering nothing. Any segment still
+    marked CLAIMED or PROCESSING against it belongs to a previous life of that worker, and
+    nothing will ever finish it.
+
+    WHY NOTHING ELSE CATCHES THIS
+        The reclaim in /segments/next needs either a stale heartbeat or an idle worker with
+        an empty progress log. A replaced container satisfies neither: registration upserts
+        on friendly_name, so the row -- and its id -- is REUSED, the new daemon heartbeats
+        immediately, and it goes on to claim something else and report online-busy. The old
+        claim is pinned to a live, healthy, busy worker and is unreachable by every existing
+        rule.
+
+        Observed 2026-09-06: a container was replaced 50% through a 673 MB LoRA download in
+        [2/6]. The segment sat in PROCESSING for SEVEN HOURS against a worker that had never
+        heard of it, and its job could not finish. It had to be freed by hand.
+
+    A worker renders one segment at a time -- the claim loop guards it with executing_event --
+    so there is no case where a registering worker legitimately holds work. Deliberately not
+    tied to container replacement specifically: any path that gets a daemon back to
+    registration (crash, OOM kill, manual restart, a pod recreated by the updater) leaves the
+    same wreckage, and they should all be cleaned up by the same rule.
+
+    Progress log is cleared with the claim. It describes an attempt that no longer exists, and
+    leaving it would also make the segment permanently ineligible for the live-worker reclaim
+    in /segments/next, which requires an empty log.
+    """
+    if worker.id is None:
+        return  # brand new row; it cannot hold anything yet
+    result = await db.execute(
+        update(Segment)
+        .where(
+            Segment.worker_id == worker.id,
+            Segment.status.in_([SegmentStatus.CLAIMED, SegmentStatus.PROCESSING]),
+        )
+        .values(status=SegmentStatus.PENDING, worker_id=None, worker_name=None,
+                claimed_at=None, progress_log=None)
+        .returning(Segment.id)
+    )
+    freed = result.scalars().all()
+    if freed:
+        logger.warning(
+            "Worker %s re-registered holding %d claimed segment(s); released to PENDING: %s",
+            worker.friendly_name, len(freed), ", ".join(str(i) for i in freed),
+        )
 
 
 async def _apply_reserved_drain(db: AsyncSession, worker: Worker) -> None:

--- a/tests/test_orphaned_claim_release.py
+++ b/tests/test_orphaned_claim_release.py
@@ -1,0 +1,137 @@
+"""A worker that re-registers holds nothing, so its old claims must be freed.
+
+THE INCIDENT (2026-09-06). The 3090's container was replaced 50% through a 673 MB LoRA
+download in [2/6]. The replacement registered under the same friendly_name, so the worker row
+-- and its id -- was REUSED, it heartbeated immediately, and it claimed something else.
+
+The segment it had been working on sat in PROCESSING for SEVEN HOURS, pinned to a worker that
+was alive, healthy, busy, and had never heard of it. Its job could not finish, and the console
+showed two segments in progress against one worker.
+
+NOTHING EXISTING COULD FREE IT. The reclaim in /segments/next needs either a stale heartbeat
+or an idle worker with an empty progress log. A replaced container satisfies neither.
+"""
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.auth import verify_api_key
+from app.database import get_db
+from app.enums import JobStatus, SegmentStatus
+from app.main import app
+from app.models import Job, Segment, User, Worker
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _user(db):
+    u = User(username=str(uuid.uuid4()), password_hash="x")
+    db.add(u); await db.flush(); return u
+
+
+async def _job(db, user):
+    j = Job(user_id=user.id, name="j", width=832, height=1216, fps=24, seed=1,
+            priority=0, status=JobStatus.PROCESSING, starting_image="s3://b/s.png")
+    db.add(j); await db.flush(); return j
+
+
+async def _worker(db, name="3090.zero", status="online-busy"):
+    w = Worker(friendly_name=name, hostname="h", ip_address="10.0.0.1",
+               status=status, comfyui_running=True)
+    db.add(w); await db.flush(); return w
+
+
+async def _segment(db, job, worker, status=SegmentStatus.PROCESSING, log="[2/6] 50% of 673 MB", index=0):
+    from datetime import datetime, timezone
+    s = Segment(job_id=job.id, index=index, prompt="p", status=status, discarded=False,
+                worker_id=worker.id if worker else None,
+                worker_name=worker.friendly_name if worker else None,
+                claimed_at=datetime.now(timezone.utc), progress_log=log)
+    db.add(s); await db.flush(); return s
+
+
+async def _register(db, name="3090.zero"):
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[verify_api_key] = lambda: None
+    try:
+        for obj in list(db.identity_map.values()):
+            if isinstance(obj, (Job, Segment, Worker)):
+                db.expire(obj)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            return await c.post("/workers", json={
+                "friendly_name": name, "hostname": "h",
+                "ip_address": "10.0.0.1", "comfyui_running": True,
+            })
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_a_reregistering_worker_releases_the_claim_it_abandoned(db):
+    """THE regression. Seven hours stuck, and unreachable by every existing rule."""
+    w = await _worker(db)
+    seg = await _segment(db, await _job(db, await _user(db)), w)
+
+    assert (await _register(db)).status_code == 201
+
+    await db.refresh(seg)
+    assert seg.status == SegmentStatus.PENDING
+    assert seg.worker_id is None and seg.worker_name is None
+    assert seg.claimed_at is None
+
+
+async def test_the_stale_progress_log_goes_with_it(db):
+    """It describes an attempt that no longer exists — and leaving it would make the segment
+    permanently ineligible for the live-worker reclaim in /segments/next, which requires an
+    empty log."""
+    w = await _worker(db)
+    seg = await _segment(db, await _job(db, await _user(db)), w)
+    await _register(db)
+    await db.refresh(seg)
+    assert not (seg.progress_log or "")
+
+
+async def test_a_claimed_but_not_yet_processing_segment_is_freed_too(db):
+    """The window this incident happened in — [1/6]/[2/6], before the engine ever sees it."""
+    w = await _worker(db)
+    seg = await _segment(db, await _job(db, await _user(db)), w,
+                         status=SegmentStatus.CLAIMED)
+    await _register(db)
+    await db.refresh(seg)
+    assert seg.status == SegmentStatus.PENDING
+
+
+async def test_finished_work_is_left_alone(db):
+    """Only in-flight claims. Rewriting a completed segment would destroy a real result."""
+    w = await _worker(db)
+    job = await _job(db, await _user(db))
+    done = await _segment(db, job, w, status=SegmentStatus.COMPLETED, log="[6/6] done", index=0)
+    failed = await _segment(db, job, w, status=SegmentStatus.FAILED, log="boom", index=1)
+    await _register(db)
+    await db.refresh(done); await db.refresh(failed)
+    assert done.status == SegmentStatus.COMPLETED
+    assert done.worker_id == w.id and done.progress_log == "[6/6] done"
+    assert failed.status == SegmentStatus.FAILED
+
+
+async def test_another_workers_claim_is_untouched(db):
+    """Scoped to the registering worker. Freeing someone else's in-flight segment would hand
+    live work to a second GPU — the exact convergence this must not cause."""
+    await _worker(db, "3090.zero")
+    theirs = await _worker(db, "runpod-1")
+    job = await _job(db, await _user(db))
+    other = await _segment(db, job, theirs)
+    # Read the id BEFORE the request expires the object: touching an expired attribute
+    # outside the route's greenlet triggers a sync lazy load and raises MissingGreenlet.
+    theirs_id = theirs.id
+
+    await _register(db, "3090.zero")
+
+    await db.refresh(other)
+    assert other.status == SegmentStatus.PROCESSING
+    assert other.worker_id == theirs_id
+
+
+async def test_a_brand_new_worker_registers_cleanly(db):
+    """No prior row, nothing to release, must not error."""
+    assert (await _register(db, f"fresh-{uuid.uuid4().hex[:6]}")).status_code == 201


### PR DESCRIPTION
Fixes a stuck-segment class found in production today. Pairs with a wanly-gpu-docker fix for the updater that triggered it.

## What happened

The 3090's container was replaced **50% through a 673 MB LoRA download in `[2/6]`**. The replacement registered under the same `friendly_name`, so the worker row *and its id* were reused, it heartbeated immediately, and it claimed something else.

```
9729dc1d idx 1   processing   held 6h54m   worker 3090.zero (alive, heartbeat 30s ago)
progress_log:    [06:37:14] [2/6] plora_sulfter...: 50% of 673 MB
```

Seven hours. The job could not finish, and the console showed **two segments in progress against one online worker** — the engine confirmed only one render (`running: 1`). Freed by hand.

## Why nothing caught it

The reclaim in `/segments/next` needs either a stale heartbeat, or an idle worker with an empty progress log. A replaced container satisfies **neither**:

| rule | why it misses |
|---|---|
| stale heartbeat | the new daemon beats immediately |
| worker `online-idle` | it's `online-busy` — on a *different* segment |
| empty progress log | holds the abandoned attempt's own output |

So the claim is pinned to a live, healthy, busy worker and is unreachable by every existing path. It never self-heals.

## The fix

Registration is the right hook: it happens **once, before the claim loop**, so a worker reaching it is by definition rendering nothing. A worker renders one segment at a time (`executing_event` guards it), so there's no case where a registering worker legitimately holds work.

Deliberately **not** tied to container replacement — any route back to registration (crash, OOM kill, manual restart, a pod recreated by an updater) leaves identical wreckage, and one rule should clean up all of them.

The progress log is cleared with the claim: it describes an attempt that no longer exists, and leaving it would also make the segment *permanently* ineligible for the live-worker reclaim, which requires an empty log.

## Scoping, because the failure modes here are severe

- **Only the registering worker.** Freeing another worker's in-flight segment hands live work to a second GPU — the convergence `/segments/next` already warns about. Tested.
- **Only `CLAIMED`/`PROCESSING`.** Rewriting a `COMPLETED` segment would destroy a real result. Tested, including that `worker_id` and the log survive on finished work.

## Tests

Six, covering the regression, the `[1/6]`/`[2/6]` window it happened in, log clearing, both scoping guards, and a brand-new worker registering cleanly. **Verified they fail with the release disabled** — 3 of 6 go red.

`pytest` — **785 passed** (779 before).

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J