### PR TITLE
workers: record and report what code a worker is running

### DIFF
--- a/alembic/versions/088_worker_build_identity.py
+++ b/alembic/versions/088_worker_build_identity.py
@@ -1,0 +1,41 @@
+"""What code a worker is actually running
+
+Revision ID: 088
+Revises: 087
+Create Date: 2026-09-06
+
+Two workers ran different code for 14 hours and nothing said so. It surfaced as a 422 on a
+content LoRA that looked random: a RunPod pod fetched it correctly, the 3090 could not,
+because the pod's daemon was current and the 3090's was cloned before the fix existed.
+
+NULLABLE, and null means "this daemon does not report it" -- an older daemon must keep
+heartbeating rather than 422 itself out of the pool on upgrade day, which is how every
+optional worker field before these behaves.
+
+TWO FIELDS, NOT ONE, because there are two independent update channels and they drift
+separately:
+
+  daemon_commit  the daemon is git-cloned from main by start.sh at every container boot
+  image_ref      start.sh, the downloader and the engine are baked into the image and only
+                 change on pull + recreate
+
+The 3090 demonstrated the difference: `docker restart` moved daemon_commit to current and
+left image_ref 37 hours stale. One field could not have shown that.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "088"
+down_revision = "087"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("workers", sa.Column("daemon_commit", sa.Text(), nullable=True))
+    op.add_column("workers", sa.Column("image_ref", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "image_ref")
+    op.drop_column("workers", "daemon_commit")

--- a/app/models.py
+++ b/app/models.py
@@ -327,6 +327,13 @@ class Worker(Base):
     # no second opinion here about what a daemon can do. NULL means never reported, which
     # this treats as fetching nothing. See app/model_requirements.py.
     fetchable_kinds: Mapped[list | None] = mapped_column(JSONB, nullable=True, default=None)
+    # What code this worker is actually running (wanly-gpu-docker#72). TWO fields, because
+    # there are two update channels that drift separately: the daemon is re-cloned from main
+    # at every container boot, while start.sh, the downloader and the engine only change on
+    # an image pull + recreate. A `docker restart` moves the first and not the second, which
+    # is exactly how the 3090 came to run a current daemon on a 37-hour-old image.
+    daemon_commit: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    image_ref: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
     drain_after_jobs: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -220,6 +220,13 @@ async def heartbeat(
         worker.checkpoints = body.checkpoints
     if body.fetchable_kinds is not None:
         worker.fetchable_kinds = body.fetchable_kinds
+    # Same conditional write again. These two answer "what code is this worker running"
+    # (wanly-gpu-docker#72) and they move independently: the daemon is re-cloned from main at
+    # every container boot, the image only changes on pull + recreate.
+    if body.daemon_commit is not None:
+        worker.daemon_commit = body.daemon_commit
+    if body.image_ref is not None:
+        worker.image_ref = body.image_ref
     if worker.status == "offline":
         worker.status = "online-idle"
     # If sd-scripts is actively training, worker can't be idle

--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class WorkerRegister(BaseModel):
@@ -25,6 +25,11 @@ class WorkerHeartbeat(BaseModel):
     loras: dict[str, Any] | None = None
     # Base models this worker can load. Optional so an older daemon still heartbeats.
     checkpoints: list[str] | None = None
+    # What code this worker is running (wanly-gpu-docker#72). Optional like everything else
+    # here: a daemon that does not report them must keep heartbeating, and absent is read as
+    # "does not report", never as a value.
+    daemon_commit: str | None = Field(default=None, max_length=64)
+    image_ref: str | None = Field(default=None, max_length=200)
     # Artifact kinds this worker can fetch on demand ("lora" today). Optional, like every
     # field before it: an older daemon that sends nothing must keep heartbeating rather than
     # 422 itself out of the pool on upgrade day. Absent is read as "fetches nothing", which
@@ -78,6 +83,12 @@ class WorkerResponse(BaseModel):
     # drops what a response model does not name, silently, which makes a stored value and an
     # unreported one indistinguishable from outside.
     fetchable_kinds: list[str] | None = None
+    # Named here deliberately, and this is the point of the whole change: a stored value that
+    # a response model omits is silently indistinguishable from an unreported one -- which is
+    # the mistake fetchable_kinds made above, and this field exists to END that class of
+    # invisibility, so it must not repeat it.
+    daemon_commit: str | None = None
+    image_ref: str | None = None
     drain_after_jobs: int | None = None
     last_heartbeat: datetime
     registered_at: datetime

--- a/tests/test_worker_build_identity.py
+++ b/tests/test_worker_build_identity.py
@@ -1,0 +1,101 @@
+"""What code a worker is actually running (wanly-gpu-docker#72).
+
+Two workers ran different code for 14 hours and nothing said so. It surfaced as a 422 on a
+content LoRA that looked random: the pod's daemon was current, the 3090's had been cloned
+before the fix existed. Diagnosing it took SSH into both boxes and reading git.
+
+TWO FIELDS, not one, because there are two update channels that drift separately:
+
+    daemon_commit   re-cloned from main by start.sh at every container boot
+    image_ref       start.sh, the downloader and the engine; only changes on pull + recreate
+
+The 3090 proved the distinction the same day: `docker restart` moved daemon_commit to current
+and left image_ref 37 hours stale. One field could not have shown that.
+"""
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.auth import verify_api_key
+from app.database import get_db
+from app.main import app
+from app.models import Worker
+from app.schemas.workers import WorkerHeartbeat, WorkerResponse
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _worker(db, **kw):
+    w = Worker(friendly_name=str(uuid.uuid4())[:12], hostname="h", ip_address="10.0.0.1",
+               status="online-idle", comfyui_running=True, **kw)
+    db.add(w)
+    await db.flush()
+    return w
+
+
+async def _beat(db, worker_id, **body):
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[verify_api_key] = lambda: None
+    try:
+        for obj in list(db.identity_map.values()):
+            if isinstance(obj, Worker):
+                db.expire(obj)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            return await c.post(f"/workers/{worker_id}/heartbeat",
+                                json={"comfyui_running": True, **body})
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_an_older_daemon_still_heartbeats():
+    """Required fields would 422 every worker on the previous daemon out of the pool the
+    moment this deployed."""
+    hb = WorkerHeartbeat(comfyui_running=True)
+    assert hb.daemon_commit is None and hb.image_ref is None
+
+
+async def test_a_heartbeat_records_both(db):
+    w = await _worker(db)
+    wid = w.id
+    r = await _beat(db, wid, daemon_commit="a044cef", image_ref="sha256:01bfaa8a85a3")
+    assert r.status_code == 200
+    await db.refresh(w)
+    assert w.daemon_commit == "a044cef"
+    assert w.image_ref == "sha256:01bfaa8a85a3"
+
+
+async def test_omitting_them_does_not_erase_what_was_reported(db):
+    """An older daemon omits the field on every beat. Assigning None would blank a good value
+    seconds after a newer worker reported it — the same trap loras and checkpoints hit."""
+    w = await _worker(db, daemon_commit="a044cef", image_ref="sha256:aaa")
+    wid = w.id
+    assert (await _beat(db, wid)).status_code == 200
+    await db.refresh(w)
+    assert w.daemon_commit == "a044cef"
+    assert w.image_ref == "sha256:aaa"
+
+
+async def test_the_response_actually_carries_them(db):
+    """THE point of the change, and the exact mistake fetchable_kinds made: a stored value a
+    response model omits is silently indistinguishable from an unreported one. A field that
+    exists to END invisibility must not itself be invisible."""
+    assert "daemon_commit" in WorkerResponse.model_fields
+    assert "image_ref" in WorkerResponse.model_fields
+
+    w = await _worker(db, daemon_commit="a044cef", image_ref="sha256:aaa")
+    wid = w.id
+    r = await _beat(db, wid, daemon_commit="a044cef")
+    assert r.json()["daemon_commit"] == "a044cef"
+    assert r.json()["image_ref"] == "sha256:aaa"
+
+
+async def test_the_two_fields_move_independently(db):
+    """`docker restart` re-clones the daemon and reuses the image. A worker must be able to
+    report a new commit on an old image — that is precisely the state the 3090 was in."""
+    w = await _worker(db, daemon_commit="6786f86", image_ref="sha256:old")
+    wid = w.id
+    await _beat(db, wid, daemon_commit="a044cef")   # image_ref omitted
+    await db.refresh(w)
+    assert w.daemon_commit == "a044cef"
+    assert w.image_ref == "sha256:old", "the image must not move when only the daemon did"


### PR DESCRIPTION
The API half of DavidJBarnes/wanly-gpu-docker#72's remaining acceptance criteria. Daemon and console halves follow.

## Why

Two workers ran different code for 14 hours and nothing said so. It surfaced as a 422 on a content LoRA that looked random — the pod's daemon was current, the 3090's had been cloned before the fix existed. Diagnosing it meant SSHing into both boxes and reading git.

## Two fields, not one

```
daemon_commit   re-cloned from main by start.sh at every container boot
image_ref       start.sh, the downloader, the engine — only on pull + recreate
```

The 3090 proved the distinction the same day: `docker restart` moved `daemon_commit` to current and left `image_ref` **37 hours stale**. A single "version" field could not have shown that, and it's exactly the state that caused the confusion.

## Following the established patterns

- **Nullable**, so an older daemon keeps heartbeating instead of 422-ing itself out of the pool on upgrade day.
- **Conditionally written** (`if body.x is not None`) — assigning `None` would blank a good value seconds after a newer worker reported it, the trap `loras` and `checkpoints` already document.
- **Named in `WorkerResponse`.** `fetchable_kinds` was stored since #249 and missing from that schema until recently, so it read as NULL everywhere it was looked at — Pydantic drops what a response model doesn't name, silently. A field whose entire purpose is to end invisibility must not itself be invisible. There's a test for it.

## Tests

Five: older daemon still heartbeats, both fields recorded, omission doesn't erase, the response actually carries them, and — the one that matters for the 3090's case — the two fields move **independently**, so reporting a new commit on an old image works.

`pytest` — **790 passed**.

## One thing I should flag

`tests/test_segment_s3_keys.py::test_upload_keys_by_segment_id` is **flaky at roughly 1 run in 6**, unrelated to this change. I measured it: 6 consecutive runs on this branch gave 5 passes and 1 failure, and clean `main` also passes and (earlier tonight, on a different branch) also failed once. It's not caused by these columns — different subsystem entirely — but it will intermittently redden CI. Ticketing separately rather than sweeping it up here.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J