### PR TITLE
Workers say what kind they are, and two things read it

### DIFF
--- a/alembic/versions/089_worker_kind_and_provides.py
+++ b/alembic/versions/089_worker_kind_and_provides.py
@@ -1,0 +1,62 @@
+"""What a worker IS, and what it runs
+
+Revision ID: 089
+Revises: 088
+Create Date: 2026-09-06
+
+wanly-api#269. The workers table has only ever described render workers -- comfyui_running,
+gpu_stats, checkpoints, loras, fetchable_kinds are all render concepts -- because until
+wanly-services existed there was only one kind of worker.
+
+TWO COLUMNS, because they answer different questions and one of them is load-bearing for the
+claim path:
+
+  kind      may I hand this work? Scalar, closed set, read by the claim gate and by
+            queue-health. NOT NULL with a default, so there is never a live worker whose
+            claimability is unknown -- and so every existing row and every current daemon
+            keeps exactly its present meaning without a migration guessing at it.
+
+  provides  what is this box actually doing? A list, because a services container runs
+            several at once (SERVICES=joycaption,qwen-edit). Nullable, where NULL means
+            "never reported" and [] means "reports nothing" -- the same distinction
+            checkpoints, loras and fetchable_kinds already make, and for the same reason: an
+            older daemon must not be indistinguishable from one with nothing to offer.
+
+WHY NOT ONE FIELD. Keying the gate on a name allowlist ("is ltx-engine in provides?") fails in
+the dangerous direction: add an engine, forget the allowlist, and that worker claims nothing --
+which this codebase already knows looks exactly like an empty queue. With kind, a new engine is
+`render` and claimable by default while a new service is `service` and excluded by default.
+Both defaults land on the safe side.
+
+provides also records something the API has never known: there is no `engine` column, so
+nothing here has ever said whether a worker runs LTX or WAN 2.2. It was inferable while there
+was one engine; it stops being inferable the moment a second kind of worker exists.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "089"
+down_revision = "088"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # server_default as well as a model default: the backfill of existing rows and any INSERT
+    # from a connection that has not seen the new model both have to land on 'render'. A
+    # nullable kind would mean a window where a live worker's claimability is unknown, and the
+    # claim gate would have to guess -- which is the whole thing this column exists to stop.
+    op.add_column(
+        "workers",
+        sa.Column("kind", sa.String(length=20), nullable=False, server_default="render"),
+    )
+    op.add_column(
+        "workers",
+        sa.Column("provides", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "provides")
+    op.drop_column("workers", "kind")

--- a/app/enums.py
+++ b/app/enums.py
@@ -44,3 +44,45 @@ JOB_VALID_TRANSITIONS: dict[str, set[str]] = {
     JobStatus.PAUSED: {JobStatus.PENDING, JobStatus.PROCESSING, JobStatus.AWAITING, JobStatus.ARCHIVED},
     JobStatus.ARCHIVED: {JobStatus.AWAITING},
 }
+
+
+class WorkerKind(StrEnum):
+    """What a worker IS — the only thing the claim gate reads (#269).
+
+    Deliberately a tiny closed set rather than the list of things a worker runs. A gate keyed
+    on names needs an allowlist, and an engine missing from that allowlist claims nothing,
+    which is indistinguishable from an empty queue. Here a new engine is RENDER and claimable
+    by default, while a new service is SERVICE and excluded by default: both defaults land on
+    the safe side.
+
+    What a worker runs is `Worker.provides`, which is a list and is for display.
+    """
+    RENDER = "render"
+    SERVICE = "service"
+
+
+#: Convenience for the model's column defaults, which cannot reference the enum member
+#: directly without dragging StrEnum into the DDL.
+WORKER_KIND_RENDER = str(WorkerKind.RENDER)
+
+
+class WorkerStatus(StrEnum):
+    """Worker statuses, across both kinds.
+
+    ONLINE_IDLE and ONLINE_BUSY are the render vocabulary and mean what they always have.
+
+    ONLINE and DEGRADED are for services, and exist because reusing ONLINE_IDLE would have
+    been the cheap wrong answer: wanly-gpu-docker#80 is open precisely because online-idle
+    already means two different things -- "waiting for work" and "cannot do work" -- and that
+    ambiguity hid a dead ComfyUI for 33 minutes. A service is never waiting for work, so
+    saying it is idle would extend exactly the confusion that is already costing us.
+
+    DEGRADED is not a synonym for broken: wanly-services reports it when some but not all of
+    its enabled services answer, which is a state a single green dot cannot express.
+    """
+    ONLINE_IDLE = "online-idle"
+    ONLINE_BUSY = "online-busy"
+    ONLINE = "online"
+    DEGRADED = "degraded"
+    DRAINING = "draining"
+    OFFLINE = "offline"

--- a/app/models.py
+++ b/app/models.py
@@ -5,7 +5,7 @@ from sqlalchemy import BigInteger, Boolean, DateTime, Float, ForeignKey, Index, 
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-from app.enums import JobStatus, SegmentStatus, VideoStatus
+from app.enums import JobStatus, SegmentStatus, VideoStatus, WORKER_KIND_RENDER
 
 
 class Base(DeclarativeBase):
@@ -300,6 +300,25 @@ class Worker(Base):
     friendly_name: Mapped[str] = mapped_column(String(255), nullable=False)
     hostname: Mapped[str] = mapped_column(String(255), nullable=False)
     ip_address: Mapped[str] = mapped_column(String(45), nullable=False)
+    # WHAT THIS WORKER IS, read by the claim gate and by queue-health (#269). `render` takes
+    # segments; `service` never can. Scalar and NOT NULL on purpose: there must be no window
+    # in which a live worker's claimability is unknown, because the gate would then have to
+    # guess, and the safe guess and the useful guess are opposites.
+    #
+    # Defaulting to `render` keeps every existing row and every current daemon meaning exactly
+    # what it meant before this column existed.
+    kind: Mapped[str] = mapped_column(String(20), nullable=False, default=WORKER_KIND_RENDER,
+                                      server_default=WORKER_KIND_RENDER)
+    # WHAT IT RUNS, for display: ["ltx-engine"], ["joycaption", "qwen-edit"]. A list because a
+    # services container runs several at once, which is the entire point of its SERVICES flag.
+    #
+    # Deliberately NOT what the gate reads. A gate keyed on names needs an allowlist, and a new
+    # engine missing from that allowlist claims nothing -- indistinguishable from an empty
+    # queue, which is the failure this codebase keeps paying for.
+    #
+    # NULL means never reported, [] means reports nothing. Same distinction as checkpoints and
+    # loras above, same reason: an older daemon must not look like one with nothing to offer.
+    provides: Mapped[list | None] = mapped_column(JSONB, nullable=True, default=None)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="online-idle")
     comfyui_running: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     # Set by workers running on RunPod. NULL for the 3090 and anything else self-hosted.

--- a/app/queue_health.py
+++ b/app/queue_health.py
@@ -22,6 +22,16 @@ from datetime import datetime
 # every bit as stalled as one with none -- it just has not noticed yet.
 LIVE_STATUSES = frozenset({"online-idle", "online-busy"})
 
+# ONLY RENDER WORKERS COUNT (#269). A service worker holds a GPU and heartbeats, but it can
+# never take a segment -- so counting it here would mean `stalled` never fires again once
+# wanly-services is up, and it would go quiet at exactly the moment it matters: every render
+# worker down, work queued, and one perfectly healthy captioner keeping the alarm silent.
+#
+# Nothing would error. The alarm would simply stop, which is the failure this whole module was
+# written to end -- the 3090 sat dead for thirteen hours with four segments queued and every
+# fact needed to notice already in the database.
+COUNTED_KINDS = frozenset({"render"})
+
 
 @dataclass(frozen=True)
 class QueueHealth:

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, UploadFile, status
-from sqlalchemy import and_, func, or_, select, text
+from sqlalchemy import and_, false as sa_false, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -23,7 +23,7 @@ from app.config import settings
 from app.database import get_db
 from app.routes.captions import caption_image_bytes
 from app.seeds import new_seed
-from app.enums import JobStatus, SegmentStatus, VideoStatus
+from app.enums import JobStatus, SegmentStatus, VideoStatus, WorkerKind
 from app.ltx_stack import LTX_STACK
 from app.model_requirements import CHECKPOINT, canonical
 from app.models import (
@@ -465,6 +465,16 @@ def _model_gate(worker: Worker | None) -> tuple:
     made against a stale one degrades to exactly the old behaviour — a loud engine failure —
     rather than to something worse.
     """
+    # A NON-RENDER WORKER TAKES NOTHING, and this is checked FIRST -- before the
+    # never-reported exemption below, which would otherwise wave it straight through (#269).
+    #
+    # A freshly registered service has checkpoints NULL, so without this it would be offered
+    # every pending segment. Nothing breaks today only because wanly-services has no daemon
+    # and never polls; that is the safety being an accident of it not asking rather than a
+    # decision that it must not be asked. `false` rather than an empty tuple, because an empty
+    # tuple means "no restriction" and is exactly the wrong answer here.
+    if worker is not None and worker.kind != WorkerKind.RENDER:
+        return (sa_false(),)
     if worker is None or worker.checkpoints is None:
         return ()
     if CHECKPOINT in (worker.fetchable_kinds or []):

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -8,9 +8,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import verify_api_key, verify_api_key_or_bearer
 from app.database import get_db
-from app.enums import JobStatus, SegmentStatus
+from app.enums import JobStatus, SegmentStatus, WorkerKind, WorkerStatus
 from app.models import Job, Segment, Worker
-from app.queue_health import assess
+from app.queue_health import COUNTED_KINDS, assess
 from app.schemas.workers import QueueHealthResponse, WorkerDrain, WorkerHeartbeat, WorkerRegister, WorkerRename, WorkerResponse, WorkerStatusUpdate
 
 logger = logging.getLogger(__name__)
@@ -45,6 +45,12 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
         worker.hostname = body.hostname
         worker.ip_address = body.ip_address
         worker.comfyui_running = body.comfyui_running
+        # Re-registering can legitimately change what a box is: the same host could stop
+        # running services and start running an engine. Taken from the request rather than
+        # preserved, so the row follows reality instead of the first thing it ever saw.
+        worker.kind = body.kind
+        if body.provides is not None:
+            worker.provides = body.provides
         # Re-registering after a container restart can land on a new pod id.
         if body.runpod_pod_id:
             worker.runpod_pod_id = body.runpod_pod_id
@@ -59,6 +65,8 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
             ip_address=body.ip_address,
             comfyui_running=body.comfyui_running,
             runpod_pod_id=body.runpod_pod_id,
+            kind=body.kind,
+            provides=body.provides,
         )
         db.add(worker)
 
@@ -227,17 +235,36 @@ async def heartbeat(
         worker.daemon_commit = body.daemon_commit
     if body.image_ref is not None:
         worker.image_ref = body.image_ref
-    if worker.status == "offline":
-        worker.status = "online-idle"
-    # If sd-scripts is actively training, worker can't be idle
-    if worker.status not in ("offline", "draining"):
-        sd_training = (
-            body.sd_scripts.get("sd_scripts_training", False)
-            if body.sd_scripts
-            else False
-        )
-        if sd_training:
-            worker.status = "online-busy"
+    # Same conditional write once more. A services container can change what it runs across a
+    # restart without re-registering, so the row would otherwise advertise yesterday's set.
+    if body.provides is not None:
+        worker.provides = body.provides
+
+    if worker.kind != WorkerKind.RENDER:
+        # A SERVICE REPORTS ITS OWN HEALTH, because there is no claim state to derive one
+        # from -- it is never idle-waiting-for-work and never busy-with-a-segment. It sends
+        # "online" when everything it was asked to run answers and "degraded" when some of it
+        # does not, which is a distinction the render vocabulary cannot express and which
+        # wanly-gpu-docker#80 is open because we could not express.
+        #
+        # `status` is honoured ONLY here. A render worker's status stays derived, so a daemon
+        # cannot talk itself into looking idle.
+        if body.status is not None:
+            worker.status = body.status
+        elif worker.status == "offline":
+            worker.status = WorkerStatus.ONLINE
+    else:
+        if worker.status == "offline":
+            worker.status = "online-idle"
+        # If sd-scripts is actively training, worker can't be idle
+        if worker.status not in ("offline", "draining"):
+            sd_training = (
+                body.sd_scripts.get("sd_scripts_training", False)
+                if body.sd_scripts
+                else False
+            )
+            if sd_training:
+                worker.status = "online-busy"
     await db.commit()
     await db.refresh(worker)
     return worker
@@ -317,7 +344,12 @@ async def queue_health(db: AsyncSession = Depends(get_db)):
         )
     )).scalar() or 0
 
-    rows = (await db.execute(select(Worker.status, Worker.last_heartbeat))).all()
+    # Render workers only. A service can never take a segment, so letting one count as live
+    # would silence `stalled` permanently -- see COUNTED_KINDS in app/queue_health.py.
+    rows = (await db.execute(
+        select(Worker.status, Worker.last_heartbeat)
+        .where(Worker.kind.in_(COUNTED_KINDS))
+    )).all()
     health = assess(
         pending_segments=pending,
         worker_statuses=[r[0] for r in rows],

--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from app.enums import WorkerKind, WorkerStatus
+
 
 class WorkerRegister(BaseModel):
     friendly_name: str
@@ -12,6 +14,17 @@ class WorkerRegister(BaseModel):
     comfyui_running: bool = False
     # Optional: only RunPod workers have one, and older daemons do not send it.
     runpod_pod_id: str | None = None
+    # WHAT THIS WORKER IS (#269). Defaulted rather than required, so every daemon in the fleet
+    # keeps registering unchanged and keeps meaning exactly what it meant before. A service
+    # has to say so explicitly, which is the right way round: the failure of forgetting is
+    # "a service is treated as a render worker", and that is caught the first time it is
+    # offered a segment it cannot do -- loudly -- rather than the reverse, which is a render
+    # worker silently claiming nothing.
+    kind: WorkerKind = WorkerKind.RENDER
+    # WHAT IT RUNS: ["ltx-engine"], ["joycaption", "qwen-edit"]. Optional, and None means
+    # "never reported" rather than "runs nothing" -- the distinction every other optional
+    # worker field here already draws.
+    provides: list[str] | None = None
 
 
 class WorkerHeartbeat(BaseModel):
@@ -35,6 +48,15 @@ class WorkerHeartbeat(BaseModel):
     # 422 itself out of the pool on upgrade day. Absent is read as "fetches nothing", which
     # is the safe direction — it can still claim work whose files it already holds.
     fetchable_kinds: list[str] | None = None
+    # Repeated on the heartbeat, not just at registration, because a services container can
+    # change what it runs without re-registering -- SERVICES is a restart away, and the row
+    # would otherwise keep advertising yesterday's set. Optional and None means "not
+    # reported", so a daemon that never sends it leaves the stored value alone.
+    provides: list[str] | None = None
+    # A service reports its own health here: "online" when everything it was asked to run is
+    # answering, "degraded" when some of it is not. Render workers do not send this -- their
+    # status is derived from claims -- so None means "leave it alone".
+    status: WorkerStatus | None = None
 
 
 class WorkerRename(BaseModel):
@@ -71,6 +93,10 @@ class WorkerResponse(BaseModel):
     hostname: str
     ip_address: str
     status: str
+    # #269. `kind` is never null -- the column is NOT NULL with a default -- so the console
+    # can rely on it and does not need a fallback branch for "unclassified worker".
+    kind: str
+    provides: list[str] | None = None
     comfyui_running: bool
     gpu_stats: dict[str, Any] | None = None
     sd_scripts: dict[str, Any] | None = None

--- a/tests/test_worker_kind.py
+++ b/tests/test_worker_kind.py
@@ -1,0 +1,165 @@
+"""What a worker IS, and the two places that must read it (#269).
+
+wanly-services is a real, long-lived, GPU-holding process that can never render. Adding it to
+the fleet is only safe if two things key on `kind`, and each has a failure that is silent:
+
+  * THE CLAIM GATE. A freshly registered service has `checkpoints` NULL, and `_model_gate`
+    deliberately does not filter a worker that has never reported checkpoints -- so without a
+    kind check it would be offered every pending segment. Nothing breaks today only because
+    wanly-services has no daemon and never polls, which is the safety being an accident of it
+    not asking rather than a decision that it must not be asked.
+
+  * QUEUE HEALTH. `stalled` means "work queued and nobody who can take it". A service counted
+    as live means the alarm can never fire again -- and it would go quiet at exactly the
+    moment it matters: every render worker down, work queued, one healthy captioner holding
+    the count above zero.
+"""
+import inspect
+
+from sqlalchemy import false as sa_false
+
+from app.enums import WorkerKind, WorkerStatus
+from app.models import Worker
+from app.queue_health import COUNTED_KINDS, assess
+from app.routes.segments import _model_gate
+from app.schemas.workers import WorkerHeartbeat, WorkerRegister, WorkerResponse
+
+
+def _worker(**kw):
+    w = Worker(friendly_name="w", hostname="h", ip_address="1.2.3.4")
+    w.kind = kw.pop("kind", WorkerKind.RENDER)
+    for k, v in kw.items():
+        setattr(w, k, v)
+    return w
+
+
+class TestTheClaimGate:
+    def test_a_service_is_offered_nothing(self):
+        gate = _model_gate(_worker(kind=WorkerKind.SERVICE, checkpoints=None))
+        assert len(gate) == 1
+        assert str(gate[0]) == str(sa_false()), "a service must be filtered out, not unfiltered"
+
+    def test_the_kind_check_beats_the_never_reported_exemption(self):
+        """The exemption returns an EMPTY tuple, meaning "no restriction". A service reaching
+        it is offered the whole queue, so the kind check has to come first — this asserts the
+        ordering, which is the entire correctness of the fix."""
+        src = inspect.getsource(_model_gate)
+        kind_at = src.index("worker.kind != WorkerKind.RENDER")
+        exempt_at = src.index("worker.checkpoints is None")
+        assert kind_at < exempt_at, \
+            "the never-reported exemption runs first and waves the service through"
+
+    def test_a_service_that_somehow_reported_checkpoints_is_still_refused(self):
+        """Kind decides, not inventory. A service sharing a models mount could plausibly see
+        checkpoints; that must not make it claimable."""
+        gate = _model_gate(_worker(kind=WorkerKind.SERVICE, checkpoints=["10Eros_v1.5_bf16"]))
+        assert str(gate[0]) == str(sa_false())
+
+    def test_a_render_worker_is_completely_unaffected(self):
+        """The whole fleet must keep behaving exactly as before."""
+        assert _model_gate(_worker(checkpoints=None)) == ()
+        assert _model_gate(None) == ()
+
+    def test_a_render_worker_with_inventory_still_gates_on_it(self):
+        gate = _model_gate(_worker(checkpoints=["10Eros_v1.5_bf16"], fetchable_kinds=[]))
+        assert len(gate) == 1
+        assert str(gate[0]) != str(sa_false())
+
+
+class TestQueueHealth:
+    def test_only_render_workers_are_counted(self):
+        assert COUNTED_KINDS == frozenset({"render"})
+
+    def test_the_query_filters_on_kind(self):
+        """Counting every row is what made this a regression rather than a preference."""
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.queue_health)
+        assert "Worker.kind.in_(COUNTED_KINDS)" in src
+
+    def test_stalled_still_fires_when_only_a_service_is_alive(self):
+        """The scenario the filter exists for: the captioner is fine, every render worker is
+        gone, and there is work. Because queue_health filters before calling assess, the
+        service simply is not in this list."""
+        h = assess(pending_segments=4, worker_statuses=["offline"])
+        assert h.stalled is True
+        assert h.live_workers == 0
+
+
+class TestRegistration:
+    def test_an_older_daemon_registers_as_render(self):
+        """No daemon in the fleet sends `kind`. Every one of them must keep meaning what it
+        meant, and the safe default is the one that keeps them working."""
+        body = WorkerRegister(friendly_name="3090.zero", hostname="h", ip_address="1.2.3.4")
+        assert body.kind == WorkerKind.RENDER
+        assert body.provides is None
+
+    def test_a_service_declares_itself(self):
+        body = WorkerRegister(friendly_name="2070.zero/services", hostname="h",
+                              ip_address="1.2.3.4", kind=WorkerKind.SERVICE,
+                              provides=["joycaption"])
+        assert body.kind == WorkerKind.SERVICE
+        assert body.provides == ["joycaption"]
+
+    def test_re_registering_can_change_what_a_box_is(self):
+        """A host could stop running services and start running an engine. The row should
+        follow reality rather than the first thing it ever saw."""
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.register_worker)
+        assert "worker.kind = body.kind" in src
+
+    def test_provides_is_a_conditional_write_on_register(self):
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.register_worker)
+        assert "if body.provides is not None:" in src
+
+
+class TestHeartbeat:
+    def test_an_older_daemon_still_heartbeats(self):
+        hb = WorkerHeartbeat(comfyui_running=True)
+        assert hb.provides is None and hb.status is None
+
+    def test_provides_is_a_conditional_write(self):
+        """Assigning None on every older-daemon heartbeat would blank what a newer one just
+        reported — the mistake loras and checkpoints each had to fix."""
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.heartbeat)
+        assert "if body.provides is not None:" in src
+
+    def test_a_service_sets_its_own_status(self):
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.heartbeat)
+        assert "if body.status is not None:" in src
+
+    def test_a_render_workers_status_is_never_taken_from_the_body(self):
+        """Otherwise a daemon could talk itself into looking idle, which is precisely the
+        confusion wanly-gpu-docker#80 is open about."""
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.heartbeat)
+        service_branch = src.index("if worker.kind != WorkerKind.RENDER:")
+        status_write = src.index("if body.status is not None:")
+        else_branch = src.index("    else:\n        if worker.status == \"offline\":")
+        assert service_branch < status_write < else_branch, \
+            "body.status is honoured outside the service branch"
+
+
+class TestTheResponse:
+    def test_it_reports_both(self):
+        """Pydantic silently drops what the response model does not name, which is how a
+        correctly stored fetchable_kinds once looked like a worker that had never reported."""
+        assert "kind" in WorkerResponse.model_fields
+        assert "provides" in WorkerResponse.model_fields
+
+
+class TestTheStatusVocabulary:
+    def test_a_service_has_words_of_its_own(self):
+        """Reusing online-idle was the cheap wrong answer: it already means both "waiting for
+        work" and "cannot do work", and that ambiguity hid a dead ComfyUI for 33 minutes."""
+        assert WorkerStatus.ONLINE == "online"
+        assert WorkerStatus.DEGRADED == "degraded"
+
+    def test_service_statuses_are_not_live_for_the_queue(self):
+        """Belt and braces behind the kind filter: even if a service row reached assess(), its
+        status is not one that counts."""
+        from app.queue_health import LIVE_STATUSES
+        assert WorkerStatus.ONLINE not in LIVE_STATUSES
+        assert WorkerStatus.DEGRADED not in LIVE_STATUSES


### PR DESCRIPTION
First of three for #269 (api → services → console). Adds `kind` and `provides` to `workers`,
and wires the two places that must not treat a service like a render worker.

## Two columns, two questions

| field | type | example | read by |
|---|---|---|---|
| `kind` | scalar, `NOT NULL DEFAULT 'render'` | `render` \| `service` | the claim gate, queue-health |
| `provides` | nullable list | `["ltx-engine"]`, `["joycaption","qwen-edit"]` | the console |

Not one field. A gate keyed on names needs an allowlist, and an engine missing from it claims
nothing — indistinguishable from an empty queue, which this codebase has paid for repeatedly.
With `kind`, a new engine is `render` and claimable by default while a new service is `service`
and excluded by default. Both defaults land on the safe side.

`provides` also records something the API has never known: there is **no `engine` column**, so
nothing here has ever said whether a worker runs LTX or WAN 2.2.

## The claim gate checks `kind` first — that ordering *is* the fix

```python
if worker is not None and worker.kind != WorkerKind.RENDER:
    return (sa_false(),)
if worker is None or worker.checkpoints is None:
    return ()                      # <- no restriction at all
```

The second branch is deliberate and correct for its own purpose (an older daemon must not
starve on upgrade day). But a freshly registered service has `checkpoints` NULL, so reaching it
means **being offered every pending segment**. Nothing breaks today only because wanly-services
has no daemon and never polls — the safety being an accident of it not asking, rather than a
decision that it must not be asked. A test asserts the ordering, not just the behaviour.

`false()` rather than an empty tuple, because an empty tuple means "no restriction" and is
exactly the wrong answer here.

## Queue health counts render workers only

`stalled` means *"work queued and nobody who can take it"*. `queue_health` read **every** worker
row, so a service counted as live would mean the alarm can never fire again — and it would go
quiet at precisely the moment it matters: every render worker down, work queued, one healthy
captioner holding the count above zero. Nothing errors; the alarm just stops, which is the
failure that module was written to end.

## A service reports its own status

`online` / `degraded`, new in `WorkerStatus`. Reusing `online-idle` was the cheap wrong answer:
it already means both "waiting for work" and "cannot do work", and that ambiguity hid a dead
ComfyUI for 33 minutes (wanly-gpu-docker#80). A service is never waiting for work, so calling it
idle would extend exactly the confusion already costing us.

`body.status` is honoured **only** for a non-render worker, so a daemon cannot talk itself into
looking idle. The render heartbeat path is unchanged branch for branch.

## Nothing in the fleet has to change

`WorkerRegister.kind` defaults to `render`, so every daemon keeps registering unchanged and
keeps meaning what it meant. A service declares itself — the right way round: forgetting means a
service is treated as a render worker, caught loudly the first time it is offered a segment,
rather than a render worker silently claiming nothing.

`provides` is a conditional write on both register and heartbeat, so an older daemon omitting it
cannot blank what a newer one just reported — the mistake `loras` and `checkpoints` each had to
fix.

## Verified beyond the unit tests

```
alembic upgrade head        → 088 -> 089 clean from an empty database
\d workers                  → kind | varchar(20) | not null | 'render'::character varying
INSERT naming no kind       → kind = render
alembic downgrade 088       → both columns dropped cleanly
```

**809 tests pass, 19 new.** F821 clean; pre-existing F401s unchanged at 19.

## Next

wanly-services registers and heartbeats (needs `QUEUE_URL`/`QUEUE_API_KEY` on the 2070, which is
new config there), then the console shows the kind chip and suppresses Drain for services.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J