### PR TITLE
A service must never be called idle, not even for 30 seconds

### DIFF
--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -54,9 +54,17 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
         # Re-registering after a container restart can land on a new pod id.
         if body.runpod_pod_id:
             worker.runpod_pod_id = body.runpod_pod_id
-        worker.status, worker.drain_after_jobs = reregistered_drain_state(
-            worker.status, worker.drain_after_jobs
-        )
+        if worker.kind == WorkerKind.RENDER:
+            worker.status, worker.drain_after_jobs = reregistered_drain_state(
+                worker.status, worker.drain_after_jobs
+            )
+        else:
+            # A service has nothing to drain, and must not spend its first 30 seconds saying
+            # "idle" -- the word #269 exists to stop applying to it. Without this the row is
+            # created on the model's default, online-idle, and only corrects on the first
+            # heartbeat; the Workers page renders "Idle" on a service for that whole window,
+            # which is exactly the ambiguity the separate vocabulary was introduced to end.
+            worker.status = WorkerStatus.ONLINE
         worker.last_heartbeat = datetime.now(timezone.utc)
     else:
         worker = Worker(
@@ -67,6 +75,9 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
             runpod_pod_id=body.runpod_pod_id,
             kind=body.kind,
             provides=body.provides,
+            # Same reason as above: the column default is online-idle, which is a render word.
+            status=(WorkerStatus.ONLINE_IDLE if body.kind == WorkerKind.RENDER
+                    else WorkerStatus.ONLINE),
         )
         db.add(worker)
 

--- a/tests/test_worker_kind.py
+++ b/tests/test_worker_kind.py
@@ -163,3 +163,34 @@ class TestTheStatusVocabulary:
         from app.queue_health import LIVE_STATUSES
         assert WorkerStatus.ONLINE not in LIVE_STATUSES
         assert WorkerStatus.DEGRADED not in LIVE_STATUSES
+
+
+class TestAServiceIsNeverCalledIdle:
+    """Registration used to leave a service on the column default, `online-idle`, until its
+    first heartbeat 30 seconds later — so the Workers page said "Idle" about a captioner for
+    that whole window. That is the exact word #269 introduced a separate vocabulary to stop
+    applying to services, so leaving it in the one place that creates the row would have
+    undone the point of the change.
+    """
+
+    def test_a_new_service_is_created_online(self):
+        import inspect
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.register_worker)
+        assert "WorkerStatus.ONLINE_IDLE if body.kind == WorkerKind.RENDER" in src
+
+    def test_a_re_registering_service_is_set_online(self):
+        import inspect
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.register_worker)
+        assert "worker.status = WorkerStatus.ONLINE" in src
+
+    def test_drain_state_is_only_recomputed_for_render_workers(self):
+        """reregistered_drain_state exists to stop a re-register cancelling an operator's
+        drain. A service cannot drain, so running it there would be meaningless."""
+        import inspect
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.register_worker)
+        guard = src.index("if worker.kind == WorkerKind.RENDER:")
+        call = src.index("reregistered_drain_state(")
+        assert guard < call


### PR DESCRIPTION
A service must never be called "idle", not even for 30 seconds (#269)

register_worker left a service on the workers column default, online-idle, until its first
heartbeat corrected it 30 seconds later. For that whole window the Workers page rendered "Idle"
on a captioner -- the exact word #269 introduced a separate vocabulary to stop applying to
services, so leaving it in the one place that creates the row would have undone the point.

Caught in production rather than in a test: the 2070 registered and showed `online-idle` for
half a minute before flipping to `online`.

reregistered_drain_state is now only consulted for render workers. It exists so a re-register
cannot cancel an operator's drain; a service has nothing to drain, so running it there was
meaningless as well as wrong.

812 tests.

Claude-Session: https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J
