### PR TITLE
Stop asserting an upload order the route does not promise

### DIFF
--- a/tests/test_segment_s3_keys.py
+++ b/tests/test_segment_s3_keys.py
@@ -69,9 +69,17 @@ async def test_upload_keys_by_segment_id(db):
                            "last_frame": ("f.png", b"f", "image/png")},
                 )
         assert resp.status_code == 200, resp.text
-        keys = [call.args[1] for call in up.call_args_list]
-        assert keys == [f"{job.id}/{seg.id}_output.mp4",
-                        f"{job.id}/{seg.id}_last_frame.png"]
+        # A SET, not a list (#272). The route uploads both files through asyncio.gather over
+        # two threads, so the order the mock records them in is whatever the scheduler did --
+        # and asserting a list failed about one run in four, on clean main too. That cost
+        # three false failures during unrelated work, which is worse than no test: the reflex
+        # becomes "just re-run it", and that is the reflex that lets a real failure through.
+        #
+        # The order was never the point. What this test is about, per its own docstring, is
+        # that the keys are built from the segment ID rather than the index.
+        keys = {call.args[1] for call in up.call_args_list}
+        assert keys == {f"{job.id}/{seg.id}_output.mp4",
+                        f"{job.id}/{seg.id}_last_frame.png"}
         # And emphatically NOT the index.
         assert not any(f"/{seg.index}_" in k for k in keys)
     finally:


### PR DESCRIPTION
Stop asserting an upload order the route does not promise (#272)

test_upload_keys_by_segment_id failed about one run in four, on clean main as well as on any
branch -- 6 pass / 2 fail over 8 isolated runs when measured. It produced at least three false
failures during unrelated work today.

The route uploads both files through asyncio.gather over two threads, so the order the mock
records them in is whatever the scheduler did. The test compared call_args_list against an
ordered list.

The route is right: two independent uploads should overlap, and nothing needs an order. The
test's own docstring says what it is actually about -- that the keys are built from the segment
ID rather than the index -- and order is incidental to that. Compared as a set now.

Not a retry decorator. A flaky test with a known cause and a one-line fix is not a flaky test,
it is an unfixed one.

20 consecutive runs of the test alone: 20 pass. Full suite 812 pass.

Claude-Session: https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J
