### PR TITLE
Training a character LoRA is a row a worker claims

### DIFF
--- a/alembic/versions/090_training_jobs.py
+++ b/alembic/versions/090_training_jobs.py
@@ -1,0 +1,82 @@
+"""Character-LoRA training as claimable work
+
+Revision ID: 090
+Revises: 089
+Create Date: 2026-09-07
+
+wanly-api#274, layer 1 of wanly-console#453. Training a LoRA has been a laptop-driven ssh
+pipeline; this makes it a row the console creates and a worker claims.
+
+SHAPED ON `segments`, deliberately. It is the same problem -- a row created here, claimed by a
+remote worker, worked on for a long time, reported back about -- and the machinery that already
+exists for that (orphan reclaim, the heartbeat sweep, the console's status rendering) only
+transfers if the shape does. Hence status/worker_id/worker_name/gpu_name/claimed_at/
+completed_at/error_message/progress_log carrying exactly their `segments` meanings.
+
+A separate table rather than a variant of `segments` because almost nothing overlaps: no job, no
+index, no seed, no video. They share a lifecycle, not a payload.
+
+Two columns `segments` has no equivalent of:
+
+  step / total_steps   a training run genuinely has a step count, and the console already has a
+                       determinate progress bar looking for exactly these two numbers. Renders
+                       have no such thing, which is why Segment reports progress as prose.
+
+  checkpoints          every epoch is a candidate and choosing between them is a human
+                       judgement made by eye at a fixed seed. Loss does NOT rank them -- a
+                       confident "later epochs overfit" call read off a loss curve was refuted
+                       outright on d0ggyff -- so all of them are recorded, not just the last.
+
+THE PARTIAL UNIQUE INDEX is the interesting one. One LIVE run per (character, version): a second
+attempt at v2 while the first is still going would train two LoRAs into the same output name and
+the second would win silently. That is the same collision new_character.sh used to produce by
+reusing one run directory per character, and it was invisible until someone read file mtimes.
+Terminal rows are excluded so a failed v2 can simply be retried.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "090"
+down_revision = "089"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "training_jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True),
+                  sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("character", sa.String(length=64), nullable=False),
+        sa.Column("trigger", sa.String(length=64), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("dataset_images", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("config", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column("worker_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("worker_name", sa.String(length=255), nullable=True),
+        sa.Column("gpu_name", sa.String(length=100), nullable=True),
+        sa.Column("progress_log", sa.Text(), nullable=True),
+        sa.Column("step", sa.Integer(), nullable=True),
+        sa.Column("total_steps", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("checkpoints", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("output_lora_path", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_training_jobs_status", "training_jobs", ["status"])
+    op.create_index(
+        "uq_training_jobs_character_version_live", "training_jobs", ["character", "version"],
+        unique=True,
+        postgresql_where=sa.text("status NOT IN ('completed','failed','cancelled')"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_training_jobs_character_version_live", table_name="training_jobs")
+    op.drop_index("ix_training_jobs_status", table_name="training_jobs")
+    op.drop_table("training_jobs")

--- a/app/enums.py
+++ b/app/enums.py
@@ -46,6 +46,31 @@ JOB_VALID_TRANSITIONS: dict[str, set[str]] = {
 }
 
 
+class TrainingStatus(StrEnum):
+    """A character-LoRA training job, wanly-api#274.
+
+    Deliberately the same shape as SegmentStatus, because it is the same shape of problem: a
+    row the console creates, a remote worker claims, works on for a long time, and reports back
+    about. Copying the vocabulary means the orphan-reclaim rules, the console's StatusChip and
+    everything else that reasons about "claimed but making no progress" transfer unchanged.
+
+    RUNNING rather than PROCESSING only because a training run has phases a render does not
+    (staging, caching latents, caching text, training) and "processing" reads as one of them.
+    """
+    PENDING = "pending"
+    CLAIMED = "claimed"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+#: Terminal states. A job in one of these is never reclaimed and never claimed again.
+TRAINING_TERMINAL = frozenset({
+    TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.CANCELLED,
+})
+
+
 class WorkerKind(StrEnum):
     """What a worker IS — the only thing the claim gate reads (#269).
 
@@ -59,6 +84,11 @@ class WorkerKind(StrEnum):
     """
     RENDER = "render"
     SERVICE = "service"
+    #: Runs character-LoRA training (wanly-api#274). A separate kind rather than a `service`
+    #: that happens to train, because the claim gates key on this: a TRAINER takes training
+    #: jobs and never segments, and a SERVICE takes neither. Collapsing them would mean the
+    #: captioner on the 2070 being offered a 50-minute training run it has no GPU for.
+    TRAINER = "trainer"
 
 
 #: Convenience for the model's column defaults, which cannot reference the enum member

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
 from app.reservation_monitor import reservation_monitor
 from app.limiter import limiter
-from app.routes import app_settings, auth, captions, favorites, files, images, jobs, ltx_recipes, runpod, segments, stats, tags, videos, wildcards, workers
+from app.routes import app_settings, auth, captions, favorites, files, images, jobs, ltx_recipes, runpod, segments, stats, tags, training, videos, wildcards, workers
 
 logger = logging.getLogger(__name__)
 
@@ -72,3 +72,4 @@ app.include_router(wildcards.router)
 app.include_router(workers.router)
 app.include_router(runpod.router)
 app.include_router(stats.router)
+app.include_router(training.router)

--- a/app/models.py
+++ b/app/models.py
@@ -5,7 +5,7 @@ from sqlalchemy import BigInteger, Boolean, DateTime, Float, ForeignKey, Index, 
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-from app.enums import JobStatus, SegmentStatus, VideoStatus, WORKER_KIND_RENDER
+from app.enums import JobStatus, SegmentStatus, TrainingStatus, VideoStatus, WORKER_KIND_RENDER
 
 
 class Base(DeclarativeBase):
@@ -394,6 +394,81 @@ class GpuReservation(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
     )
+
+
+class TrainingJob(Base):
+    """A character-LoRA training run: what to train, who is training it, and what came out.
+
+    SHAPED ON Segment, deliberately. It is the same problem — a row the console creates, a
+    remote worker claims, works on for a long time, and reports back about — and the existing
+    machinery for that (orphan reclaim, the heartbeat sweep, the console's status rendering)
+    only transfers if the shape does.
+
+    It is a separate table rather than a Segment variant because almost nothing overlaps: no
+    job, no index, no seed, no video. The two share a lifecycle, not a payload.
+    """
+    __tablename__ = "training_jobs"
+    __table_args__ = (
+        Index("ix_training_jobs_status", "status"),
+        # One live run per character+version. A second attempt at v2 while the first is still
+        # going would train two LoRAs into the same output name and the second would win
+        # silently -- the same class of collision that made new_character.sh mix versions.
+        Index("uq_training_jobs_character_version_live", "character", "version",
+              unique=True,
+              postgresql_where=text("status NOT IN ('completed','failed','cancelled')")),
+    )
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+
+    # ---- what to train
+    character = mapped_column(String(64), nullable=False)
+    # The token the captions use and a prompt types. Allowed to differ from `character`, and on
+    # p@y it must: the LoRA installs as `pay_...` because it is served over HTTP and lands in
+    # JSON and URLs, while the trigger stays `p@y` because that is what trained.
+    trigger = mapped_column(String(64), nullable=False)
+    version = mapped_column(Integer, nullable=False, default=1)
+    # The dataset, as s3:// URIs, ORDER SIGNIFICANT -- the trainer stages them as sel_000..N and
+    # the captions pair by index. Precedent: Segment.smashcut_clip_paths.
+    dataset_images = mapped_column(JSONB, nullable=False)
+    # Everything the run needs, snapshotted. Same rule as Segment.ltx_recipe: the worker must
+    # never look its configuration up for itself, because a worker that cannot look one up
+    # cannot look up a STALE one. Holds caption(s), steps, rank, LR -- the recipe as it was
+    # when the job was created, so a later change to the defaults cannot retroactively alter
+    # what a queued job will do.
+    config = mapped_column(JSONB, nullable=False, default=dict)
+
+    # ---- who is doing it
+    status = mapped_column(String(20), nullable=False, default=TrainingStatus.PENDING)
+    # No FK on worker_id, matching Segment: worker rows are deleted on deregister, and a
+    # finished training run should still say which box produced it.
+    worker_id = mapped_column(UUID(as_uuid=True), nullable=True)
+    worker_name = mapped_column(String(255), nullable=True)
+    # Snapshotted at claim, because the workers row vanishes when a pod drains and "which GPU
+    # trained this" is exactly the question you ask six weeks later.
+    gpu_name = mapped_column(String(100), nullable=True)
+
+    # ---- what happened
+    # Free text, wholly overwritten on each report, exactly like Segment.progress_log -- and
+    # load-bearing for the same reason: an empty progress log is the only trustworthy evidence
+    # that a claim is not actually being worked on. Status can lie; this cannot.
+    progress_log = mapped_column(Text, nullable=True)
+    # Structured progress, which Segment has no equivalent of. A training run genuinely has a
+    # step count, and the console already has a determinate progress bar looking for exactly
+    # these two numbers.
+    step = mapped_column(Integer, nullable=True)
+    total_steps = mapped_column(Integer, nullable=True)
+    error_message = mapped_column(Text, nullable=True)
+    # Every epoch checkpoint the run produced, as reported. The choice of WHICH one to install
+    # is a human judgement made by eye at a fixed seed -- loss does not rank them -- so all of
+    # them are recorded rather than just the last.
+    checkpoints = mapped_column(JSONB, nullable=True)
+    # The s3:// URI of the installed LoRA, once one is chosen.
+    output_lora_path = mapped_column(Text, nullable=True)
+
+    created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    claimed_at = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class LtxCharacter(Base):

--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -13,7 +13,8 @@ from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_
 from app.config import settings
 from app.database import get_db
 from app.joycaption import CaptionError
-from app.models import Favorite, ImageMeta, Job, Segment, User
+from app.enums import TRAINING_TERMINAL
+from app.models import Favorite, ImageMeta, Job, Segment, TrainingJob, User
 from app.routes.captions import caption_image_bytes
 from app.schemas.images import ImageSceneRequest, ImageSceneResponse, ImageTagsUpdate
 from app.tag_filter import like_escape
@@ -117,7 +118,8 @@ async def find_image_references(db: AsyncSession, paths: list[str]) -> dict[str,
     def _hold(path: str | None, kind: str, holder_id) -> None:
         if not path or path not in wanted:
             return
-        entry = refs.setdefault(path, {"job_ids": [], "segment_ids": []})
+        entry = refs.setdefault(path, {"job_ids": [], "segment_ids": [],
+                                       "training_ids": []})
         if str(holder_id) not in entry[kind]:
             entry[kind].append(str(holder_id))
 
@@ -138,6 +140,22 @@ async def find_image_references(db: AsyncSession, paths: list[str]) -> dict[str,
     for row in seg_rows.all():
         for value in row[1:]:
             _hold(value, "segment_ids", row[0])
+
+    # TRAINING DATASETS COUNT TOO (wanly-api#274). A queued training job holds its dataset as a
+    # JSONB list of s3:// URIs, and deleting one of those images is the same silent failure as
+    # deleting a start frame: nothing breaks until the trainer claims the job, fetches a 404,
+    # and fails a run that was queued days earlier for a reason nowhere near the cause.
+    #
+    # Matched in Python rather than SQL because the paths live inside a JSON array; the row
+    # count here is tiny (one per training run, ever) so a containment query would be more
+    # machinery than the problem deserves.
+    train_rows = await db.execute(
+        select(TrainingJob.id, TrainingJob.dataset_images)
+        .where(TrainingJob.status.not_in(list(TRAINING_TERMINAL)))
+    )
+    for job_id, images in train_rows.all():
+        for value in images or []:
+            _hold(value, "training_ids", job_id)
 
     return refs
 

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -1,0 +1,366 @@
+"""Character-LoRA training as claimable work (wanly-api#274, wanly-console#453).
+
+Training a LoRA has been a laptop-driven ssh pipeline. This makes it a row the console creates
+and a trainer claims, which is how every other long remote job in this system works.
+
+PULL, NOT PUSH, and that is the whole design decision. The alternative -- the console or the API
+calling a trainer over HTTP -- would need a trainer URL in config, a retry policy, and its own
+answer to "the trainer restarted mid-run". Claiming gets orphan reclaim, the heartbeat/offline
+sweep and queue-health for free, because they already exist for segments and key on the same
+columns.
+
+WHAT IS DELIBERATELY NOT HERE: any knowledge of how a LoRA is trained. The recipe -- rank, LR,
+steps, the preset -- is snapshotted into `config` when the job is created and handed to the
+trainer verbatim. This module could not tell you what rank 32 means, and should not be able to.
+"""
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import s3
+from app.auth import get_current_user, verify_api_key, verify_api_key_or_bearer
+from app.config import settings
+from app.database import get_db
+from app.enums import TRAINING_TERMINAL, TrainingStatus, WorkerKind
+from app.models import LtxCharacter, TrainingJob, User, Worker
+from app.schemas.training import (
+    TrainingClaimResponse, TrainingCreate, TrainingProgress, TrainingResponse,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+#: Mirrors the segment claim's grace period: a claim held by a worker that says it is idle and
+#: has written no progress is presumed lost after this. Longer than a segment's because a
+#: trainer's first phase (staging a dataset, caching latents) is legitimately quiet for minutes.
+ORPHANED_TRAINING_MINUTES = 20
+#: A worker not heard from in this long is dead, whatever it last said.
+STALE_HEARTBEAT_MINUTES = 5
+
+#: What the recipe is, at the moment a job is created. Snapshotted rather than referenced so a
+#: change here cannot retroactively alter what a queued job will do. The trainer owns the real
+#: implementation; these are the values it is told to use.
+RECIPE_DEFAULTS = {
+    "network_dim": 32,
+    "network_alpha": 32,
+    "learning_rate": 1e-4,
+    "lora_target_preset": "video_sa_ca_ff",
+    "num_repeats": 10,
+    "seed": 42,
+}
+
+
+def _live_states() -> list[str]:
+    return [TrainingStatus.CLAIMED, TrainingStatus.RUNNING]
+
+
+@router.post("/training", response_model=TrainingResponse, status_code=201)
+async def create_training_job(
+    body: TrainingCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Queue a training run. The console's entry point."""
+    dupe = (await db.execute(
+        select(TrainingJob).where(
+            TrainingJob.character == body.character,
+            TrainingJob.version == body.version,
+            TrainingJob.status.not_in(list(TRAINING_TERMINAL)),
+        )
+    )).scalar_one_or_none()
+    if dupe:
+        # The database would refuse this anyway via the partial unique index; catching it here
+        # turns a 500 into a sentence.
+        raise HTTPException(
+            status_code=409,
+            detail=f"{body.character} v{body.version} is already {dupe.status}. "
+                   f"Cancel it, or pick another version.")
+
+    job = TrainingJob(
+        user_id=user.id,
+        character=body.character,
+        trigger=body.trigger,
+        version=body.version,
+        dataset_images=body.dataset_images,
+        config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": body.caption},
+        status=TrainingStatus.PENDING,
+        total_steps=body.steps,
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    logger.info("queued training %s v%d (%d images) for %s",
+                job.character, job.version, len(job.dataset_images), user.username)
+    return job
+
+
+@router.get("/training", response_model=list[TrainingResponse],
+            dependencies=[Depends(verify_api_key_or_bearer)])
+async def list_training_jobs(
+    status: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+):
+    q = select(TrainingJob).order_by(TrainingJob.created_at.desc()).limit(limit)
+    if status:
+        q = q.where(TrainingJob.status == status)
+    return list((await db.execute(q)).scalars().all())
+
+
+@router.get("/training/next", dependencies=[Depends(verify_api_key)])
+async def claim_next_training_job(
+    worker_id: uuid.UUID = Query(...),
+    worker_name: str = Query(None),
+    db: AsyncSession = Depends(get_db),
+):
+    """Hand one queued job to a trainer, or null.
+
+    ONLY A TRAINER MAY CLAIM. Checked first and explicitly: a render worker or a captioner
+    picking up a 50-minute training run would be worse than it not being picked up at all.
+
+    Returns null rather than 404 for an empty queue, matching /segments/next -- an empty queue
+    is not an error and a poller should not have to distinguish it from one.
+    """
+    worker = await db.get(Worker, worker_id)
+    if worker is None or worker.kind != WorkerKind.TRAINER:
+        # Not an error the poller can fix by retrying differently, but not fatal either: a
+        # worker that registered before this existed simply gets nothing.
+        return None
+
+    await _reclaim_orphans(db)
+
+    # FOR UPDATE SKIP LOCKED, exactly as the segment claim does it: two trainers polling at once
+    # must not be handed the same row, and SKIP LOCKED is what makes that true without a queue
+    # table or an advisory lock. Oldest first.
+    job = (await db.execute(
+        select(TrainingJob)
+        .where(TrainingJob.status == TrainingStatus.PENDING)
+        .order_by(TrainingJob.created_at.asc())
+        .limit(1)
+        .with_for_update(skip_locked=True)
+    )).scalar_one_or_none()
+    if job is None:
+        return None
+
+    # PRESIGN BEFORE MUTATING. Presigned so the trainer needs no AWS credentials -- the same
+    # arrangement the render daemon has for LoRAs -- and the order pairs 1:1 with
+    # dataset_images, because the trainer stages them as sel_000..N.
+    #
+    # Done first because it can fail. Marking the row claimed and then throwing would leave a
+    # job owned by a worker that never received the answer: the lost-claim-response failure
+    # (wanly-api#242), which the reclaim rules above do eventually fix, but only after the
+    # grace period, with the queue stopped in the meantime. Nothing is written unless the
+    # response can actually be built.
+    try:
+        urls = await asyncio.to_thread(
+            lambda: [s3.generate_presigned_url(u) for u in job.dataset_images])
+    except Exception as e:
+        logger.error("could not presign the dataset for %s v%d: %s",
+                     job.character, job.version, e)
+        raise HTTPException(
+            status_code=503,
+            detail=f"could not presign the dataset ({e}); the job is still queued") from e
+
+    job.status = TrainingStatus.CLAIMED
+    job.worker_id = worker_id
+    job.worker_name = worker_name or worker.friendly_name
+    # Snapshotted, because the workers row vanishes when a pod drains and "which GPU trained
+    # this" is exactly the question asked six weeks later.
+    job.gpu_name = (worker.gpu_stats or {}).get("gpu_name")
+    job.claimed_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(job)
+    logger.info("training %s v%d claimed by %s", job.character, job.version, job.worker_name)
+    return TrainingClaimResponse(**TrainingResponse.model_validate(job).model_dump(),
+                                 download_urls=urls)
+
+
+async def _reclaim_orphans(db: AsyncSession) -> None:
+    """Put back claims nobody is working on.
+
+    The same three rules the segment claim uses, and for the same reasons -- see
+    app/routes/segments.py, which explains at length why reclaiming from a LIVE worker needs all
+    three conditions and what happened the time it did not.
+
+    The one that matters most: an empty progress_log is the only trustworthy evidence that a
+    claim is not being worked. Status can lie -- a daemon's status push can fail -- but a run
+    that is actually going writes progress within seconds.
+    """
+    now = datetime.now(timezone.utc)
+    heartbeat_cutoff = now - timedelta(minutes=STALE_HEARTBEAT_MINUTES)
+    orphan_cutoff = now - timedelta(minutes=ORPHANED_TRAINING_MINUTES)
+
+    rows = (await db.execute(
+        select(TrainingJob, Worker.last_heartbeat)
+        .outerjoin(Worker, Worker.id == TrainingJob.worker_id)
+        .where(
+            TrainingJob.status.in_(_live_states()),
+            TrainingJob.claimed_at.is_not(None),
+            or_(
+                # dead worker
+                Worker.last_heartbeat < heartbeat_cutoff,
+                # the worker row is gone entirely
+                and_(TrainingJob.claimed_at < orphan_cutoff, Worker.id.is_(None)),
+                # alive, idle, and has written nothing: the claim response was lost
+                and_(
+                    Worker.status.in_(["online", "online-idle"]),
+                    Worker.last_heartbeat >= heartbeat_cutoff,
+                    or_(TrainingJob.progress_log.is_(None), TrainingJob.progress_log == ""),
+                    TrainingJob.claimed_at < orphan_cutoff,
+                ),
+            ),
+        )
+    )).all()
+
+    for job, _ in rows:
+        logger.warning("reclaiming orphaned training %s v%d from %s",
+                       job.character, job.version, job.worker_name)
+        job.status = TrainingStatus.PENDING
+        job.worker_id = None
+        job.worker_name = None
+        job.claimed_at = None
+        job.progress_log = None
+    if rows:
+        await db.commit()
+
+
+@router.get("/training/{job_id}", response_model=TrainingResponse,
+            dependencies=[Depends(verify_api_key_or_bearer)])
+async def get_training_job(job_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+    return job
+
+
+@router.patch("/training/{job_id}", response_model=TrainingResponse,
+              dependencies=[Depends(verify_api_key)])
+async def update_training_job(
+    job_id: uuid.UUID,
+    body: TrainingProgress,
+    db: AsyncSession = Depends(get_db),
+):
+    """A trainer reporting in.
+
+    Every field is written only when present. A report that omits a field must never blank what
+    an earlier one set -- the mistake the worker heartbeat had to fix twice, where an older
+    daemon's partial report erased a newer one's good data.
+    """
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+
+    for field in ("progress_log", "step", "total_steps", "error_message",
+                  "checkpoints", "output_lora_path"):
+        value = getattr(body, field)
+        if value is not None:
+            setattr(job, field, value)
+
+    if body.status is not None:
+        job.status = body.status
+        if body.status in TRAINING_TERMINAL:
+            job.completed_at = datetime.now(timezone.utc)
+            if body.status == TrainingStatus.COMPLETED:
+                await _publish_character(db, job)
+
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
+    """Make the finished LoRA usable in a recipe.
+
+    Nothing else does this. `GET /loras` lists the bucket, so the FILE is discoverable the
+    moment it is written -- but a pose fills its <TRIGGER> placeholder from an LtxCharacter row,
+    so without one the LoRA exists and no recipe can reach it.
+
+    Upsert on name: retraining a character replaces which LoRA it points at, which is the whole
+    point of a v2. The strengths are left alone if the row exists, because they may have been
+    tuned by hand.
+    """
+    if not job.output_lora_path:
+        return
+    basename = job.output_lora_path.rsplit("/", 1)[-1]
+    existing = (await db.execute(
+        select(LtxCharacter).where(LtxCharacter.name == job.character)
+    )).scalar_one_or_none()
+    if existing:
+        existing.char_lora = basename
+        existing.trigger = job.trigger
+        logger.info("character %s now points at %s", job.character, basename)
+    else:
+        db.add(LtxCharacter(name=job.character, char_lora=basename, trigger=job.trigger))
+        logger.info("created character %s -> %s", job.character, basename)
+
+
+@router.post("/training/{job_id}/artifact", response_model=TrainingResponse,
+             dependencies=[Depends(verify_api_key)])
+async def upload_training_artifact(
+    job_id: uuid.UUID,
+    lora: UploadFile = File(...),
+    epoch: int | None = None,
+    db: AsyncSession = Depends(get_db),
+):
+    """Publish a finished LoRA.
+
+    THIS ENDPOINT EXISTS BECAUSE POST /upload NEEDS A JWT. A trainer holds the shared worker API
+    key and nothing else, so it cannot use the console's upload path. Without this it would need
+    AWS credentials in the container -- which no worker in this system has, deliberately.
+
+    Writing to `character/` IS the registration step. GET /loras lists the bucket live and
+    derives kind from that prefix, so there is nothing else to call: the LoRA is offerable to
+    every worker the moment the object lands. The LtxCharacter row that makes it reachable from
+    a recipe is created when the job reports `completed`.
+    """
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+
+    data = await lora.read()
+    # A character LoRA at rank 32 is ~650 MB. Anything tiny is a truncated upload or an error
+    # page, and letting it land would put a file in the library that fails at load, inside
+    # somebody's render, days later.
+    if len(data) < 10 * 1024 * 1024:
+        raise HTTPException(
+            status_code=400,
+            detail=f"refusing a {len(data)} byte LoRA — a rank-32 character LoRA is ~650 MB, "
+                   f"so this is a truncated upload")
+
+    # `@` and friends cannot be in the name: this is served over HTTP and lands in JSON and
+    # URLs. The TRIGGER keeps the original -- that is what the captions trained on.
+    safe = "".join(c for c in job.character if c.isalnum() or c in "._-")
+    tag = f"_e{epoch:02d}" if epoch is not None else ""
+    key = f"character/{safe}_v{job.version}{tag}.safetensors"
+    uri = await asyncio.to_thread(s3.upload_bytes, data, key, settings.s3_loras_bucket)
+
+    job.output_lora_path = uri
+    await db.commit()
+    await db.refresh(job)
+    logger.info("published %s (%.0f MB) for %s v%d",
+                uri, len(data) / 1024 ** 2, job.character, job.version)
+    return job
+
+
+@router.post("/training/{job_id}/cancel", response_model=TrainingResponse)
+async def cancel_training_job(
+    job_id: uuid.UUID,
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+    if job.status in TRAINING_TERMINAL:
+        raise HTTPException(status_code=400, detail=f"already {job.status}")
+    # The trainer notices on its next report and stops. Nothing here reaches into the GPU box.
+    job.status = TrainingStatus.CANCELLED
+    job.completed_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(job)
+    return job

--- a/app/schemas/training.py
+++ b/app/schemas/training.py
@@ -1,0 +1,114 @@
+"""Wire shapes for character-LoRA training (wanly-api#274).
+
+Three audiences, and they want different things, which is why this is not one model:
+
+  the console   creates a job and reads its progress
+  the trainer   claims a job and needs EVERYTHING to run it in one response
+  both          list and inspect
+
+The claim response is deliberately self-contained. Same rule as SegmentClaimResponse: a worker
+must never look its configuration up for itself, because a worker that cannot look one up cannot
+look up a STALE one.
+"""
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+from app.enums import TrainingStatus
+
+#: Below this a run is not worth the GPU hour. p@y worked on 13 and that is the floor anyone has
+#: actually proved; 8 is where it stops being arguable.
+MIN_DATASET_IMAGES = 8
+#: Culling k3llydw from 622 to 50 lifted mean cos 0.558 -> 0.699. More is not better, the extras
+#: dilute -- but this is a guard against a mis-click selecting a whole folder, not a quality
+#: opinion, so it sits well above the useful range.
+MAX_DATASET_IMAGES = 400
+
+
+class TrainingCreate(BaseModel):
+    #: THE LtxCharacter NAME, not a filesystem-safe version of it. `p@y` is correct here.
+    #:
+    #: This is what the finished LoRA is published against, and it upserts on the name -- so
+    #: passing `pay` for a character the system already knows as `p@y` creates a SECOND
+    #: character row pointing at the same LoRA, and recipes keep using the old one. The
+    #: filename is sanitised separately at upload (`pay_v3_e04.safetensors`), because a LoRA
+    #: is served over HTTP and lands in JSON and URLs; the name and the trigger are not.
+    character: str = Field(min_length=1, max_length=64)
+    trigger: str = Field(min_length=1, max_length=64)
+    version: int = Field(default=1, ge=1, le=99)
+    dataset_images: list[str] = Field(min_length=MIN_DATASET_IMAGES,
+                                      max_length=MAX_DATASET_IMAGES)
+    #: One caption for every image. Per-image captions come from the dataset instead, and are
+    #: the better answer -- all 13 of p@y's read "p@y, woman" over close-ups, so the trigger
+    #: carries close-up framing as part of its identity.
+    caption: str | None = Field(default=None, max_length=500)
+    steps: int = Field(default=1200, ge=100, le=6000)
+
+    @field_validator("character")
+    @classmethod
+    def _no_path_tricks(cls, v: str) -> str:
+        # It becomes a directory name and an output filename on the trainer.
+        if "/" in v or v.startswith(".") or any(c.isspace() for c in v):
+            raise ValueError("character cannot contain slashes, whitespace, or start with a dot")
+        return v
+
+    @field_validator("dataset_images")
+    @classmethod
+    def _s3_uris_only(cls, v: list[str]) -> list[str]:
+        bad = [x for x in v if not x.startswith("s3://")]
+        if bad:
+            raise ValueError(f"dataset_images must be s3:// URIs, got {bad[0]!r}")
+        if len(set(v)) != len(v):
+            # Duplicates train the same image twice under two sel_NNN names, silently
+            # reweighting the set.
+            raise ValueError("dataset_images contains duplicates")
+        return v
+
+
+class TrainingResponse(BaseModel):
+    id: uuid.UUID
+    character: str
+    trigger: str
+    version: int
+    status: str
+    dataset_images: list[str]
+    config: dict
+    worker_name: str | None = None
+    gpu_name: str | None = None
+    progress_log: str | None = None
+    step: int | None = None
+    total_steps: int | None = None
+    error_message: str | None = None
+    checkpoints: list | None = None
+    output_lora_path: str | None = None
+    created_at: datetime | None = None
+    claimed_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class TrainingClaimResponse(TrainingResponse):
+    """What a trainer gets. Everything it needs, resolved.
+
+    `download_urls` pairs 1:1 with dataset_images, in order, so the trainer never needs S3
+    credentials -- it fetches through the API's own proxy, the same way the render daemon gets
+    its LoRAs.
+    """
+    download_urls: list[str]
+
+
+class TrainingProgress(BaseModel):
+    """A trainer reporting in. Every field optional and written only when present.
+
+    Same conditional-write rule as the worker heartbeat: a report that omits a field must not
+    blank what a previous one set, or a trainer that only sends `step` erases the log.
+    """
+    status: TrainingStatus | None = None
+    progress_log: str | None = None
+    step: int | None = Field(default=None, ge=0)
+    total_steps: int | None = Field(default=None, ge=1)
+    error_message: str | None = None
+    checkpoints: list | None = None
+    output_lora_path: str | None = None

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -1,0 +1,256 @@
+"""Character-LoRA training as claimable work (wanly-api#274).
+
+The design decision under test is that training is PULL, like everything else here: the console
+creates a row, a trainer claims it. That buys orphan reclaim and the heartbeat sweep for free,
+and it only works if the claim gate and the reclaim rules are right — both of which have already
+cost this project real incidents in their segment form.
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.enums import TRAINING_TERMINAL, TrainingStatus, WorkerKind
+from app.models import LtxCharacter, TrainingJob, Worker
+from app.routes.training import ORPHANED_TRAINING_MINUTES, _publish_character, _reclaim_orphans
+from app.schemas.training import TrainingCreate, TrainingProgress
+
+
+def _images(n=13):
+    return [f"s3://wanly-images/2026-09-07/img{i}.jpg" for i in range(n)]
+
+
+def _job(**kw):
+    base = dict(id=uuid.uuid4(), character="pay", trigger="p@y", version=1,
+                dataset_images=_images(), config={}, status=TrainingStatus.PENDING,
+                created_at=datetime.now(timezone.utc))
+    base.update(kw)
+    return TrainingJob(**base)
+
+
+def _worker(**kw):
+    base = dict(id=uuid.uuid4(), friendly_name="3090/services", hostname="h",
+                ip_address="1.2.3.4", kind=WorkerKind.TRAINER, status="online",
+                last_heartbeat=datetime.now(timezone.utc))
+    base.update(kw)
+    return Worker(**base)
+
+
+class TestTheRequest:
+    def test_a_dataset_of_s3_uris_is_required(self):
+        """A local path would be meaningless to a trainer on another machine."""
+        with pytest.raises(ValueError, match="s3://"):
+            TrainingCreate(character="pay", trigger="p@y",
+                           dataset_images=["/home/david/img.jpg"] * 13)
+
+    def test_duplicates_are_refused(self):
+        """A duplicate trains the same image twice under two sel_NNN names, silently
+        reweighting the set toward it."""
+        with pytest.raises(ValueError, match="duplicates"):
+            TrainingCreate(character="pay", trigger="p@y",
+                           dataset_images=["s3://b/a.jpg"] * 13)
+
+    def test_too_few_images_is_refused(self):
+        with pytest.raises(ValueError):
+            TrainingCreate(character="pay", trigger="p@y", dataset_images=_images(3))
+
+    def test_a_character_cannot_contain_a_path(self):
+        """It becomes a directory name and an output filename on the trainer."""
+        for bad in ("../etc", "a/b", ".hidden", "two words"):
+            with pytest.raises(ValueError):
+                TrainingCreate(character=bad, trigger="t", dataset_images=_images())
+
+    def test_the_trigger_may_differ_from_the_character(self):
+        """p@y REQUIRES this: the LoRA is served over HTTP and lands in JSON and URLs, so the
+        filename cannot hold an @ — but the captions trained on one."""
+        t = TrainingCreate(character="pay", trigger="p@y", dataset_images=_images())
+        assert t.character == "pay" and t.trigger == "p@y"
+
+
+class TestTheClaimGate:
+    """Only a trainer may claim. A render worker or a captioner picking up a 50-minute training
+    run would be worse than it going unclaimed."""
+
+    @pytest.mark.parametrize("kind", [WorkerKind.RENDER, WorkerKind.SERVICE])
+    def test_only_a_trainer_kind_passes(self, kind):
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.claim_next_training_job)
+        assert "worker.kind != WorkerKind.TRAINER" in src
+        assert kind != WorkerKind.TRAINER
+
+    def test_the_gate_runs_before_the_reclaim_and_the_select(self):
+        """Order matters: an ineligible worker must not even trigger a reclaim pass."""
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.claim_next_training_job)
+        assert src.index("WorkerKind.TRAINER") < src.index("_reclaim_orphans")
+
+    def test_it_locks_with_skip_locked(self):
+        """Two trainers polling at once must not be handed the same row."""
+        import inspect
+        from app.routes import training as mod
+        assert "with_for_update(skip_locked=True)" in inspect.getsource(mod.claim_next_training_job)
+
+    def test_next_is_routed_before_the_id_wildcard(self):
+        """/training/{job_id} declared first would swallow /training/next and every poll would
+        404 looking for a job called "next"."""
+        from app.main import app
+        paths = [r.path for r in app.routes if r.path.startswith("/training")]
+        assert paths.index("/training/next") < paths.index("/training/{job_id}")
+
+
+@pytest.mark.asyncio
+class TestReclaim:
+    async def test_a_claim_from_a_dead_worker_comes_back(self, db):
+        w = _worker(last_heartbeat=datetime.now(timezone.utc) - timedelta(minutes=30))
+        j = _job(status=TrainingStatus.RUNNING, worker_id=w.id, worker_name=w.friendly_name,
+                 claimed_at=datetime.now(timezone.utc) - timedelta(minutes=40),
+                 progress_log="[3/4] training")
+        db.add_all([w, j])
+        await db.flush()
+        await _reclaim_orphans(db)
+        assert j.status == TrainingStatus.PENDING
+        assert j.worker_id is None and j.progress_log is None
+
+    async def test_a_live_worker_making_progress_keeps_its_claim(self, db):
+        """The rule that matters. A training run is ~50 minutes; stealing one from a worker that
+        is actually training is how two GPUs once converged on the same segment."""
+        w = _worker(status="online")
+        j = _job(status=TrainingStatus.RUNNING, worker_id=w.id,
+                 claimed_at=datetime.now(timezone.utc) - timedelta(hours=2),
+                 progress_log="[3/4] step 800/1200")
+        db.add_all([w, j])
+        await db.flush()
+        await _reclaim_orphans(db)
+        assert j.status == TrainingStatus.RUNNING
+
+    async def test_a_live_idle_worker_with_no_progress_loses_it(self, db):
+        """The lost-claim-response case: the row was assigned before the answer was sent, and
+        the answer never arrived. An empty progress log is the only trustworthy evidence."""
+        w = _worker(status="online")
+        j = _job(status=TrainingStatus.CLAIMED, worker_id=w.id, progress_log=None,
+                 claimed_at=datetime.now(timezone.utc)
+                 - timedelta(minutes=ORPHANED_TRAINING_MINUTES + 5))
+        db.add_all([w, j])
+        await db.flush()
+        await _reclaim_orphans(db)
+        assert j.status == TrainingStatus.PENDING
+
+    async def test_a_recent_claim_is_left_alone(self, db):
+        """Staging a dataset and caching latents is legitimately quiet for minutes."""
+        w = _worker(status="online")
+        j = _job(status=TrainingStatus.CLAIMED, worker_id=w.id, progress_log=None,
+                 claimed_at=datetime.now(timezone.utc) - timedelta(minutes=2))
+        db.add_all([w, j])
+        await db.flush()
+        await _reclaim_orphans(db)
+        assert j.status == TrainingStatus.CLAIMED
+
+
+@pytest.mark.asyncio
+class TestPublishing:
+    async def test_completing_creates_the_character(self, db):
+        """GET /loras makes the FILE discoverable, but a pose fills <TRIGGER> from an
+        LtxCharacter row — without one the LoRA exists and no recipe can reach it."""
+        j = _job(output_lora_path="s3://ltx-loras/character/pay_v1_e05.safetensors")
+        db.add(j)
+        await db.flush()
+        await _publish_character(db, j)
+        await db.flush()
+        from sqlalchemy import select
+        row = (await db.execute(select(LtxCharacter).where(
+            LtxCharacter.name == "pay"))).scalar_one()
+        assert row.char_lora == "pay_v1_e05.safetensors"
+        assert row.trigger == "p@y"
+
+    async def test_retraining_repoints_the_existing_character(self, db):
+        """The whole point of a v2. The strengths are left alone — they may be hand-tuned."""
+        db.add(LtxCharacter(name="pay", char_lora="pay_v1_e05.safetensors", trigger="p@y",
+                            strength_stage_1=0.9, strength_stage_2=1.4))
+        await db.flush()
+        j = _job(version=2, output_lora_path="s3://ltx-loras/character/pay_v2_e03.safetensors")
+        await _publish_character(db, j)
+        await db.flush()
+        from sqlalchemy import select
+        row = (await db.execute(select(LtxCharacter).where(
+            LtxCharacter.name == "pay"))).scalar_one()
+        assert row.char_lora == "pay_v2_e03.safetensors"
+        assert row.strength_stage_1 == 0.9, "hand-tuned strengths were overwritten"
+
+    async def test_nothing_is_published_without_a_file(self, db):
+        j = _job(output_lora_path=None)
+        await _publish_character(db, j)
+        from sqlalchemy import select
+        assert (await db.execute(select(LtxCharacter))).scalars().first() is None
+
+
+class TestReporting:
+    def test_an_omitted_field_does_not_blank_a_stored_one(self):
+        """The mistake the worker heartbeat had to fix twice: a partial report erasing good
+        data written by a fuller one."""
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.update_training_job)
+        assert "if value is not None:" in src
+
+    def test_a_progress_report_need_not_carry_a_status(self):
+        p = TrainingProgress(step=400)
+        assert p.status is None and p.progress_log is None
+
+    def test_terminal_states_are_the_three_that_stop_work(self):
+        assert TRAINING_TERMINAL == {TrainingStatus.COMPLETED, TrainingStatus.FAILED,
+                                     TrainingStatus.CANCELLED}
+
+
+class TestTheClaimIsAtomicEnough:
+    """A claim that mutates and then fails leaves a job owned by a worker that never heard
+    about it — wanly-api#242 in a new place. It recovers, but only after the grace period,
+    with the queue stopped meanwhile. Cheaper to not create it."""
+
+    def test_presigning_happens_before_the_row_is_marked(self):
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.claim_next_training_job)
+        assert src.index("generate_presigned_url") < src.index("job.status = TrainingStatus.CLAIMED")
+
+    def test_a_presign_failure_says_the_job_is_still_queued(self):
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.claim_next_training_job)
+        assert "still queued" in src and "503" in src
+
+
+class TestCharacterNaming:
+    """`character` is the LtxCharacter name, `@` and all — not a filesystem-safe version.
+
+    Verified against a real API: training `p@y` v3 repointed the existing `p@y` row from
+    `pay_v2_e05` to `pay_v3_e04.safetensors`, one row. Passing `pay` instead created a second
+    character row pointing at the same LoRA while every recipe kept using the old one.
+    """
+
+    def test_an_at_sign_is_allowed_in_the_character(self):
+        t = TrainingCreate(character="p@y", trigger="p@y", dataset_images=_images())
+        assert t.character == "p@y"
+
+    def test_the_filename_is_sanitised_at_upload_not_at_creation(self):
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.upload_training_artifact)
+        assert 'c.isalnum() or c in "._-"' in src
+        # and the trigger is untouched by that
+        assert "job.trigger" not in src.split("safe =")[1].split("key =")[0]
+
+    @pytest.mark.asyncio
+    async def test_retraining_a_character_with_an_at_sign_repoints_one_row(self, db):
+        from sqlalchemy import select
+        db.add(LtxCharacter(name="p@y", char_lora="pay_v2_e05.safetensors", trigger="p@y"))
+        await db.flush()
+        j = _job(character="p@y", version=3,
+                 output_lora_path="s3://ltx-loras/character/pay_v3_e04.safetensors")
+        await _publish_character(db, j)
+        await db.flush()
+        rows = (await db.execute(select(LtxCharacter).where(
+            LtxCharacter.name == "p@y"))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].char_lora == "pay_v3_e04.safetensors"


### PR DESCRIPTION
Training a character LoRA is a row a worker claims (#274)

Layer 1 of wanly-console#453. Training has been a laptop-driven ssh pipeline; this makes it
work the queue can hand out.

PULL, NOT PUSH, which is the design decision the ticket asked to revisit. #453 implied the
console calls a trainer over HTTP. Everything in this system is pull -- the API never calls a
worker -- and claiming buys orphan reclaim, the heartbeat/offline sweep and queue-health for
free, because they already exist for segments and key on the same columns. Push would have
needed a trainer URL in config, a retry policy, and its own answer to "the trainer restarted
mid-run".

TrainingJob is shaped on Segment for exactly that reason: status, worker_id/worker_name/
gpu_name snapshotted at claim, claimed_at/completed_at, error_message and progress_log carry
their segment meanings so the machinery transfers. Two columns Segment has no equivalent of --
step/total_steps, because a training run genuinely has a step count and the console already
has a determinate progress bar looking for those two numbers; and checkpoints, because every
epoch is a candidate and loss does NOT rank them, so all of them are recorded.

WorkerKind.TRAINER is a third kind rather than a service that happens to train. The claim gates
key on it: a TRAINER takes training jobs and never segments, a SERVICE takes neither. Collapsing
them would mean the captioner on the 2070 being offered a 50-minute run it has no GPU for.

A PARTIAL UNIQUE INDEX allows one LIVE run per (character, version). A second attempt at v2
while the first is going would train two LoRAs into the same output name and the second would
win silently -- the collision new_character.sh used to produce by reusing one run directory,
invisible until someone read file mtimes. Terminal rows are excluded, so a failed v2 is
retryable.

POST /training/{id}/artifact exists because POST /upload needs a JWT and a trainer holds only
the shared worker key. Without it the container would need AWS credentials, which no worker in
this system has, deliberately. Writing to character/ IS the registration step: GET /loras lists
the bucket live and derives kind from that prefix.

find_image_references now counts training datasets. Without that the console will delete a
dataset image out from under a queued job, and nothing breaks until the trainer fetches a 404
days later, nowhere near the cause.

On completion the LtxCharacter row is created or repointed. Nothing else does this, and it is
what makes the LoRA reachable from a recipe -- a pose fills <TRIGGER> from that row. `character`
is the LtxCharacter name, @ and all; the FILENAME is sanitised separately at upload, because a
LoRA is served over HTTP and lands in JSON and URLs while a trigger does not.

FOUND BY THE END-TO-END RUN, not by a unit test: the claim marked the row CLAIMED and then
presigned, so a presign failure left a job owned by a worker that never received the answer --
wanly-api#242 in a new place, recoverable only after the 20-minute grace period with the queue
stopped meanwhile. Presigning now happens first and a failure returns 503 saying the job is
still queued.

VERIFIED against the running app with real S3 credentials: create (recipe snapshotted), a
duplicate refused 409, a render worker offered null, a trainer claiming with the GPU snapshotted
and 13 presigned URLs, an empty queue returning null, a partial report updating step without
blanking the log, completion setting completed_at, the character row created -- and separately,
retraining p@y v3 repointing that one existing row rather than adding a second. Migration 090
applies from empty and rolls back clean; the partial index refuses a second live run and permits
a retry after failure.

841 tests, 26 new. F821 clean.

Claude-Session: https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J
