### PR TITLE
The LoRA filename is asked for, not guessed

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -55,6 +55,15 @@ RECIPE_DEFAULTS = {
 }
 
 
+def _default_lora_name(character: str) -> str:
+    """A safe filename stem, as a STARTING POINT for the user to correct.
+
+    Stripping is the honest default -- it never invents a letter -- but it is not always the
+    right answer, which is why the field exists.
+    """
+    return "".join(c for c in character if c.isalnum() or c in "._-") or "lora"
+
+
 def _live_states() -> list[str]:
     return [TrainingStatus.CLAIMED, TrainingStatus.RUNNING]
 
@@ -87,7 +96,8 @@ async def create_training_job(
         trigger=body.trigger,
         version=body.version,
         dataset_images=body.dataset_images,
-        config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": body.caption},
+        config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": body.caption,
+                "lora_name": body.lora_name or _default_lora_name(body.character)},
         status=TrainingStatus.PENDING,
         total_steps=body.steps,
     )
@@ -332,11 +342,12 @@ async def upload_training_artifact(
             detail=f"refusing a {len(data)} byte LoRA — a rank-32 character LoRA is ~650 MB, "
                    f"so this is a truncated upload")
 
-    # `@` and friends cannot be in the name: this is served over HTTP and lands in JSON and
-    # URLs. The TRIGGER keeps the original -- that is what the captions trained on.
-    safe = "".join(c for c in job.character if c.isalnum() or c in "._-")
+    # The stem the job was created with. Not derived here: stripping `p@y` gives `py`, while
+    # the file this project actually renders with is `pay_...` -- a human read `@` as `a`, and
+    # no rule produces that. The TRIGGER keeps the original either way; that is what trained.
+    stem = (job.config or {}).get("lora_name") or _default_lora_name(job.character)
     tag = f"_e{epoch:02d}" if epoch is not None else ""
-    key = f"character/{safe}_v{job.version}{tag}.safetensors"
+    key = f"character/{stem}_v{job.version}{tag}.safetensors"
     uri = await asyncio.to_thread(s3.upload_bytes, data, key, settings.s3_loras_bucket)
 
     job.output_lora_path = uri

--- a/app/schemas/training.py
+++ b/app/schemas/training.py
@@ -44,6 +44,18 @@ class TrainingCreate(BaseModel):
     #: carries close-up framing as part of its identity.
     caption: str | None = Field(default=None, max_length=500)
     steps: int = Field(default=1200, ge=100, le=6000)
+    #: The filename stem the LoRA installs under. ASKED, NOT DERIVED.
+    #:
+    #: A LoRA is served over HTTP and lands in JSON and URLs, so `p@y` cannot be a filename --
+    #: but stripping the character it cannot carry gives `py`, and the file this project has
+    #: actually been rendering with is `pay_v2_e05.safetensors`. A human read `@` as `a`. There
+    #: is no rule that produces that: `@`->`a` is a transliteration, and inventing a table for
+    #: it generalises badly (k3lly2026 keeps its digits, so `3`->`e` is wrong).
+    #:
+    #: So it is a field, defaulted to the stripped form and visible in the dialog, rather than
+    #: a guess made silently at upload time.
+    lora_name: str | None = Field(default=None, max_length=64,
+                                  pattern=r"^[A-Za-z0-9._-]+$")
 
     @field_validator("character")
     @classmethod

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -233,13 +233,20 @@ class TestCharacterNaming:
         t = TrainingCreate(character="p@y", trigger="p@y", dataset_images=_images())
         assert t.character == "p@y"
 
-    def test_the_filename_is_sanitised_at_upload_not_at_creation(self):
+    def test_the_filename_stem_is_decided_at_creation_not_at_upload(self):
+        """It is a field on the request, defaulted and correctable, rather than a guess made
+        silently when the file lands. See TestTheLoraFilename for why."""
+        import inspect
+        from app.routes import training as mod
+        assert "lora_name" in inspect.getsource(mod.create_training_job)
+        assert 'get("lora_name")' in inspect.getsource(mod.upload_training_artifact)
+
+    def test_the_trigger_never_feeds_the_filename(self):
+        """They are different things. The trigger keeps whatever trained."""
         import inspect
         from app.routes import training as mod
         src = inspect.getsource(mod.upload_training_artifact)
-        assert 'c.isalnum() or c in "._-"' in src
-        # and the trigger is untouched by that
-        assert "job.trigger" not in src.split("safe =")[1].split("key =")[0]
+        assert "job.trigger" not in src
 
     @pytest.mark.asyncio
     async def test_retraining_a_character_with_an_at_sign_repoints_one_row(self, db):
@@ -254,3 +261,40 @@ class TestCharacterNaming:
             LtxCharacter.name == "p@y"))).scalars().all()
         assert len(rows) == 1
         assert rows[0].char_lora == "pay_v3_e04.safetensors"
+
+
+class TestTheLoraFilename:
+    """The stem is ASKED, not derived.
+
+    Stripping `p@y` gives `py`. The file this project has actually been rendering with is
+    `pay_v2_e05.safetensors` — a human read `@` as `a`, and no rule produces that. `@`->`a` is a
+    transliteration, and a table for it generalises badly: k3lly2026 keeps its digits, so
+    `3`->`e` would be wrong.
+    """
+
+    def test_the_default_strips_and_never_invents_a_letter(self):
+        from app.routes.training import _default_lora_name
+        assert _default_lora_name("p@y") == "py"
+        assert _default_lora_name("k3lly2026") == "k3lly2026"
+
+    def test_a_name_of_only_unsafe_characters_still_yields_something(self):
+        from app.routes.training import _default_lora_name
+        assert _default_lora_name("@@@") == "lora"
+
+    def test_an_explicit_name_is_accepted(self):
+        t = TrainingCreate(character="p@y", trigger="p@y", lora_name="pay",
+                           dataset_images=_images())
+        assert t.lora_name == "pay"
+
+    def test_an_unsafe_explicit_name_is_refused(self):
+        """Otherwise the field just moves the problem."""
+        for bad in ("p@y", "a/b", "with space"):
+            with pytest.raises(ValueError):
+                TrainingCreate(character="x", trigger="x", lora_name=bad,
+                               dataset_images=_images())
+
+    def test_the_upload_uses_the_stored_stem_not_a_fresh_guess(self):
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.upload_training_artifact)
+        assert 'get("lora_name")' in src


### PR DESCRIPTION
The LoRA filename is asked for, not guessed

Caught by a console test asserting the filename this project actually renders with.

The artifact upload derived the stem by stripping what a filename cannot carry. For p@y that
gives `py`. The file on the 3090, the one every recipe points at, is `pay_v2_e05.safetensors` --
a human read `@` as `a`, and no rule produces that. `@`->`a` is a transliteration, and inventing
a table for it generalises badly: k3lly2026 keeps its digits, so `3`->`e` would be wrong in the
same breath.

So `lora_name` is a field on the request, defaulted to the stripped form and pattern-checked so
the field cannot just move the problem, stored in the job's config snapshot, and read at upload
rather than re-derived. The trigger is untouched either way -- it keeps whatever trained, and a
test now asserts it never feeds the filename.

Left the default as a strip rather than something cleverer, deliberately: it never invents a
letter, and being visibly a little wrong in the dialog is better than being invisibly wrong in
the bucket.

847 tests.

Claude-Session: https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J
