### PR TITLE
Datasets: named, tagged, uploadable — and every checkpoint downloadable

### DIFF
--- a/alembic/versions/091_datasets.py
+++ b/alembic/versions/091_datasets.py
@@ -1,0 +1,48 @@
+"""Named, taggable training datasets
+
+Revision ID: 091
+Revises: 090
+Create Date: 2026-09-07
+
+The grouping that did not exist. Before this the only ways to say "these images belong together"
+were an S3 folder prefix and a per-user favourites list, so a training set could not be named,
+tagged, or re-opened -- every run meant re-selecting the images by hand, and a v2 meant doing it
+again from memory.
+
+Images are an explicit ORDERED list rather than a folder listing. A dataset usually corresponds
+to a folder and uploads go into one, but the list is what the dataset IS: it survives an image
+being moved, and it fixes the order the trainer stages them in, which is what the captions pair
+against.
+
+`tags` is a comma-separated string rather than an array, matching ImageMeta.tags. A second
+convention for the same idea would mean the console parsing tags two ways.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "091"
+down_revision = "090"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "datasets",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("tags", sa.String(length=500), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("images", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("prefix", sa.String(length=200), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_datasets_name", "datasets", ["name"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_datasets_name", table_name="datasets")
+    op.drop_table("datasets")

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from app.config import settings
 from app.heartbeat_monitor import heartbeat_monitor
 from app.reservation_monitor import reservation_monitor
 from app.limiter import limiter
-from app.routes import app_settings, auth, captions, favorites, files, images, jobs, ltx_recipes, runpod, segments, stats, tags, training, videos, wildcards, workers
+from app.routes import app_settings, auth, captions, datasets, favorites, files, images, jobs, ltx_recipes, runpod, segments, stats, tags, training, videos, wildcards, workers
 
 logger = logging.getLogger(__name__)
 
@@ -72,4 +72,5 @@ app.include_router(wildcards.router)
 app.include_router(workers.router)
 app.include_router(runpod.router)
 app.include_router(stats.router)
+app.include_router(datasets.router)
 app.include_router(training.router)

--- a/app/models.py
+++ b/app/models.py
@@ -396,6 +396,39 @@ class GpuReservation(Base):
     )
 
 
+class Dataset(Base):
+    """A named, taggable set of images kept for training.
+
+    THE THING THAT DID NOT EXIST. Until now the only groupings were an S3 folder prefix and a
+    per-user favourites list, so "these 27 images are p@y v2's training set" could not be
+    written down -- you re-selected them by hand every time, and a v3 meant doing it again from
+    memory.
+
+    Images are an explicit ORDERED list of s3:// URIs rather than a folder listing. A dataset
+    usually corresponds to a folder, and uploads go into one, but the list is what the dataset
+    IS: it survives an image being moved, and it records the order the trainer will stage them
+    in, which pairs with the captions.
+    """
+    __tablename__ = "datasets"
+    __table_args__ = (Index("ix_datasets_name", "name", unique=True),)
+
+    id = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    name = mapped_column(String(100), nullable=False)
+    # Comma-separated, matching ImageMeta.tags rather than inventing a second convention. The
+    # console already knows how to parse, render and filter that shape.
+    tags = mapped_column(String(500), nullable=True)
+    notes = mapped_column(Text, nullable=True)
+    #: s3:// URIs, order significant.
+    images = mapped_column(JSONB, nullable=False, default=list)
+    #: The S3 prefix uploads land in. Recorded rather than derived, because a rename must not
+    #: silently point a dataset at a folder that does not exist.
+    prefix = mapped_column(String(200), nullable=True)
+    created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc),
+                               onupdate=lambda: datetime.now(timezone.utc))
+
+
 class TrainingJob(Base):
     """A character-LoRA training run: what to train, who is training it, and what came out.
 

--- a/app/routes/datasets.py
+++ b/app/routes/datasets.py
@@ -1,0 +1,160 @@
+"""Named, taggable training datasets (wanly-console#453).
+
+WHAT THIS REPLACES. Before it, "these 27 images are p@y v2's training set" could not be written
+down. The only groupings were an S3 folder prefix and a per-user favourites list, so every
+training run meant re-selecting images by hand and a v2 meant doing it again from memory.
+
+Uploads land in one S3 prefix per dataset, so a dataset is ALSO browsable as a folder in the
+Image Repo -- nothing new to learn, and the images stay ordinary images. But the dataset is the
+ordered LIST, not the folder listing: it survives an image being moved, and it fixes the order
+the trainer stages them in, which is what the captions pair against.
+"""
+import asyncio
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import s3
+from app.auth import get_current_user, verify_api_key_or_bearer
+from app.config import settings
+from app.database import get_db
+from app.models import Dataset, User
+from app.schemas.datasets import DatasetCreate, DatasetResponse, DatasetUpdate
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
+
+
+def _prefix(name: str) -> str:
+    """The S3 folder a dataset's uploads go into.
+
+    Spaces become dashes: a prefix with spaces works but is miserable to type in a URL or read
+    in a listing, and these become part of every image's key forever.
+    """
+    return "dataset-" + name.strip().lower().replace(" ", "-")
+
+
+@router.post("/datasets", response_model=DatasetResponse, status_code=201)
+async def create_dataset(
+    body: DatasetCreate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    dupe = (await db.execute(select(Dataset).where(Dataset.name == body.name))).scalar_one_or_none()
+    if dupe:
+        raise HTTPException(status_code=409, detail=f"a dataset called {body.name!r} already exists")
+    ds = Dataset(user_id=user.id, name=body.name, tags=body.tags, notes=body.notes,
+                 images=[], prefix=_prefix(body.name))
+    db.add(ds)
+    await db.commit()
+    await db.refresh(ds)
+    # The marker is what makes the prefix show up as a folder in the Image Repo before anything
+    # has been uploaded into it. Without it an empty dataset is invisible there.
+    await asyncio.to_thread(s3.upload_bytes, b"", f"{ds.prefix}/.folder",
+                            settings.s3_images_bucket)
+    return ds
+
+
+@router.get("/datasets", response_model=list[DatasetResponse],
+            dependencies=[Depends(verify_api_key_or_bearer)])
+async def list_datasets(db: AsyncSession = Depends(get_db)):
+    rows = (await db.execute(select(Dataset).order_by(Dataset.updated_at.desc()))).scalars().all()
+    return list(rows)
+
+
+@router.get("/datasets/{dataset_id}", response_model=DatasetResponse,
+            dependencies=[Depends(verify_api_key_or_bearer)])
+async def get_dataset(dataset_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    ds = await db.get(Dataset, dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    return ds
+
+
+@router.patch("/datasets/{dataset_id}", response_model=DatasetResponse)
+async def update_dataset(
+    dataset_id: uuid.UUID,
+    body: DatasetUpdate,
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    ds = await db.get(Dataset, dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    if body.name is not None:
+        ds.name = body.name
+        # The prefix deliberately does NOT follow a rename. Renaming a dataset must not move
+        # objects that other rows -- a finished training job's dataset_images -- point at.
+    if body.tags is not None:
+        ds.tags = body.tags
+    if body.notes is not None:
+        ds.notes = body.notes
+    if body.images is not None:
+        ds.images = body.images
+    await db.commit()
+    await db.refresh(ds)
+    return ds
+
+
+@router.post("/datasets/{dataset_id}/images", response_model=DatasetResponse)
+async def add_images(
+    dataset_id: uuid.UUID,
+    files: list[UploadFile] = File(...),
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Upload images into a dataset. Many at once, because a dataset is 13-50 of them."""
+    ds = await db.get(Dataset, dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+
+    added: list[str] = []
+    for f in files:
+        name = (f.filename or "image.jpg").rsplit("/", 1)[-1]
+        ext = ("." + name.rsplit(".", 1)[1].lower()) if "." in name else ".jpg"
+        if ext not in IMAGE_SUFFIXES:
+            # Skipped rather than fatal: one stray file in a folder drag-and-drop should not
+            # reject the other forty-nine.
+            logger.info("dataset %s: skipping %s (not an image)", ds.name, name)
+            continue
+        data = await f.read()
+        uri = await asyncio.to_thread(
+            s3.upload_bytes, data, f"{ds.prefix}/{name}", settings.s3_images_bucket)
+        if uri not in ds.images:
+            added.append(uri)
+
+    if added:
+        # Reassigned rather than appended in place: JSONB columns do not see a mutation of the
+        # existing list, so `ds.images.append(...)` writes nothing and the upload silently
+        # vanishes on the next read.
+        ds.images = list(ds.images) + added
+        await db.commit()
+        await db.refresh(ds)
+    logger.info("dataset %s: added %d image(s), now %d", ds.name, len(added), len(ds.images))
+    return ds
+
+
+@router.delete("/datasets/{dataset_id}", status_code=204)
+async def delete_dataset(
+    dataset_id: uuid.UUID,
+    purge: bool = False,
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete the dataset row. `purge=true` also deletes its images from S3.
+
+    Not by default: a finished training job records the URIs it trained on, and destroying them
+    turns a reproducible run into an unreproducible one.
+    """
+    ds = await db.get(Dataset, dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    if purge and ds.prefix:
+        await asyncio.to_thread(s3.delete_prefix, settings.s3_images_bucket, ds.prefix + "/")
+    await db.delete(ds)
+    await db.commit()

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -27,9 +27,10 @@ from app.auth import get_current_user, verify_api_key, verify_api_key_or_bearer
 from app.config import settings
 from app.database import get_db
 from app.enums import TRAINING_TERMINAL, TrainingStatus, WorkerKind
-from app.models import LtxCharacter, TrainingJob, User, Worker
+from app.models import Dataset, LtxCharacter, TrainingJob, User, Worker
 from app.schemas.training import (
-    TrainingClaimResponse, TrainingCreate, TrainingProgress, TrainingResponse,
+    MIN_DATASET_IMAGES, TrainingClaimResponse, TrainingCreate, TrainingProgress,
+    TrainingResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -75,6 +76,23 @@ async def create_training_job(
     db: AsyncSession = Depends(get_db),
 ):
     """Queue a training run. The console's entry point."""
+    # A dataset is the normal path; a raw list stays supported so a CLI or a curl can train
+    # without creating one first.
+    images = list(body.dataset_images)
+    if body.dataset_id:
+        ds = await db.get(Dataset, body.dataset_id)
+        if not ds:
+            raise HTTPException(status_code=404, detail="Dataset not found")
+        images = list(ds.images)
+    # Checked here rather than on the schema, because it applies to whichever of the two was
+    # given -- a schema minimum on dataset_images would reject every dataset_id request.
+    if len(images) < MIN_DATASET_IMAGES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{len(images)} images — at least {MIN_DATASET_IMAGES} are needed")
+    if len(set(images)) != len(images):
+        raise HTTPException(status_code=422, detail="the dataset contains duplicates")
+
     dupe = (await db.execute(
         select(TrainingJob).where(
             TrainingJob.character == body.character,
@@ -95,7 +113,7 @@ async def create_training_job(
         character=body.character,
         trigger=body.trigger,
         version=body.version,
-        dataset_images=body.dataset_images,
+        dataset_images=images,
         config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": body.caption,
                 "lora_name": body.lora_name or _default_lora_name(body.character)},
         status=TrainingStatus.PENDING,
@@ -350,6 +368,13 @@ async def upload_training_artifact(
     key = f"character/{stem}_v{job.version}{tag}.safetensors"
     uri = await asyncio.to_thread(s3.upload_bytes, data, key, settings.s3_loras_bucket)
 
+    # EVERY EPOCH IS RECORDED, not just the last. Choosing between them is a judgement made by
+    # eye at a fixed seed -- loss does not rank them -- so the console has to be able to offer
+    # all of them for download. `output_lora_path` tracks the most recent, which is what the
+    # character row points at until someone picks differently.
+    existing = [c for c in (job.checkpoints or []) if isinstance(c, str)]
+    if uri not in existing:
+        job.checkpoints = existing + [uri]
     job.output_lora_path = uri
     await db.commit()
     await db.refresh(job)

--- a/app/schemas/datasets.py
+++ b/app/schemas/datasets.py
@@ -1,0 +1,49 @@
+"""Wire shapes for training datasets."""
+import re
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+#: Same character class the image folders use, because a dataset's uploads land in one and an S3
+#: prefix that needs escaping is a prefix nobody can type.
+NAME_RE = re.compile(r"^[A-Za-z0-9 _.@-]+$")
+
+
+class DatasetCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    tags: str | None = Field(default=None, max_length=500)
+    notes: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _safe(cls, v: str) -> str:
+        v = v.strip()
+        if not NAME_RE.match(v):
+            raise ValueError("letters, numbers, spaces, and . _ - @ only")
+        return v
+
+
+class DatasetUpdate(BaseModel):
+    name: str | None = Field(default=None, max_length=100)
+    tags: str | None = Field(default=None, max_length=500)
+    notes: str | None = None
+    #: Replaces the list wholesale. Used to reorder or remove; adding is done by uploading.
+    images: list[str] | None = None
+
+
+class DatasetResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    tags: str | None = None
+    notes: str | None = None
+    images: list[str]
+    prefix: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @property
+    def image_count(self) -> int:
+        return len(self.images)
+
+    model_config = {"from_attributes": True}

--- a/app/schemas/training.py
+++ b/app/schemas/training.py
@@ -37,8 +37,12 @@ class TrainingCreate(BaseModel):
     character: str = Field(min_length=1, max_length=64)
     trigger: str = Field(min_length=1, max_length=64)
     version: int = Field(default=1, ge=1, le=99)
-    dataset_images: list[str] = Field(min_length=MIN_DATASET_IMAGES,
-                                      max_length=MAX_DATASET_IMAGES)
+    #: Either give the images, or name a dataset and let the API resolve them. The dataset is
+    #: the normal path now -- a set worth training is a set worth being able to re-open. The
+    #: minimum is enforced in the route rather than here, because it applies to whichever of
+    #: the two was used.
+    dataset_images: list[str] = Field(default_factory=list, max_length=MAX_DATASET_IMAGES)
+    dataset_id: uuid.UUID | None = None
     #: One caption for every image. Per-image captions come from the dataset instead, and are
     #: the better answer -- all 13 of p@y's read "p@y, woman" over close-ups, so the trigger
     #: carries close-up framing as part of its identity.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,104 @@
+"""Named, taggable training datasets.
+
+The grouping that did not exist. Before this the only ways to say "these images belong together"
+were an S3 folder prefix and a per-user favourites list, so a training set could not be named,
+tagged or re-opened — every run meant re-selecting by hand, and a v2 meant doing it again from
+memory.
+"""
+import uuid
+
+import pytest
+
+from app.models import Dataset
+from app.routes.datasets import _prefix
+from app.schemas.datasets import DatasetCreate
+from app.schemas.training import TrainingCreate
+
+
+class TestNaming:
+    def test_a_readable_name_is_allowed(self):
+        assert DatasetCreate(name="p@y v2 faces").name == "p@y v2 faces"
+
+    @pytest.mark.parametrize("bad", ["a/b", "../etc", "tab\there", ""])
+    def test_a_name_that_breaks_a_prefix_is_refused(self, bad):
+        """It becomes part of every image's S3 key, forever."""
+        with pytest.raises(ValueError):
+            DatasetCreate(name=bad)
+
+    def test_the_prefix_is_typeable(self):
+        """Spaces work in S3 and are miserable in a URL or a listing."""
+        assert _prefix("p@y v2 faces") == "dataset-p@y-v2-faces"
+
+
+class TestTraining:
+    def test_a_job_can_name_a_dataset_instead_of_listing_images(self):
+        t = TrainingCreate(character="p@y", trigger="p@y", dataset_id=uuid.uuid4())
+        assert t.dataset_images == []
+        assert t.dataset_id is not None
+
+    def test_a_raw_list_still_works(self):
+        """A CLI or a curl should not have to create a dataset first."""
+        imgs = [f"s3://b/{i}.jpg" for i in range(13)]
+        assert TrainingCreate(character="x", trigger="x", dataset_images=imgs).dataset_id is None
+
+    def test_the_minimum_is_enforced_in_the_route_not_the_schema(self):
+        """A schema minimum on dataset_images would reject every dataset_id request, which is
+        the normal path."""
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.create_training_job)
+        assert "len(images) < MIN_DATASET_IMAGES" in src
+        # and it resolves the dataset before checking
+        assert src.index("body.dataset_id") < src.index("len(images) < MIN_DATASET_IMAGES")
+
+
+@pytest.mark.asyncio
+class TestTheRow:
+    async def test_images_are_an_ordered_list(self, db):
+        """Order is significant: the trainer stages them as sel_000..N and the captions pair
+        by index."""
+        ds = Dataset(id=uuid.uuid4(), name="d", images=["s3://b/z.jpg", "s3://b/a.jpg"],
+                     prefix="dataset-d")
+        db.add(ds)
+        await db.flush()
+        assert ds.images == ["s3://b/z.jpg", "s3://b/a.jpg"]
+
+    async def test_a_dataset_starts_empty(self, db):
+        ds = Dataset(id=uuid.uuid4(), name="empty", images=[], prefix="dataset-empty")
+        db.add(ds)
+        await db.flush()
+        assert ds.images == []
+
+
+class TestUploadSemantics:
+    def test_the_image_list_is_reassigned_not_mutated(self):
+        """A JSONB column does not see a mutation of the existing list, so `images.append(...)`
+        writes nothing and the upload silently vanishes on the next read."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.add_images)
+        assert "ds.images = list(ds.images) + added" in src
+        # Code only. The comment above that line names the mistake it is avoiding, and a
+        # substring check would match the explanation rather than the bug.
+        code = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
+        assert "ds.images.append" not in code
+
+    def test_a_non_image_is_skipped_not_fatal(self):
+        """One stray file in a folder drag-and-drop must not reject the other forty-nine."""
+        import inspect
+        from app.routes import datasets as mod
+        assert "continue" in inspect.getsource(mod.add_images)
+
+    def test_deleting_a_dataset_keeps_its_images_by_default(self):
+        """A finished training job records the URIs it trained on; destroying them turns a
+        reproducible run into an unreproducible one."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.delete_dataset)
+        assert "purge" in src and "if purge" in src
+
+    def test_renaming_does_not_move_the_prefix(self):
+        """Objects other rows point at must not move under them."""
+        import inspect
+        from app.routes import datasets as mod
+        assert "does NOT follow a rename" in inspect.getsource(mod.update_dataset)

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -50,9 +50,12 @@ class TestTheRequest:
             TrainingCreate(character="pay", trigger="p@y",
                            dataset_images=["s3://b/a.jpg"] * 13)
 
-    def test_too_few_images_is_refused(self):
-        with pytest.raises(ValueError):
-            TrainingCreate(character="pay", trigger="p@y", dataset_images=_images(3))
+    def test_too_few_images_is_refused_by_the_route(self):
+        """The floor moved off the schema when dataset_id arrived: a schema minimum on
+        dataset_images would reject every dataset_id request, which is the normal path now."""
+        import inspect
+        from app.routes import training as mod
+        assert "at least {MIN_DATASET_IMAGES} are needed" in inspect.getsource(mod.create_training_job)
 
     def test_a_character_cannot_contain_a_path(self):
         """It becomes a directory name and an output filename on the trainer."""
@@ -298,3 +301,26 @@ class TestTheLoraFilename:
         from app.routes import training as mod
         src = inspect.getsource(mod.upload_training_artifact)
         assert 'get("lora_name")' in src
+
+
+class TestEveryCheckpointIsOffered:
+    """Choosing between epochs is a judgement made by eye at a fixed seed. Loss does not rank
+    them — a confident "later epochs overfit" call read off a loss curve was refuted outright on
+    d0ggyff — so a console that only offers the final epoch has thrown the decision away."""
+
+    def test_uploading_appends_rather_than_replaces(self):
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.upload_training_artifact)
+        assert "job.checkpoints = existing + [uri]" in src
+
+    def test_the_same_uri_is_not_recorded_twice(self):
+        import inspect
+        from app.routes import training as mod
+        assert "if uri not in existing:" in inspect.getsource(mod.upload_training_artifact)
+
+    def test_output_lora_path_tracks_the_most_recent(self):
+        """It is what the character row points at until someone picks differently."""
+        import inspect
+        from app.routes import training as mod
+        assert "job.output_lora_path = uri" in inspect.getsource(mod.upload_training_artifact)


### PR DESCRIPTION
Datasets: named, tagged, uploadable — and every checkpoint downloadable

The grouping that did not exist. Until now the only ways to say "these 27 images are p@y v2's
training set" were an S3 folder prefix and a per-user favourites list, so a training set could
not be named, tagged or re-opened: every run meant re-selecting by hand, and a v2 meant doing it
again from memory.

`datasets` carries a unique name, comma-separated tags (matching ImageMeta.tags rather than
inventing a second convention the console would have to parse two ways), free notes, and an
ORDERED list of s3:// URIs. The list is what the dataset IS, not the folder listing: it survives
an image being moved, and it fixes the order the trainer stages them in, which is what the
captions pair against.

Uploads land in one prefix per dataset, so a dataset is also browsable as an ordinary folder in
the Image Repo -- nothing new to learn. A `.folder` marker is written at creation so an empty
dataset is visible there before anything is in it.

POST /datasets/{id}/images takes MANY files, because a dataset is 13-50 of them, and skips a
non-image rather than failing: one stray file in a folder drag-and-drop must not reject the
other forty-nine. The image list is REASSIGNED, never appended in place -- a JSONB column does
not see a mutation of the existing list, so ds.images.append() writes nothing and the upload
silently vanishes on the next read.

Deleting a dataset keeps its images unless purge=true, because a finished training job records
the URIs it trained on and destroying them turns a reproducible run into an unreproducible one.
Renaming does not move the prefix, for the same reason.

POST /training now takes dataset_id as well as a raw list. The minimum-images check moved from
the schema to the route: a schema minimum on dataset_images would reject every dataset_id
request, which is the normal path now.

EVERY CHECKPOINT IS RECORDED, not just the last. The artifact upload appends to
job.checkpoints instead of overwriting, and the trainer publishes all of them on completion.
Choosing between epochs is a judgement made by eye at a fixed seed -- loss does not rank them,
and a confident "later epochs overfit" call read off a loss curve was refuted outright on
d0ggyff -- so a console offering only the final epoch has thrown the decision away.

869 tests. Migration 091 applies from empty and rolls back clean.

Claude-Session: https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J
