### PR TITLE
Only downloadable checkpoints are offered

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -372,7 +372,14 @@ async def upload_training_artifact(
     # eye at a fixed seed -- loss does not rank them -- so the console has to be able to offer
     # all of them for download. `output_lora_path` tracks the most recent, which is what the
     # character row points at until someone picks differently.
-    existing = [c for c in (job.checkpoints or []) if isinstance(c, str)]
+    # ONLY s3:// SURVIVES. The console turns every entry into a download button pointed at
+    # GET /files, which can serve an S3 URI and nothing else. Early trainer builds recorded the
+    # container-local output path instead of uploading, so a completed job carries entries like
+    # `/loras/p@y/ltx23b-v2/output/p@y_v2-000003.comfy.safetensors` -- carrying those forward
+    # puts five buttons on the page and four of them 404. Dropping them here is also the
+    # backfill: re-uploading a job's epochs replaces the dead list with the live one.
+    existing = [c for c in (job.checkpoints or [])
+                if isinstance(c, str) and c.startswith("s3://")]
     if uri not in existing:
         job.checkpoints = existing + [uri]
     job.output_lora_path = uri

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -324,3 +324,53 @@ class TestEveryCheckpointIsOffered:
         import inspect
         from app.routes import training as mod
         assert "job.output_lora_path = uri" in inspect.getsource(mod.upload_training_artifact)
+
+
+@pytest.mark.asyncio
+class TestOnlyDownloadableCheckpointsSurvive:
+    """The console turns every `checkpoints` entry into a download button pointed at
+    GET /files, which serves an S3 URI and nothing else. Early trainer builds recorded the
+    container-local output path instead of uploading, so a completed job carried five entries
+    that all 404. Re-uploading has to REPLACE that list, not extend it."""
+
+    async def _upload(self, db, job, monkeypatch, epoch=None):
+        import io
+        from fastapi import UploadFile
+        from app.routes import training as mod
+
+        uploaded = {}
+
+        def fake_upload(data, key, bucket):
+            uploaded["key"] = key
+            return f"s3://{bucket}/{key}"
+
+        monkeypatch.setattr(mod.s3, "upload_bytes", fake_upload)
+        # Over the 10 MB floor the route enforces against truncated uploads.
+        payload = b"\0" * (11 * 1024 * 1024)
+        f = UploadFile(filename="lora.safetensors", file=io.BytesIO(payload))
+        return await mod.upload_training_artifact(job.id, lora=f, epoch=epoch, db=db)
+
+    async def test_a_container_local_path_is_dropped(self, db, monkeypatch):
+        job = _job(status=TrainingStatus.COMPLETED, config={"lora_name": "pay"},
+                   checkpoints=["/loras/p@y/ltx23b-v2/output/p@y_v2-000003.comfy.safetensors"])
+        db.add(job)
+        await db.commit()
+
+        out = await self._upload(db, job, monkeypatch, epoch=3)
+
+        assert all(c.startswith("s3://") for c in out.checkpoints), out.checkpoints
+        assert len(out.checkpoints) == 1
+
+    async def test_earlier_s3_epochs_are_still_kept(self, db, monkeypatch):
+        """Dropping the dead entries must not also drop the good ones — every epoch is
+        offered because loss does not rank them."""
+        prior = "s3://ltx-loras/character/pay_v2_e01.safetensors"
+        job = _job(status=TrainingStatus.COMPLETED, config={"lora_name": "pay"},
+                   checkpoints=[prior, "/loras/output/p@y_v2-000002.comfy.safetensors"])
+        db.add(job)
+        await db.commit()
+
+        out = await self._upload(db, job, monkeypatch, epoch=2)
+
+        assert prior in out.checkpoints
+        assert len(out.checkpoints) == 2


### PR DESCRIPTION
`upload_training_artifact` appended to `job.checkpoints` unconditionally. The console renders
one download button per entry, pointed at `GET /files` — which serves an S3 URI and nothing
else.

Early trainer builds recorded the container-local output path instead of uploading. The
completed p@y v2 job on production carries five such entries, every one of them a dead button:

```
/loras/p@y/ltx23b-v2/output/p@y_v2-000003.comfy.safetensors
```

Filtering to `s3://` on append makes the re-upload the backfill: the dead list is replaced
rather than extended to ten buttons with half broken. Earlier real epochs are kept — loss does
not rank checkpoints, so all of them have to stay on offer.

Two behavioural tests (not source inspection): a local path is dropped, and a prior `s3://`
epoch survives alongside the new one.

`879 passed`

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J