### PR TITLE
A cancel is sticky

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -289,7 +289,20 @@ async def update_training_job(
         if value is not None:
             setattr(job, field, value)
 
-    if body.status is not None:
+    # A CANCEL IS STICKY.
+    #
+    # Nothing here reaches into the GPU box, so a cancelled job keeps reporting `running` until
+    # the trainer notices -- and an unconditional write meant every one of those reports undid
+    # the cancel. The button appeared to work, the row flipped back within seconds, and the run
+    # went to completion. Cancelling had no effect at all.
+    #
+    # Sticky rather than "only a worker may leave cancelled" because a cancel is a human
+    # decision about work nobody wants any more. A trainer that finishes before it notices has
+    # not made the run wanted again.
+    #
+    # This is also how the trainer FINDS OUT: the response carries the row back, so the reply to
+    # the progress report it just sent says cancelled, and it stops. There is no second call.
+    if body.status is not None and job.status != TrainingStatus.CANCELLED:
         job.status = body.status
         if body.status in TRAINING_TERMINAL:
             job.completed_at = datetime.now(timezone.utc)

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -374,3 +374,58 @@ class TestOnlyDownloadableCheckpointsSurvive:
 
         assert prior in out.checkpoints
         assert len(out.checkpoints) == 2
+
+
+@pytest.mark.asyncio
+class TestCancellingActuallyCancels:
+    """Nothing in the API reaches into the GPU box, so a cancelled job keeps reporting
+    `running` until the trainer notices. Writing that report unconditionally undid the cancel
+    within seconds: the button appeared to work and the run went to completion."""
+
+    async def _patch(self, db, job, **fields):
+        from app.routes.training import update_training_job
+        return await update_training_job(job.id, TrainingProgress(**fields), db=db)
+
+    async def test_a_progress_report_does_not_revive_a_cancelled_job(self, db):
+        job = _job(status=TrainingStatus.CANCELLED,
+                   completed_at=datetime.now(timezone.utc))
+        db.add(job)
+        await db.commit()
+
+        out = await self._patch(db, job, status=TrainingStatus.RUNNING, step=412)
+
+        assert out.status == TrainingStatus.CANCELLED
+        # The progress itself is still recorded — it is what the run was doing when it stopped.
+        assert out.step == 412
+
+    async def test_a_cancelled_job_is_not_completed_by_a_late_finish(self, db):
+        """A trainer that finishes before it notices has not made the run wanted again."""
+        job = _job(status=TrainingStatus.CANCELLED,
+                   completed_at=datetime.now(timezone.utc))
+        db.add(job)
+        await db.commit()
+
+        out = await self._patch(db, job, status=TrainingStatus.COMPLETED)
+
+        assert out.status == TrainingStatus.CANCELLED
+
+    async def test_the_reply_tells_the_trainer_it_was_cancelled(self, db):
+        """This is how the trainer finds out — there is no second call."""
+        job = _job(status=TrainingStatus.CANCELLED,
+                   completed_at=datetime.now(timezone.utc))
+        db.add(job)
+        await db.commit()
+
+        out = await self._patch(db, job, status=TrainingStatus.RUNNING)
+
+        assert out.status == TrainingStatus.CANCELLED
+
+    async def test_an_ordinary_running_job_still_advances(self, db):
+        job = _job(status=TrainingStatus.CLAIMED)
+        db.add(job)
+        await db.commit()
+
+        out = await self._patch(db, job, status=TrainingStatus.RUNNING, step=7)
+
+        assert out.status == TrainingStatus.RUNNING
+        assert out.step == 7


### PR DESCRIPTION
Cancelling a training job did nothing.

Nothing in the API reaches into the GPU box, so a cancelled job keeps reporting `running` until
the trainer notices. `update_training_job` wrote the reported status unconditionally:

```python
if body.status is not None:
    job.status = body.status
```

So every progress report undid the cancel. The row flipped back within seconds — the button
appeared to work and the run went to completion.

**Sticky**, rather than "only a worker may leave cancelled": a cancel is a human decision about
work nobody wants any more, and a trainer that finishes before it notices has not made the run
wanted again.

It is also how the trainer finds out. The PATCH response carries the row back, so the reply to
the report it just sent says `cancelled` and it can stop — no second call and no polling. The
trainer-side half of that is a separate wanly-services change.

Progress fields are still written on a cancelled job; that is the record of what it was doing
when it stopped.

Four tests. The three new assertions were each verified to fail with the guard removed:

```
FAILED test_a_progress_report_does_not_revive_a_cancelled_job
FAILED test_a_cancelled_job_is_not_completed_by_a_late_finish
FAILED test_the_reply_tells_the_trainer_it_was_cancelled
```

`883 passed`

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J