### PR TITLE
Cropping can take every face, not only the largest

### DIFF
--- a/app/routes/datasets.py
+++ b/app/routes/datasets.py
@@ -167,6 +167,7 @@ async def crop_faces(
     dataset_id: uuid.UUID,
     reference_dataset_id: uuid.UUID | None = None,
     gate: bool = True,
+    largest_only: bool = True,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -185,6 +186,13 @@ async def crop_faces(
     Writes a NEW dataset rather than replacing this one. The photographs are the source of truth
     and a crop is derived; overwriting them would make the operation unrepeatable with different
     padding or a different reference.
+
+    `largest_only` DEFAULTS TRUE BUT IS NOT ALWAYS RIGHT. A dataset of solo portraits wants one
+    face per photo. A dataset of couples does not: "largest" is then whoever stood closer to the
+    camera, so the output silently interleaves two people -- and with no reference the gate
+    scores against the crops' own mean, which for a mixed set is a blend of both and cannot
+    separate them. For that shape the working order is: take every face, gate off, remove the
+    wrong people by hand, then run again using the result as the reference.
     """
     ds = await db.get(Dataset, dataset_id)
     if not ds:
@@ -207,7 +215,7 @@ async def crop_faces(
         "images": [base64.b64encode(await asyncio.to_thread(s3.download_bytes, u)).decode()
                    for u in ds.images],
         "reference": ref_embeddings,
-        "largest_only": True,
+        "largest_only": largest_only,
     }
     async with httpx.AsyncClient(timeout=settings.face_crop_timeout_s) as client:
         try:
@@ -244,7 +252,8 @@ async def crop_faces(
         name = f"{name} {uuid.uuid4().hex[:4]}"
     out = Dataset(user_id=user.id, name=name, tags=ds.tags, images=[], prefix=_prefix(name),
                   notes=(f"Cropped from {ds.name}: {len(faces)} faces from {len(ds.images)} "
-                         f"photos, {len(result.get('no_face', []))} with none detected, "
+                         f"photos ({'largest only' if largest_only else 'every face'}), "
+                         f"{len(result.get('no_face', []))} with none detected, "
                          f"{len(dropped)} below the {floor} floor"
                          + ("" if ref_embeddings else
                             " (scored against the crops' own mean — internal consistency only, "

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -125,6 +125,30 @@ class TestCropping:
         assert "out = Dataset(" in src
         assert "ds.images = uris" not in src
 
+    def test_one_face_per_photo_is_the_default_but_is_a_choice(self):
+        """A dataset of couples does not want the largest face: "largest" is then whoever stood
+        closer to the camera, so the output silently interleaves two people."""
+        import inspect
+        from app.routes import datasets as mod
+        sig = inspect.signature(mod.crop_faces)
+        assert sig.parameters["largest_only"].default is True
+
+    def test_the_choice_actually_reaches_the_service(self):
+        """It was hardcoded True in the payload, so the parameter alone would do nothing."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.crop_faces)
+        assert '"largest_only": largest_only,' in src
+        assert '"largest_only": True,' not in src
+
+    def test_the_new_dataset_records_which_mode_produced_it(self):
+        """Two crops of the same photographs differ in what they contain, not just how many —
+        a note saying only the count cannot tell them apart."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.crop_faces)
+        assert "largest only" in src and "every face" in src
+
     def test_an_unconfigured_service_says_so_rather_than_timing_out(self):
         import inspect
         from app.routes import datasets as mod


### PR DESCRIPTION
`"largest_only": True` was hardcoded in the payload to face-crop.

That is right for a set of solo portraits and wrong for the shape a real dataset arrives in. In
a photo of two people, "largest" is whoever stood closer to the camera — so the output silently
interleaves two people. And with no reference the gate scores against the crops' **own mean**,
which for a mixed set is a blend of both faces and cannot separate them.

Now a query parameter, still defaulting to `True`.

For a couples set the working order is: take every face → gate off → remove the wrong people by
hand → run again using the result as the reference. The hand-removal step is a console change;
the API already supports it through `PATCH /datasets/{id}` with a full `images` list.

The new dataset's note records which mode produced it — two crops of the same photographs
differ in *what* they contain, not just how many.

Three tests, including one asserting the parameter actually reaches the payload (a parameter
that never displaced the hardcoded `True` would do nothing).

`882 passed`

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J