### PR TITLE
Keep every crop, and score them against one picked anchor

### DIFF
--- a/alembic/versions/092_dataset_anchor.py
+++ b/alembic/versions/092_dataset_anchor.py
@@ -1,0 +1,34 @@
+"""An anchor image per dataset
+
+Revision ID: 092
+Revises: 091
+Create Date: 2026-09-08
+
+One image in a set, nominated as the face every other image is scored against.
+
+The reference machinery that already existed scored against a whole dataset's MEAN, and that is
+unusable on the sets people actually have. A mean over a set that still contains two people is a
+blend of both and separates neither; with no reference at all the crops are scored against their
+own mean, which only shows they resemble each other. One picked face has no such ambiguity.
+
+A URI rather than an index, because removing an image reorders the list -- an index would
+silently come to mean a different photograph.
+
+Nullable, and no backfill: a dataset without an anchor is the normal state until someone picks
+one, and that is exactly what "no reference" already meant.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "092"
+down_revision = "091"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("datasets", sa.Column("anchor_uri", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("datasets", "anchor_uri")

--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,11 @@ class Settings(BaseSettings):
     # Generous. It is per REQUEST, and a request carries a whole dataset — 50 images at a
     # second or two each on CPU.
     face_crop_timeout_s: int = 300
+    # buffalo_l's same-person floor. Below this against a picked anchor is a different person;
+    # it is shown as a line on the scores rather than used to delete anything, because the two
+    # people who got into this project's training sets got there past a human eye, not past a
+    # number nobody was shown.
+    face_cos_floor: float = 0.4
     a1111_url: str = "http://2070.zero:7860"
     # Unloading is a few seconds of torch teardown. Short, because failing to free the card
     # only costs the caption, which is never fatal to a render.

--- a/app/models.py
+++ b/app/models.py
@@ -424,6 +424,19 @@ class Dataset(Base):
     #: The S3 prefix uploads land in. Recorded rather than derived, because a rename must not
     #: silently point a dataset at a folder that does not exist.
     prefix = mapped_column(String(200), nullable=True)
+    #: ONE IMAGE IN THIS SET, NOMINATED AS THE FACE EVERYTHING ELSE IS SCORED AGAINST.
+    #:
+    #: The alternative already here -- score against a reference DATASET's mean -- is unusable
+    #: on the sets people actually have. A mean over a set that still contains two people is a
+    #: blend of both and separates neither, and with no reference at all the crops are scored
+    #: against their own mean, which only shows they resemble each other.
+    #:
+    #: One picked face has no such ambiguity: "is this the same person as THAT" is the question
+    #: worth asking, and it is answerable from the moment the crops exist.
+    #:
+    #: A URI, not an index. The list is reordered by removal, so an index would silently come
+    #: to mean a different photograph.
+    anchor_uri = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc),
                                onupdate=lambda: datetime.now(timezone.utc))

--- a/app/routes/datasets.py
+++ b/app/routes/datasets.py
@@ -24,7 +24,9 @@ from app.auth import get_current_user, verify_api_key_or_bearer
 from app.config import settings
 from app.database import get_db
 from app.models import Dataset, User
-from app.schemas.datasets import DatasetCreate, DatasetResponse, DatasetUpdate
+from app.schemas.datasets import (
+    DatasetCreate, DatasetResponse, DatasetScore, DatasetScores, DatasetUpdate,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -98,6 +100,13 @@ async def update_dataset(
         ds.notes = body.notes
     if body.images is not None:
         ds.images = body.images
+        # An anchor that was just removed would silently score everything against nothing.
+        if ds.anchor_uri and ds.anchor_uri not in body.images:
+            ds.anchor_uri = None
+    if body.anchor_uri is not None:
+        # "" clears it. None means the field was not sent, which must not clear anything --
+        # the same distinction every other field here makes.
+        ds.anchor_uri = body.anchor_uri or None
     await db.commit()
     await db.refresh(ds)
     return ds
@@ -167,7 +176,7 @@ async def crop_faces(
     dataset_id: uuid.UUID,
     reference_dataset_id: uuid.UUID | None = None,
     gate: bool = True,
-    largest_only: bool = True,
+    largest_only: bool = False,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -177,22 +186,28 @@ async def crop_faces(
     existed only as laptop scripts that ssh'd to the box with insightface. A dataset uploaded in
     the console had no way to become face crops, so the whole flow stopped at step one.
 
-    THE GATE IS ON BY DEFAULT and that is the important half. Detection is easy; telling p@y
-    from someone else in the same photo set is what hand-culling failed at twice, once into a
-    set that had already been culled by eye. Scored against the mean embedding of a reference
-    dataset -- or against the crops' own mean when none is given, which proves internal
-    consistency and nothing more, and is reported as such.
+    Detection is easy; telling p@y from someone else in the same photo set is what hand-culling
+    failed at twice, once into a set that had already been culled by eye. The answer to that is
+    a NUMBER PUT IN FRONT OF THE PERSON CULLING -- see POST /datasets/{id}/score -- not a gate
+    that deletes on a score nobody looked at. An automatic drop still happens when a known-good
+    reference dataset was named, because there the number means something.
 
     Writes a NEW dataset rather than replacing this one. The photographs are the source of truth
     and a crop is derived; overwriting them would make the operation unrepeatable with different
     padding or a different reference.
 
-    `largest_only` DEFAULTS TRUE BUT IS NOT ALWAYS RIGHT. A dataset of solo portraits wants one
-    face per photo. A dataset of couples does not: "largest" is then whoever stood closer to the
-    camera, so the output silently interleaves two people -- and with no reference the gate
-    scores against the crops' own mean, which for a mixed set is a blend of both and cannot
-    separate them. For that shape the working order is: take every face, gate off, remove the
-    wrong people by hand, then run again using the result as the reference.
+    `largest_only` DEFAULTS FALSE: KEEP EVERY FACE.
+
+    It was hardcoded True, which is right only for solo portraits. In a photo of two people
+    "largest" is whoever stood closer to the camera, so the output silently interleaves two
+    people -- and it throws away the other face, which cannot be recovered without cropping
+    again. Keeping everything is the recoverable default: an unwanted crop is one click to
+    remove, a missing one is a re-run.
+
+    THE GATE IS OFF unless something meaningful to score against was given. Scoring a mixed set
+    against its own mean is not a check -- the mean is a blend of everyone in it -- and dropping
+    images on that basis destroys work while looking like diligence. Nominate an anchor
+    (`POST /datasets/{id}/score`) and the number means something.
     """
     ds = await db.get(Dataset, dataset_id)
     if not ds:
@@ -227,17 +242,20 @@ async def crop_faces(
 
     faces = result["faces"]
     floor = result.get("cos_floor", 0.4)
-    # With no reference, score against the crops' own mean. It cannot tell you the set is the
-    # right person -- only that it is internally consistent -- and the note says so.
-    if gate and not ref_embeddings and faces:
-        own = [f.get("embedding") or [] for f in faces]
-        mean = await _mean_via_service(own)
-        for f in faces:
-            f["cos"] = _cos(f.get("embedding") or [], mean)
 
+    # NOTHING IS DROPPED WITHOUT A REAL REFERENCE.
+    #
+    # This used to fall back to the crops' own mean. On a set that still contains two people
+    # that mean is a blend of both: it separates neither, and whichever person happens to be in
+    # the minority scores lower and gets deleted. That is work destroyed by something that looks
+    # like diligence, and it is worse now that every face is kept by default.
+    #
+    # Culling is a person's job, informed by POST /datasets/{id}/score against an anchor they
+    # picked. The gate here is for the case where a known-good set was named.
+    gating = gate and bool(ref_embeddings)
     kept, dropped = [], []
     for f in faces:
-        if gate and f.get("cos") is not None and f["cos"] < floor:
+        if gating and f.get("cos") is not None and f["cos"] < floor:
             dropped.append((ds.images[f["source_index"]], f["cos"]))
         else:
             kept.append(f)
@@ -256,8 +274,8 @@ async def crop_faces(
                          f"{len(result.get('no_face', []))} with none detected, "
                          f"{len(dropped)} below the {floor} floor"
                          + ("" if ref_embeddings else
-                            " (scored against the crops' own mean — internal consistency only, "
-                            "not proof of identity)")))
+                            " — nothing dropped, no reference was given. Pick an anchor and "
+                            "score to see how alike these are.")))
     db.add(out)
     await db.flush()
 
@@ -273,6 +291,79 @@ async def crop_faces(
     logger.info("cropped %s -> %s: %d kept, %d dropped below %.2f",
                 ds.name, out.name, len(uris), len(dropped), floor)
     return out
+
+
+@router.post("/datasets/{dataset_id}/score", response_model=DatasetScores)
+async def score_against_anchor(
+    dataset_id: uuid.UUID,
+    anchor_uri: str | None = None,
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Score every image in a set against ONE image in it, nominated as the anchor.
+
+    THE QUESTION THIS ANSWERS IS THE ONLY ONE WORTH ASKING: is this the same person as that.
+
+    The reference machinery that came first scored against a whole dataset's MEAN, and that does
+    not survive contact with a real set. A mean over images that still contain two people is a
+    blend of both -- it separates neither, and whichever person is in the minority scores lower
+    for no reason but being outnumbered. With no reference at all it scored against the crops'
+    own mean, which shows they resemble each other and nothing else. One picked face has neither
+    problem.
+
+    IT RETURNS NUMBERS; IT DELETES NOTHING. Hand-culling failed twice in this project, but the
+    failure was culling with no information, not culling by hand -- an unlabelled thumbnail of a
+    stranger at a bad angle looks like a bad photo of the right person. A score beside each
+    image fixes that, and leaves the judgement where it belongs. Removing is a separate,
+    reversible click.
+
+    The anchor is remembered on the dataset, so re-scoring after a cull compares against the
+    same face rather than a moving target.
+    """
+    ds = await db.get(Dataset, dataset_id)
+    if not ds:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    if not settings.face_crop_url:
+        raise HTTPException(
+            status_code=503,
+            detail="no face-crop service is configured (face_crop_url is empty)")
+
+    uri = anchor_uri or ds.anchor_uri
+    if not uri:
+        raise HTTPException(status_code=422, detail="pick an anchor image first")
+    if uri not in ds.images:
+        # Most likely it was removed since it was picked. Say which, rather than returning a
+        # set of scores quietly measured against nothing.
+        raise HTTPException(
+            status_code=422,
+            detail="the anchor is not in this dataset — it may have been removed; pick another")
+
+    embeddings = await _embed_all(ds.images)
+    anchor_vec = embeddings[ds.images.index(uri)]
+    if not anchor_vec:
+        raise HTTPException(
+            status_code=422,
+            detail="no face was detected in the anchor image — pick one that is a clear face")
+
+    floor = settings.face_cos_floor
+    scores = [
+        DatasetScore(
+            uri=u,
+            # -2.0 is _cos's "one side had no embedding", which is not a low score but an
+            # absent one. Surfaced as null so the console can say "no face" rather than
+            # rendering it as the worst match in the set.
+            cos=None if not e else round(_cos(e, anchor_vec), 4),
+            is_anchor=(u == uri),
+        )
+        for u, e in zip(ds.images, embeddings)
+    ]
+
+    # Remembered only once it has been shown to work on this set.
+    if ds.anchor_uri != uri:
+        ds.anchor_uri = uri
+        await db.commit()
+
+    return DatasetScores(anchor_uri=uri, cos_floor=floor, scores=scores)
 
 
 async def _embed_all(uris: list[str]) -> list[list[float]]:

--- a/app/schemas/datasets.py
+++ b/app/schemas/datasets.py
@@ -30,6 +30,9 @@ class DatasetUpdate(BaseModel):
     notes: str | None = None
     #: Replaces the list wholesale. Used to reorder or remove; adding is done by uploading.
     images: list[str] | None = None
+    #: The image every other one is scored against. Settable directly so the console can clear
+    #: it, or set it without immediately paying for a scoring pass.
+    anchor_uri: str | None = None
 
 
 class DatasetResponse(BaseModel):
@@ -39,6 +42,7 @@ class DatasetResponse(BaseModel):
     notes: str | None = None
     images: list[str]
     prefix: str | None = None
+    anchor_uri: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 
@@ -47,3 +51,19 @@ class DatasetResponse(BaseModel):
         return len(self.images)
 
     model_config = {"from_attributes": True}
+
+
+class DatasetScore(BaseModel):
+    """One image's likeness to the anchor."""
+    uri: str
+    #: None means no face was detected, which is not a low score but an absent one. The console
+    #: has to say "no face" rather than rendering it as the worst match in the set.
+    cos: float | None = None
+    is_anchor: bool = False
+
+
+class DatasetScores(BaseModel):
+    anchor_uri: str
+    #: buffalo_l's same-person floor. A line on a chart, not a delete rule.
+    cos_floor: float
+    scores: list[DatasetScore]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -125,13 +125,13 @@ class TestCropping:
         assert "out = Dataset(" in src
         assert "ds.images = uris" not in src
 
-    def test_one_face_per_photo_is_the_default_but_is_a_choice(self):
-        """A dataset of couples does not want the largest face: "largest" is then whoever stood
-        closer to the camera, so the output silently interleaves two people."""
+    def test_how_many_faces_to_keep_is_a_choice(self):
+        """A dataset of couples does not want only the largest face: "largest" is then whoever
+        stood closer to the camera, so the output silently interleaves two people. Which way it
+        defaults is asserted in TestKeepEverythingByDefault."""
         import inspect
         from app.routes import datasets as mod
-        sig = inspect.signature(mod.crop_faces)
-        assert sig.parameters["largest_only"].default is True
+        assert "largest_only" in inspect.signature(mod.crop_faces).parameters
 
     def test_the_choice_actually_reaches_the_service(self):
         """It was hardcoded True in the payload, so the parameter alone would do nothing."""
@@ -154,12 +154,15 @@ class TestCropping:
         from app.routes import datasets as mod
         assert "face_crop_url is empty" in inspect.getsource(mod.crop_faces)
 
-    def test_scoring_without_a_reference_is_labelled_as_weak(self):
-        """Against the crops' own mean it proves internal consistency and nothing more — the
-        l@ura set scored 0.931 mean that way and it meant only "the swap held"."""
+    def test_a_crop_with_no_reference_says_nothing_was_dropped(self):
+        """It used to score against the crops' own mean and call that a check — the l@ura set
+        scored 0.931 that way and it meant only "the swap held". Now it drops nothing and the
+        note says why, pointing at the anchor as the thing that would make it meaningful."""
         import inspect
         from app.routes import datasets as mod
-        assert "internal consistency only" in inspect.getsource(mod.crop_faces)
+        src = inspect.getsource(mod.crop_faces)
+        assert "nothing dropped, no reference was given" in src
+        assert "internal consistency only" not in src
 
     def test_everything_failing_the_gate_is_an_error_not_an_empty_dataset(self):
         import inspect
@@ -182,3 +185,122 @@ class TestCropping:
     def test_an_absent_embedding_scores_below_any_floor(self):
         from app.routes.datasets import _cos
         assert _cos([], [1.0]) < 0.4
+
+
+class TestKeepEverythingByDefault:
+    """An unwanted crop is one click to remove; a missing one is a re-run. So the recoverable
+    default is to keep every face, and to delete nothing without something real to score
+    against."""
+
+    def test_every_face_is_kept_by_default(self):
+        import inspect
+        from app.routes import datasets as mod
+        sig = inspect.signature(mod.crop_faces)
+        assert sig.parameters["largest_only"].default is False
+
+    def test_nothing_is_dropped_without_a_reference(self):
+        """It used to fall back to the crops' own mean. On a set that still contains two people
+        that mean is a blend of both, so whichever person is in the minority scores lower for no
+        reason but being outnumbered — and got deleted."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.crop_faces)
+        assert "gating = gate and bool(ref_embeddings)" in src
+
+    def test_the_own_mean_fallback_is_gone_not_just_unused(self):
+        import ast, inspect
+        from app.routes import datasets as mod
+        tree = ast.parse(inspect.getsource(mod.crop_faces).strip())
+        calls = [n.func.id for n in ast.walk(tree)
+                 if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
+        assert "_mean_via_service" not in calls
+
+
+@pytest.mark.asyncio
+class TestTheAnchor:
+    """One picked face, and everything scored against it.
+
+    Scoring against a dataset MEAN does not survive a real set: a mean over images that still
+    contain two people is a blend of both. One face has no such ambiguity.
+    """
+
+    async def _ds(self, db, **kw):
+        from app.models import Dataset
+        base = dict(name=f"set-{uuid.uuid4().hex[:6]}", images=[], prefix="p")
+        base.update(kw)
+        ds = Dataset(**base)
+        db.add(ds)
+        await db.commit()
+        return ds
+
+    async def test_an_anchor_is_remembered_on_the_dataset(self, db):
+        ds = await self._ds(db, images=["s3://b/a.png"], anchor_uri="s3://b/a.png")
+        assert ds.anchor_uri == "s3://b/a.png"
+
+    async def test_removing_the_anchor_clears_it(self, db):
+        """Otherwise the next scoring pass measures against an image that is no longer there."""
+        from app.routes.datasets import update_dataset
+        from app.schemas.datasets import DatasetUpdate
+        ds = await self._ds(db, images=["s3://b/a.png", "s3://b/b.png"],
+                            anchor_uri="s3://b/a.png")
+        out = await update_dataset(ds.id, DatasetUpdate(images=["s3://b/b.png"]),
+                                   _user=None, db=db)
+        assert out.anchor_uri is None
+
+    async def test_removing_something_else_keeps_the_anchor(self, db):
+        from app.routes.datasets import update_dataset
+        from app.schemas.datasets import DatasetUpdate
+        ds = await self._ds(db, images=["s3://b/a.png", "s3://b/b.png"],
+                            anchor_uri="s3://b/a.png")
+        out = await update_dataset(ds.id, DatasetUpdate(images=["s3://b/a.png"]),
+                                   _user=None, db=db)
+        assert out.anchor_uri == "s3://b/a.png"
+
+    async def test_an_absent_field_does_not_clear_the_anchor(self, db):
+        """The same distinction every other field on this route makes."""
+        from app.routes.datasets import update_dataset
+        from app.schemas.datasets import DatasetUpdate
+        ds = await self._ds(db, images=["s3://b/a.png"], anchor_uri="s3://b/a.png")
+        out = await update_dataset(ds.id, DatasetUpdate(tags="x"), _user=None, db=db)
+        assert out.anchor_uri == "s3://b/a.png"
+
+    async def test_an_empty_string_clears_it(self, db):
+        from app.routes.datasets import update_dataset
+        from app.schemas.datasets import DatasetUpdate
+        ds = await self._ds(db, images=["s3://b/a.png"], anchor_uri="s3://b/a.png")
+        out = await update_dataset(ds.id, DatasetUpdate(anchor_uri=""), _user=None, db=db)
+        assert out.anchor_uri is None
+
+    async def test_scoring_refuses_an_anchor_that_is_not_in_the_set(self, db):
+        """Rather than returning scores quietly measured against nothing."""
+        from fastapi import HTTPException
+        from app.routes.datasets import score_against_anchor
+        ds = await self._ds(db, images=["s3://b/a.png"])
+        with pytest.raises(HTTPException) as e:
+            await score_against_anchor(ds.id, anchor_uri="s3://b/gone.png", _user=None, db=db)
+        assert e.value.status_code == 422
+        assert "not in this dataset" in e.value.detail
+
+    async def test_scoring_needs_an_anchor_at_all(self, db):
+        from fastapi import HTTPException
+        from app.routes.datasets import score_against_anchor
+        ds = await self._ds(db, images=["s3://b/a.png"])
+        with pytest.raises(HTTPException) as e:
+            await score_against_anchor(ds.id, _user=None, db=db)
+        assert e.value.status_code == 422
+
+    def test_scoring_deletes_nothing(self):
+        """The failure was culling with NO information, not culling by hand. A score beside each
+        image fixes that and leaves the judgement where it belongs."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.score_against_anchor)
+        assert "db.delete" not in src
+        assert "ds.images =" not in src
+
+    def test_a_missing_face_is_null_not_a_low_score(self):
+        """_cos returns -2.0 for an absent embedding, which would render as the worst match in
+        the set rather than as 'no face'."""
+        import inspect
+        from app.routes import datasets as mod
+        assert "cos=None if not e else" in inspect.getsource(mod.score_against_anchor)


### PR DESCRIPTION
> *"I'd rather it save all crops and I can remove what I don't want. A single photo should be
> able to be selected as anchor or reference pic. All others are scored for likeness against
> it."*

Two changes to the same decision: **who decides which crops are the right person.**

## Keep everything

`largest_only` now defaults `False`. Keeping only the largest face is right for solo portraits
and wrong for the sets people actually have — in a photo of two people "largest" is whoever
stood closer to the camera, and the other face is discarded where nothing can recover it but
cropping again. An unwanted crop is one click to remove; a missing one is a re-run.

## Nothing is dropped without a real reference

The own-mean fallback is **gone, not merely unused** (there is a test asserting the call is not
reachable). On a set that still contains two people that mean is a blend of both: it separates
neither, and whichever person is in the minority scores lower for no reason but being
outnumbered — then gets deleted. Keeping every face by default made that worse.

An automatic drop still happens when a known-good reference dataset was named, because there the
number means something.

## The anchor

`POST /datasets/{id}/score` scores every image against **one image in the set**. That is the only
question worth asking — *is this the same person as that* — and one picked face has none of a
mean's ambiguity.

**It returns numbers and deletes nothing.** Hand-culling failed twice in this project, but the
failure was culling with *no information*, not culling by hand: an unlabelled thumbnail of a
stranger at a bad angle looks like a bad photo of the right person. A score beside it does not.

- Remembered on the row (migration **092**), so re-scoring after a cull compares against the same
  face rather than a moving target.
- **Cleared automatically if the anchor is removed** — otherwise the next pass measures against
  an image that is no longer there.
- A URI, not an index: removal reorders the list, so an index would come to mean a different
  photograph.
- A missing face scores `null`, not `-2.0`, so the console says "no face" rather than rendering
  it as the worst match in the set.

`898 passed`. Migration applied, rolled back and re-applied on a scratch database.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J