### PR TITLE
Training artifacts: presign a PUT, commit after looking, name the final, delete finished runs

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -15,6 +15,7 @@ trainer verbatim. This module could not tell you what rank 32 means, and should 
 """
 import asyncio
 import logging
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -340,15 +341,145 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
         logger.info("created character %s -> %s", job.character, basename)
 
 
+#: Below this a "LoRA" is a truncated upload or an error page. A rank-32 character LoRA is
+#: ~650 MB; letting a tiny one land puts a file in the library that fails at load, inside
+#: somebody's render, days later.
+MIN_ARTIFACT_BYTES = 10 * 1024 * 1024
+
+
+def _artifact_key(job: TrainingJob, epoch: int | None, final: bool) -> str:
+    """Where a checkpoint of this job lives in the LoRA bucket.
+
+    The stem is the one the job was created with, not derived here: stripping `p@y` gives
+    `py`, while the file this project actually renders with is `pay_...` -- a human read `@`
+    as `a`, and no rule produces that.
+
+    `_eNN` for an epoch, `_final` for the checkpoint written when the step count ran out. The
+    trainer writes that one WITHOUT an epoch number, and it is usually a partial epoch -- 1200
+    steps over 27 images is 4.4 epochs, so the final file is the fifth, unfinished pass and
+    also the one with the most training in it. Left unlabelled it was published as a bare
+    `pay_v2.safetensors`, which reads as "the v2" and hides that four other candidates exist.
+    """
+    stem = (job.config or {}).get("lora_name") or _default_lora_name(job.character)
+    tag = "_final" if final else (f"_e{epoch:02d}" if epoch is not None else "")
+    return f"character/{stem}_v{job.version}{tag}.safetensors"
+
+
+def _belongs_to(job: TrainingJob, uri: str) -> bool:
+    """Is this URI one of the names `_artifact_key` can produce for THIS job?
+
+    Anchored on the whole name, not a prefix: `pay_v2` is a prefix of `pay_v20_e01`.
+    """
+    own = f"s3://{settings.s3_loras_bucket}/" + _artifact_key(job, None, False)[:-len(".safetensors")]
+    if not uri.startswith(own):
+        return False
+    return re.fullmatch(r"(_e\d{2}|_final)?\.safetensors", uri[len(own):]) is not None
+
+
+def _record_checkpoint(job: TrainingJob, uri: str) -> None:
+    """One more downloadable checkpoint on the job.
+
+    EVERY EPOCH IS RECORDED, not just the last. Choosing between them is a judgement made by
+    eye at a fixed seed -- loss does not rank them -- so the console has to be able to offer
+    all of them. `output_lora_path` tracks the most recent, which is what the character row
+    points at until someone picks differently.
+
+    ONLY s3:// SURVIVES. The console turns every entry into a download button pointed at
+    GET /files, which can serve an S3 URI and nothing else. Early trainer builds recorded the
+    container-local output path instead of uploading, so a completed job carried entries like
+    `/loras/p@y/ltx23b-v2/output/p@y_v2-000003.comfy.safetensors` -- five buttons on the page
+    and four of them 404. Dropping them here is also the backfill.
+    """
+    existing = [c for c in (job.checkpoints or [])
+                if isinstance(c, str) and c.startswith("s3://")]
+    if uri not in existing:
+        # Reassigned, never appended: JSONB does not see an in-place mutation.
+        job.checkpoints = existing + [uri]
+    job.output_lora_path = uri
+
+
+@router.post("/training/{job_id}/artifact-url", dependencies=[Depends(verify_api_key)])
+async def presign_training_artifact(
+    job_id: uuid.UUID,
+    epoch: int | None = None,
+    final: bool = False,
+    db: AsyncSession = Depends(get_db),
+):
+    """Where to PUT one checkpoint, signed so the trainer needs no AWS credentials.
+
+    THE TRAINER WRITES STRAIGHT TO S3. The multipart `/artifact` endpoint below still works
+    and is what a CLI backfill uses, but it was the wrong shape for the trainer: five 650 MB
+    files, each read whole into the memory of a t3.small and re-sent to S3, one after the
+    other, AFTER training -- so the console showed "running" at 100% for the hour that took,
+    and when two of the five did not survive the trip the job still said "completed" with
+    the final checkpoint missing and the character row pointing at last week's file.
+
+    Two calls: this one for the URL, `/artifact-commit` once the PUT succeeded. The commit is
+    what records the checkpoint, and it checks the object is really there and really a LoRA,
+    so a failed or truncated PUT records nothing.
+    """
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+    if epoch is None and not final:
+        raise HTTPException(status_code=422, detail="say which: epoch=N or final=true")
+    uri = f"s3://{settings.s3_loras_bucket}/{_artifact_key(job, epoch, final)}"
+    try:
+        url = await asyncio.to_thread(s3.generate_presigned_put, uri)
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"could not presign {uri}: {e}") from e
+    return {"uri": uri, "put_url": url, "expires_in": 21600}
+
+
+@router.post("/training/{job_id}/artifact-commit", response_model=TrainingResponse,
+             dependencies=[Depends(verify_api_key)])
+async def commit_training_artifact(
+    job_id: uuid.UUID,
+    uri: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+):
+    """The trainer says a checkpoint landed. Believed only after looking.
+
+    The object has to exist, be big enough to be a LoRA, and belong to THIS job -- a trainer
+    cannot register somebody else's file, or a file outside `character/`, against a run.
+    """
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+    if not _belongs_to(job, uri):
+        raise HTTPException(
+            status_code=422,
+            detail=f"{uri} is not a checkpoint of {job.character} v{job.version}")
+    head = await asyncio.to_thread(s3.head_object, uri)
+    if head is None:
+        raise HTTPException(status_code=409, detail=f"{uri} is not in the bucket — the PUT did not land")
+    if head["Size"] < MIN_ARTIFACT_BYTES:
+        raise HTTPException(
+            status_code=409,
+            detail=f"{uri} is {head['Size']} bytes — a rank-32 character LoRA is ~650 MB, so "
+                   f"this is a truncated upload")
+    _record_checkpoint(job, uri)
+    await db.commit()
+    await db.refresh(job)
+    logger.info("recorded %s (%.0f MB) for %s v%d",
+                uri, head["Size"] / 1024 ** 2, job.character, job.version)
+    return job
+
+
 @router.post("/training/{job_id}/artifact", response_model=TrainingResponse,
              dependencies=[Depends(verify_api_key)])
 async def upload_training_artifact(
     job_id: uuid.UUID,
     lora: UploadFile = File(...),
     epoch: int | None = None,
+    final: bool = False,
     db: AsyncSession = Depends(get_db),
 ):
-    """Publish a finished LoRA.
+    """Publish a finished LoRA, through this API. The CLI and backfill path.
+
+    The trainer no longer uses this -- see `/artifact-url` for why -- but a curl from a
+    laptop with a checkpoint on it still does, and it has to land in the same place with the
+    same name.
 
     THIS ENDPOINT EXISTS BECAUSE POST /upload NEEDS A JWT. A trainer holds the shared worker API
     key and nothing else, so it cannot use the console's upload path. Without this it would need
@@ -376,43 +507,40 @@ async def upload_training_artifact(
         raise HTTPException(status_code=404, detail="Training job not found")
 
     data = await lora.read()
-    # A character LoRA at rank 32 is ~650 MB. Anything tiny is a truncated upload or an error
-    # page, and letting it land would put a file in the library that fails at load, inside
-    # somebody's render, days later.
-    if len(data) < 10 * 1024 * 1024:
+    if len(data) < MIN_ARTIFACT_BYTES:
         raise HTTPException(
             status_code=400,
             detail=f"refusing a {len(data)} byte LoRA — a rank-32 character LoRA is ~650 MB, "
                    f"so this is a truncated upload")
-
-    # The stem the job was created with. Not derived here: stripping `p@y` gives `py`, while
-    # the file this project actually renders with is `pay_...` -- a human read `@` as `a`, and
-    # no rule produces that. The TRIGGER keeps the original either way; that is what trained.
-    stem = (job.config or {}).get("lora_name") or _default_lora_name(job.character)
-    tag = f"_e{epoch:02d}" if epoch is not None else ""
-    key = f"character/{stem}_v{job.version}{tag}.safetensors"
+    key = _artifact_key(job, epoch, final)
     uri = await asyncio.to_thread(s3.upload_bytes, data, key, settings.s3_loras_bucket)
-
-    # EVERY EPOCH IS RECORDED, not just the last. Choosing between them is a judgement made by
-    # eye at a fixed seed -- loss does not rank them -- so the console has to be able to offer
-    # all of them for download. `output_lora_path` tracks the most recent, which is what the
-    # character row points at until someone picks differently.
-    # ONLY s3:// SURVIVES. The console turns every entry into a download button pointed at
-    # GET /files, which can serve an S3 URI and nothing else. Early trainer builds recorded the
-    # container-local output path instead of uploading, so a completed job carries entries like
-    # `/loras/p@y/ltx23b-v2/output/p@y_v2-000003.comfy.safetensors` -- carrying those forward
-    # puts five buttons on the page and four of them 404. Dropping them here is also the
-    # backfill: re-uploading a job's epochs replaces the dead list with the live one.
-    existing = [c for c in (job.checkpoints or [])
-                if isinstance(c, str) and c.startswith("s3://")]
-    if uri not in existing:
-        job.checkpoints = existing + [uri]
-    job.output_lora_path = uri
+    _record_checkpoint(job, uri)
     await db.commit()
     await db.refresh(job)
     logger.info("published %s (%.0f MB) for %s v%d",
                 uri, len(data) / 1024 ** 2, job.character, job.version)
     return job
+
+
+@router.delete("/training/{job_id}", status_code=204)
+async def delete_training_job(
+    job_id: uuid.UUID,
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Take a finished run off the board.
+
+    Terminal jobs only: a live one is cancelled first, so that the trainer working on it
+    still has a row to report to. The LoRAs it published stay in the bucket -- they are
+    library items now, and a character may be pointing at one.
+    """
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+    if job.status not in TRAINING_TERMINAL:
+        raise HTTPException(status_code=409, detail=f"still {job.status} — cancel it first")
+    await db.delete(job)
+    await db.commit()
 
 
 @router.post("/training/{job_id}/cancel", response_model=TrainingResponse)

--- a/app/s3.py
+++ b/app/s3.py
@@ -263,10 +263,36 @@ def generate_presigned_url(uri: str, expires: int = 21600) -> str:
     )
 
 
+def generate_presigned_put(uri: str, expires: int = 21600) -> str:
+    """A presigned PUT for an S3 URI, so a worker with no AWS credentials can write ONE object.
+
+    The trainer's checkpoints are ~650 MB each and there are five or six per run. Routed
+    through this API they were read whole into a t3.small's memory and then re-sent to S3,
+    and the console showed "running" for the extra hour that took; a presigned PUT sends them
+    straight from the GPU box to the bucket, and the API only has to be told when one landed.
+
+    Six hours, the same as the GET: a checkpoint takes ten minutes to cross a home uplink and a
+    retry must not find its URL expired.
+
+    Signed with NO Content-Type. Every header that is part of the signature has to be sent
+    back byte-for-byte, and the uploader is not a browser -- the fewer things it has to get
+    right, the fewer SignatureDoesNotMatch rejections after ten minutes of upload.
+    """
+    bucket, key = parse_s3_uri(uri)
+    client = _client_for_bucket(bucket)
+    return client.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=expires,
+        HttpMethod="PUT",
+    )
+
+
 def head_object(uri: str) -> dict | None:
     """Return {Key, Size, LastModified} for a single S3 object, or None."""
     bucket, key = parse_s3_uri(uri)
-    client = _get_client()
+    # Per-bucket, for the same reason the presigners are: ltx-loras is in another region.
+    client = _client_for_bucket(bucket)
     try:
         resp = client.head_object(Bucket=bucket, Key=key)
         return {

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -16,6 +16,11 @@ from app.routes.training import ORPHANED_TRAINING_MINUTES, _publish_character, _
 from app.schemas.training import TrainingCreate, TrainingProgress
 
 
+def _run_sync(coro):
+    import asyncio
+    return asyncio.run(coro)
+
+
 def _images(n=13):
     return [f"s3://wanly-images/2026-09-07/img{i}.jpg" for i in range(n)]
 
@@ -242,7 +247,7 @@ class TestCharacterNaming:
         import inspect
         from app.routes import training as mod
         assert "lora_name" in inspect.getsource(mod.create_training_job)
-        assert 'get("lora_name")' in inspect.getsource(mod.upload_training_artifact)
+        assert 'get("lora_name")' in inspect.getsource(mod._artifact_key)
 
     def test_the_trigger_never_feeds_the_filename(self):
         """They are different things. The trigger keeps whatever trained."""
@@ -297,10 +302,17 @@ class TestTheLoraFilename:
                                dataset_images=_images())
 
     def test_the_upload_uses_the_stored_stem_not_a_fresh_guess(self):
+        from app.routes.training import _artifact_key
+        job = _job(character="p@y", version=3, config={"lora_name": "pay"})
+        assert _artifact_key(job, 4, False) == "character/pay_v3_e04.safetensors"
+
+    def test_both_upload_paths_name_the_file_the_same_way(self):
+        """The CLI backfill and the trainer's direct PUT must land on identical keys, or a
+        backfilled epoch sits beside the live one under a second name."""
         import inspect
         from app.routes import training as mod
-        src = inspect.getsource(mod.upload_training_artifact)
-        assert 'get("lora_name")' in src
+        assert "_artifact_key(job, epoch, final)" in inspect.getsource(mod.upload_training_artifact)
+        assert "_artifact_key(job, epoch, final)" in inspect.getsource(mod.presign_training_artifact)
 
 
 class TestEveryCheckpointIsOffered:
@@ -309,21 +321,154 @@ class TestEveryCheckpointIsOffered:
     d0ggyff — so a console that only offers the final epoch has thrown the decision away."""
 
     def test_uploading_appends_rather_than_replaces(self):
-        import inspect
-        from app.routes import training as mod
-        src = inspect.getsource(mod.upload_training_artifact)
-        assert "job.checkpoints = existing + [uri]" in src
+        from app.routes.training import _record_checkpoint
+        job = _job(checkpoints=["s3://ltx-loras/character/pay_v1_e01.safetensors"])
+        _record_checkpoint(job, "s3://ltx-loras/character/pay_v1_e02.safetensors")
+        assert job.checkpoints == ["s3://ltx-loras/character/pay_v1_e01.safetensors",
+                                   "s3://ltx-loras/character/pay_v1_e02.safetensors"]
 
     def test_the_same_uri_is_not_recorded_twice(self):
-        import inspect
-        from app.routes import training as mod
-        assert "if uri not in existing:" in inspect.getsource(mod.upload_training_artifact)
+        from app.routes.training import _record_checkpoint
+        job = _job(checkpoints=["s3://ltx-loras/character/pay_v1_e01.safetensors"])
+        _record_checkpoint(job, "s3://ltx-loras/character/pay_v1_e01.safetensors")
+        assert len(job.checkpoints) == 1
 
     def test_output_lora_path_tracks_the_most_recent(self):
         """It is what the character row points at until someone picks differently."""
+        from app.routes.training import _record_checkpoint
+        job = _job()
+        _record_checkpoint(job, "s3://ltx-loras/character/pay_v1_e01.safetensors")
+        _record_checkpoint(job, "s3://ltx-loras/character/pay_v1_final.safetensors")
+        assert job.output_lora_path == "s3://ltx-loras/character/pay_v1_final.safetensors"
+
+    def test_both_upload_paths_record_through_one_function(self):
         import inspect
         from app.routes import training as mod
-        assert "job.output_lora_path = uri" in inspect.getsource(mod.upload_training_artifact)
+        assert "_record_checkpoint(job, uri)" in inspect.getsource(mod.upload_training_artifact)
+        assert "_record_checkpoint(job, uri)" in inspect.getsource(mod.commit_training_artifact)
+
+
+class TestTheFinalCheckpointIsNamed:
+    """The trainer writes the checkpoint at the end of the step count WITHOUT an epoch number.
+    It is usually a partial epoch and it is the one with the most training in it; published
+    as a bare `pay_v2.safetensors` it read as "the v2" and hid that four other candidates
+    existed. The console labelled it with the whole filename."""
+
+    def test_final_gets_its_own_tag(self):
+        from app.routes.training import _artifact_key
+        job = _job(character="p@y", version=2, config={"lora_name": "pay"})
+        assert _artifact_key(job, None, True) == "character/pay_v2_final.safetensors"
+
+    def test_an_epoch_is_zero_padded(self):
+        from app.routes.training import _artifact_key
+        assert _artifact_key(_job(config={"lora_name": "pay"}), 5, False).endswith("_e05.safetensors")
+
+    def test_the_url_endpoint_insists_on_one_or_the_other(self):
+        """A checkpoint with neither an epoch nor `final` would land on the bare name."""
+        from fastapi import HTTPException
+        from app.routes.training import presign_training_artifact
+
+        class _DB:
+            async def get(self, *_a):
+                return _job()
+
+        with pytest.raises(HTTPException) as e:
+            _run_sync(presign_training_artifact(uuid.uuid4(), epoch=None, final=False, db=_DB()))
+        assert e.value.status_code == 422
+
+
+class TestACommitIsBelievedOnlyAfterLooking:
+    """The trainer PUTs straight to S3 and then says so. Saying so must not be enough: a PUT
+    that failed, was truncated, or went to somebody else's key would otherwise put a dead
+    download button on the page -- exactly what this replaces."""
+
+    def _job(self):
+        return _job(character="p@y", version=2, config={"lora_name": "pay"})
+
+    def test_a_uri_of_another_job_is_refused(self):
+        from app.routes.training import _belongs_to
+        job = self._job()
+        assert not _belongs_to(job, "s3://ltx-loras/character/laura_v2_e01.safetensors")
+        assert not _belongs_to(job, "s3://ltx-loras/character/pay_v20_e01.safetensors")
+        assert not _belongs_to(job, "s3://ltx-loras/character/pay_v3_e01.safetensors")
+        assert not _belongs_to(job, "s3://wanly-images/character/pay_v2_e01.safetensors")
+
+    def test_its_own_names_are_accepted(self):
+        from app.routes.training import _belongs_to
+        job = self._job()
+        assert _belongs_to(job, "s3://ltx-loras/character/pay_v2_e01.safetensors")
+        assert _belongs_to(job, "s3://ltx-loras/character/pay_v2_final.safetensors")
+
+    def test_a_put_that_did_not_land_records_nothing(self, monkeypatch):
+        from fastapi import HTTPException
+        from app.routes import training as mod
+        job = self._job()
+        monkeypatch.setattr(mod.s3, "head_object", lambda uri: None)
+
+        class _DB:
+            async def get(self, *_a):
+                return job
+
+        with pytest.raises(HTTPException) as e:
+            _run_sync(mod.commit_training_artifact(
+                job.id, uri="s3://ltx-loras/character/pay_v2_e01.safetensors", db=_DB()))
+        assert e.value.status_code == 409
+        assert not job.checkpoints
+
+    def test_a_truncated_object_records_nothing(self, monkeypatch):
+        from fastapi import HTTPException
+        from app.routes import training as mod
+        job = self._job()
+        monkeypatch.setattr(mod.s3, "head_object", lambda uri: {"Key": "k", "Size": 1234})
+
+        class _DB:
+            async def get(self, *_a):
+                return job
+
+        with pytest.raises(HTTPException) as e:
+            _run_sync(mod.commit_training_artifact(
+                job.id, uri="s3://ltx-loras/character/pay_v2_e01.safetensors", db=_DB()))
+        assert e.value.status_code == 409
+        assert not job.checkpoints
+
+    async def test_a_real_object_is_recorded(self, db, monkeypatch):
+        from app.routes import training as mod
+        job = self._job()
+        db.add(job)
+        await db.commit()
+        monkeypatch.setattr(mod.s3, "head_object",
+                            lambda uri: {"Key": "k", "Size": 650 * 1024 * 1024})
+
+        out = await mod.commit_training_artifact(
+            job.id, uri="s3://ltx-loras/character/pay_v2_final.safetensors", db=db)
+
+        assert out.checkpoints == ["s3://ltx-loras/character/pay_v2_final.safetensors"]
+        assert out.output_lora_path == "s3://ltx-loras/character/pay_v2_final.safetensors"
+
+
+class TestAFinishedRunCanBeDeleted:
+    """Four failed and cancelled p@y rows sat above the one that worked, forever."""
+
+    def test_a_live_job_is_refused(self):
+        from fastapi import HTTPException
+        from app.routes.training import delete_training_job
+        job = _job(status=TrainingStatus.RUNNING)
+
+        class _DB:
+            async def get(self, *_a):
+                return job
+
+        with pytest.raises(HTTPException) as e:
+            _run_sync(delete_training_job(job.id, _user=None, db=_DB()))
+        assert e.value.status_code == 409
+
+    async def test_a_terminal_job_goes(self, db):
+        from app.routes.training import delete_training_job
+        job = _job(status=TrainingStatus.FAILED)
+        db.add(job)
+        await db.commit()
+        await delete_training_job(job.id, _user=None, db=db)
+        assert await db.get(TrainingJob, job.id) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What was wrong

The trainer's checkpoints came through this API as 650 MB multiparts, each read whole into a t3.small's memory and re-sent to S3, one after another, after training. Two of five did not survive the 2026-09-07 p@y v2 run, the job said **completed** anyway, and the final checkpoint was going to land as a bare `pay_v2.safetensors`.

## What this does

- `POST /training/{id}/artifact-url?epoch=N|final=true` signs a PUT for one checkpoint so the trainer writes straight to the bucket with no AWS credentials (same arrangement as the presigned GETs it already gets for the dataset).
- `POST /training/{id}/artifact-commit?uri=` records it, after checking the object exists, is over 10 MB, and is one of *this* job's names (anchored on the whole name, so `pay_v2` does not accept `pay_v20_e01`).
- The unnumbered final checkpoint is published as `_final`.
- `DELETE /training/{id}` takes a finished run off the board (409 while live). The LoRAs stay in the library.
- The multipart `/artifact` endpoint stays for the CLI backfill; both paths share `_artifact_key` and `_record_checkpoint`.
- `head_object` now uses the per-bucket client, because `ltx-loras` is in another region.

Pairs with DavidJBarnes/wanly-services#19 (the trainer side) and DavidJBarnes/wanly-console#463 (the "Use" button and version defaults).

## Verified

- `pytest`: 695 passed, 221 skipped (DB tests run in CI).
- Presigned PUT with a streamed body proven against the real bucket with a 20 MB object; HEAD size matched; object deleted.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW