### PR TITLE
Datasets: id-keyed prefix hidden from the Image Repo, crop in place, rename; deleting a run deletes its LoRAs

### DIFF
--- a/app/routes/datasets.py
+++ b/app/routes/datasets.py
@@ -34,13 +34,20 @@ router = APIRouter()
 IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp"}
 
 
-def _prefix(name: str) -> str:
+#: Every dataset's objects live under this top-level prefix, and the Image Repo does not list
+#: it (see `list_folders`). Datasets used to land in a `dataset-<name>/` folder that showed up
+#: in the repo beside the generation folders, which made it look as if the two were connected
+#: (wanly-console#464). They are not: a dataset is training input, the repo is render input.
+DATASETS_PREFIX = "datasets"
+
+
+def _prefix(ds_id: uuid.UUID) -> str:
     """The S3 folder a dataset's uploads go into.
 
-    Spaces become dashes: a prefix with spaces works but is miserable to type in a URL or read
-    in a listing, and these become part of every image's key forever.
+    Keyed by id, not by name, so a rename is just a rename -- the name was becoming part of
+    every image's key forever, which is why renaming was never offered.
     """
-    return "dataset-" + name.strip().lower().replace(" ", "-")
+    return f"{DATASETS_PREFIX}/{ds_id}"
 
 
 @router.post("/datasets", response_model=DatasetResponse, status_code=201)
@@ -52,15 +59,12 @@ async def create_dataset(
     dupe = (await db.execute(select(Dataset).where(Dataset.name == body.name))).scalar_one_or_none()
     if dupe:
         raise HTTPException(status_code=409, detail=f"a dataset called {body.name!r} already exists")
-    ds = Dataset(user_id=user.id, name=body.name, tags=body.tags, notes=body.notes,
-                 images=[], prefix=_prefix(body.name))
+    ds_id = uuid.uuid4()
+    ds = Dataset(id=ds_id, user_id=user.id, name=body.name, tags=body.tags, notes=body.notes,
+                 images=[], prefix=_prefix(ds_id))
     db.add(ds)
     await db.commit()
     await db.refresh(ds)
-    # The marker is what makes the prefix show up as a folder in the Image Repo before anything
-    # has been uploaded into it. Without it an empty dataset is invisible there.
-    await asyncio.to_thread(s3.upload_bytes, b"", f"{ds.prefix}/.folder",
-                            settings.s3_images_bucket)
     return ds
 
 
@@ -90,10 +94,16 @@ async def update_dataset(
     ds = await db.get(Dataset, dataset_id)
     if not ds:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    if body.name is not None:
+    if body.name is not None and body.name != ds.name:
+        dupe = (await db.execute(
+            select(Dataset).where(Dataset.name == body.name, Dataset.id != ds.id)
+        )).scalar_one_or_none()
+        if dupe:
+            raise HTTPException(status_code=409,
+                                detail=f"a dataset called {body.name!r} already exists")
         ds.name = body.name
-        # The prefix deliberately does NOT follow a rename. Renaming a dataset must not move
-        # objects that other rows -- a finished training job's dataset_images -- point at.
+        # The prefix does not follow a rename: it is keyed by id, and moving objects that a
+        # finished training job's dataset_images point at would break that job's record.
     if body.tags is not None:
         ds.tags = body.tags
     if body.notes is not None:
@@ -174,40 +184,30 @@ async def delete_dataset(
 @router.post("/datasets/{dataset_id}/crop", response_model=DatasetResponse)
 async def crop_faces(
     dataset_id: uuid.UUID,
-    reference_dataset_id: uuid.UUID | None = None,
-    gate: bool = True,
     largest_only: bool = False,
-    user: User = Depends(get_current_user),
+    _user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Turn a dataset of photographs into a dataset of face crops.
+    """Replace this dataset's images with the faces cropped out of them.
 
-    This is steps 2 and 3 of the documented pipeline -- crop, then gate -- which until now
-    existed only as laptop scripts that ssh'd to the box with insightface. A dataset uploaded in
-    the console had no way to become face crops, so the whole flow stopped at step one.
+    IN PLACE. It used to write a second dataset called "<name> faces" and leave this one as
+    it was, on the argument that the photographs are the source of truth and a crop is
+    derived. In use that meant every dataset came in pairs, the one you trained from was
+    never the one you named, and the question "why did cropping make a new dataset?" was
+    asked on the first try (wanly-console#464). The photographs are still in the bucket under
+    the dataset's own prefix, so nothing is destroyed; the dataset simply IS the crops now,
+    which is what anyone cropping wanted.
 
-    Detection is easy; telling p@y from someone else in the same photo set is what hand-culling
-    failed at twice, once into a set that had already been culled by eye. The answer to that is
-    a NUMBER PUT IN FRONT OF THE PERSON CULLING -- see POST /datasets/{id}/score -- not a gate
-    that deletes on a score nobody looked at. An automatic drop still happens when a known-good
-    reference dataset was named, because there the number means something.
+    NO GATE, NO REFERENCE. Cropping used to take a reference dataset and drop faces that
+    scored below the same-person floor against its mean. A mean over a set that still
+    contains two people is a blend of both and separates neither, so the gate was already
+    off unless a reference was named, and the dropdown for naming one was the single most
+    confusing control on the page. Culling is done afterwards, against ONE anchor face the
+    user picks, with the numbers on screen: POST /datasets/{id}/score.
 
-    Writes a NEW dataset rather than replacing this one. The photographs are the source of truth
-    and a crop is derived; overwriting them would make the operation unrepeatable with different
-    padding or a different reference.
-
-    `largest_only` DEFAULTS FALSE: KEEP EVERY FACE.
-
-    It was hardcoded True, which is right only for solo portraits. In a photo of two people
-    "largest" is whoever stood closer to the camera, so the output silently interleaves two
-    people -- and it throws away the other face, which cannot be recovered without cropping
-    again. Keeping everything is the recoverable default: an unwanted crop is one click to
-    remove, a missing one is a re-run.
-
-    THE GATE IS OFF unless something meaningful to score against was given. Scoring a mixed set
-    against its own mean is not a check -- the mean is a blend of everyone in it -- and dropping
-    images on that basis destroys work while looking like diligence. Nominate an anchor
-    (`POST /datasets/{id}/score`) and the number means something.
+    `largest_only` DEFAULTS FALSE: KEEP EVERY FACE. In a photo of two people "largest" is
+    whoever stood closer to the camera. An unwanted crop is one click to remove; a missing
+    one is a re-run.
     """
     ds = await db.get(Dataset, dataset_id)
     if not ds:
@@ -219,20 +219,13 @@ async def crop_faces(
     if not ds.images:
         raise HTTPException(status_code=422, detail="this dataset has no images")
 
-    ref_embeddings: list[list[float]] = []
-    if reference_dataset_id:
-        ref = await db.get(Dataset, reference_dataset_id)
-        if not ref:
-            raise HTTPException(status_code=404, detail="Reference dataset not found")
-        ref_embeddings = await _embed_all(ref.images)
-
     # CONCURRENTLY. Fetched one at a time this was fourteen serial round trips to S3 before any
     # work started; they are independent and the wait is entirely network.
     blobs = await asyncio.gather(
         *(asyncio.to_thread(s3.download_bytes, u) for u in ds.images))
     payload = {
         "images": [base64.b64encode(b).decode() for b in blobs],
-        "reference": ref_embeddings,
+        "reference": [],
         "largest_only": largest_only,
     }
     async with httpx.AsyncClient(timeout=settings.face_crop_timeout_s) as client:
@@ -242,68 +235,41 @@ async def crop_faces(
         except httpx.HTTPError as e:
             raise HTTPException(status_code=503, detail=f"face-crop unreachable: {e}") from e
     result = r.json()
-
     faces = result["faces"]
-    floor = result.get("cos_floor", 0.4)
-
-    # NOTHING IS DROPPED WITHOUT A REAL REFERENCE.
-    #
-    # This used to fall back to the crops' own mean. On a set that still contains two people
-    # that mean is a blend of both: it separates neither, and whichever person happens to be in
-    # the minority scores lower and gets deleted. That is work destroyed by something that looks
-    # like diligence, and it is worse now that every face is kept by default.
-    #
-    # Culling is a person's job, informed by POST /datasets/{id}/score against an anchor they
-    # picked. The gate here is for the case where a known-good set was named.
-    gating = gate and bool(ref_embeddings)
-    kept, dropped = [], []
-    for f in faces:
-        if gating and f.get("cos") is not None and f["cos"] < floor:
-            dropped.append((ds.images[f["source_index"]], f["cos"]))
-        else:
-            kept.append(f)
-    if not kept:
-        raise HTTPException(
-            status_code=422,
-            detail=f"every crop scored below the {floor} same-person floor — "
-                   f"either the reference is wrong or this is not one person")
-
-    name = f"{ds.name} faces"
-    if (await db.execute(select(Dataset).where(Dataset.name == name))).scalar_one_or_none():
-        name = f"{name} {uuid.uuid4().hex[:4]}"
-    out = Dataset(user_id=user.id, name=name, tags=ds.tags, images=[], prefix=_prefix(name),
-                  notes=(f"Cropped from {ds.name}: {len(faces)} faces from {len(ds.images)} "
-                         f"photos ({'largest only' if largest_only else 'every face'}), "
-                         f"{len(result.get('no_face', []))} with none detected, "
-                         f"{len(dropped)} below the {floor} floor"
-                         + ("" if ref_embeddings else
-                            " — nothing dropped, no reference was given. Pick an anchor and "
-                            "score to see how alike these are.")))
-    db.add(out)
-    await db.flush()
+    if not faces:
+        raise HTTPException(status_code=422, detail="no faces were detected in any image")
 
     # THE EXTENSION FOLLOWS WHAT THE SERVICE ACTUALLY SENT. It returns JPEG now, capped at the
     # trainer's resolution ceiling, because full-resolution lossless PNG made an 80 MB response
     # that could not cross a home uplink inside the read timeout. `format` is absent on a
     # face-crop that predates that, and the old contract there was PNG -- so the two repos can
     # deploy in either order.
-    ext = {"jpeg": "jpg"}.get(str(kept[0].get("format", "png")).lower(), "png")
+    ext = {"jpeg": "jpg"}.get(str(faces[0].get("format", "png")).lower(), "png")
+    # A crop batch gets its own sub-folder, so cropping twice cannot overwrite the first
+    # batch's files while a training job still records them.
+    batch = f"{ds.prefix}/faces-{uuid.uuid4().hex[:6]}"
 
     # Uploaded concurrently, for the same reason the fetch is: independent, network-bound, and
     # serial round trips are the whole cost.
     async def put(i: int, f: dict) -> str:
         src = ds.images[f["source_index"]].rsplit("/", 1)[-1].rsplit(".", 1)[0]
-        key = f"{out.prefix}/{i:03d}_{src}_f{f['face_index']}.{ext}"
+        key = f"{batch}/{i:03d}_{src}_f{f['face_index']}.{ext}"
         return await asyncio.to_thread(
             s3.upload_bytes, base64.b64decode(f["png_b64"]), key, settings.s3_images_bucket)
 
-    uris = list(await asyncio.gather(*(put(i, f) for i, f in enumerate(kept))))
-    out.images = uris
+    uris = list(await asyncio.gather(*(put(i, f) for i, f in enumerate(faces))))
+    no_face = len(result.get("no_face", []))
+    note = (f"Cropped {len(faces)} faces from {len(ds.images)} photos "
+            f"({'largest only' if largest_only else 'every face'})"
+            + (f", {no_face} with none detected" if no_face else "") + ".")
+    ds.notes = f"{ds.notes}\n{note}".strip() if ds.notes else note
+    ds.images = uris
+    # The anchor was a photograph; the set is faces now.
+    ds.anchor_uri = None
     await db.commit()
-    await db.refresh(out)
-    logger.info("cropped %s -> %s: %d kept, %d dropped below %.2f",
-                ds.name, out.name, len(uris), len(dropped), floor)
-    return out
+    await db.refresh(ds)
+    logger.info("cropped %s in place: %d faces from %d photos", ds.name, len(uris), len(blobs))
+    return ds
 
 
 @router.post("/datasets/{dataset_id}/score", response_model=DatasetScores)
@@ -386,17 +352,6 @@ async def _embed_all(uris: list[str]) -> list[list[float]]:
         r = await client.post(f"{settings.face_crop_url.rstrip('/')}/embed", json=body)
         r.raise_for_status()
     return r.json()["embeddings"]
-
-
-async def _mean_via_service(embeddings: list[list[float]]) -> list[float]:
-    """The mean is arithmetic, not a model call — done here rather than round-tripping bytes."""
-    usable = [e for e in embeddings if e]
-    if not usable:
-        return []
-    n = len(usable[0])
-    mean = [sum(e[i] for e in usable) / len(usable) for i in range(n)]
-    norm = sum(x * x for x in mean) ** 0.5
-    return [x / norm for x in mean] if norm else []
 
 
 def _cos(a: list[float], b: list[float]) -> float:

--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
 from app.config import settings
+from app.routes.datasets import DATASETS_PREFIX
 from app.database import get_db
 from app.joycaption import CaptionError
 from app.enums import TRAINING_TERMINAL
@@ -207,6 +208,9 @@ async def list_folders():
     """List folders in the images bucket, sorted by creation date newest first."""
     bucket = settings.s3_images_bucket
     prefixes = await asyncio.to_thread(list_common_prefixes, bucket)
+    # Datasets share the bucket but are not repo folders: they are training input, and
+    # listing them here made the two look connected (wanly-console#464).
+    prefixes = [p for p in prefixes if p.rstrip("/") != DATASETS_PREFIX]
 
     async def _folder_info(prefix: str) -> dict:
         name = prefix.rstrip("/")

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -525,20 +525,40 @@ async def upload_training_artifact(
 @router.delete("/training/{job_id}", status_code=204)
 async def delete_training_job(
     job_id: uuid.UUID,
+    purge: bool = True,
     _user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Take a finished run off the board.
+    """Take a finished run off the board, and its LoRA files out of the bucket.
 
     Terminal jobs only: a live one is cancelled first, so that the trainer working on it
-    still has a row to report to. The LoRAs it published stay in the bucket -- they are
-    library items now, and a character may be pointing at one.
+    still has a row to report to.
+
+    THE FILES GO TOO, by default. A deleted run whose checkpoints linger in the library is
+    what someone deleting a run does not expect (wanly-console#464), and a LoRA nobody can
+    trace to a run is a LoRA nobody dares delete later. The one thing that stops it: a
+    character that currently renders with one of these checkpoints. Deleting under it would
+    break every recipe that names the character, so that is refused and says which.
     """
     job = await db.get(TrainingJob, job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Training job not found")
     if job.status not in TRAINING_TERMINAL:
         raise HTTPException(status_code=409, detail=f"still {job.status} — cancel it first")
+    files = [c for c in (job.checkpoints or []) if isinstance(c, str) and c.startswith("s3://")]
+    if purge and files:
+        stems = {f.rsplit("/", 1)[-1].removesuffix(".safetensors") for f in files}
+        using = (await db.execute(
+            select(LtxCharacter).where(LtxCharacter.char_lora.in_(stems))
+        )).scalars().all()
+        if using:
+            names = ", ".join(f"{c.name} ({c.char_lora})" for c in using)
+            raise HTTPException(
+                status_code=409,
+                detail=f"{names} renders with a checkpoint of this run — point the character "
+                       f"at another LoRA first, or delete the run without its files")
+        await asyncio.gather(*(asyncio.to_thread(s3.delete_object, f) for f in files))
+        logger.info("deleted %d checkpoint(s) of %s v%d", len(files), job.character, job.version)
     await db.delete(job)
     await db.commit()
 

--- a/app/s3.py
+++ b/app/s3.py
@@ -161,7 +161,7 @@ def delete_prefix_except(prefix: str, bucket: str, except_uris: set[str]) -> int
 def delete_object(uri: str) -> None:
     """Delete a single object by S3 URI."""
     bucket, key = parse_s3_uri(uri)
-    client = _get_client()
+    client = _client_for_bucket(bucket)
     client.delete_object(Bucket=bucket, Key=key)
     logger.info("Deleted %s/%s", bucket, key)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -25,10 +25,26 @@ class TestNaming:
         with pytest.raises(ValueError):
             DatasetCreate(name=bad)
 
-    def test_the_prefix_is_typeable(self):
-        """Spaces work in S3 and are miserable in a URL or a listing."""
-        assert _prefix("p@y v2 faces") == "dataset-p@y-v2-faces"
+    def test_the_prefix_is_keyed_by_id_under_one_hidden_folder(self):
+        """It used to be `dataset-<name>`, which put every dataset in the Image Repo's folder
+        list beside the generation folders and made the two look connected (console#464).
+        By id, so a rename is just a rename."""
+        import uuid
+        from app.routes.datasets import DATASETS_PREFIX, _prefix
+        i = uuid.uuid4()
+        assert _prefix(i) == f"{DATASETS_PREFIX}/{i}"
 
+    def test_the_image_repo_does_not_list_the_datasets_folder(self):
+        import inspect
+        from app.routes import images as mod
+        src = inspect.getsource(mod.list_folders)
+        assert 'p.rstrip("/") != DATASETS_PREFIX' in src
+
+    def test_a_rename_refuses_a_name_that_exists(self):
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.update_dataset)
+        assert "already exists" in src
 
 class TestTraining:
     def test_a_job_can_name_a_dataset_instead_of_listing_images(self):
@@ -98,37 +114,51 @@ class TestUploadSemantics:
         assert "purge" in src and "if purge" in src
 
     def test_renaming_does_not_move_the_prefix(self):
-        """Objects other rows point at must not move under them."""
+        """A finished training job's dataset_images point at the old keys."""
         import inspect
         from app.routes import datasets as mod
-        assert "does NOT follow a rename" in inspect.getsource(mod.update_dataset)
-
+        src = inspect.getsource(mod.update_dataset)
+        assert "ds.prefix" not in src.split("body.name")[1].split("body.tags")[0]
 
 class TestCropping:
-    """Steps 2 and 3 of the documented pipeline — crop, then gate — which until now existed
-    only as laptop scripts that ssh'd to the box with insightface."""
+    """Step 2 of the documented pipeline, which until now existed only as laptop scripts that
+    ssh'd to the box with insightface."""
 
-    def test_the_gate_is_on_by_default(self):
-        """Detection is easy; telling one person from another in the same photo set is what
-        hand-culling failed at twice, once into a set already culled by eye."""
-        import inspect
-        from app.routes import datasets as mod
-        sig = inspect.signature(mod.crop_faces)
-        assert sig.parameters["gate"].default is True
-
-    def test_it_writes_a_new_dataset_rather_than_replacing(self):
-        """The photographs are the source of truth and a crop is derived. Overwriting them
-        makes the operation unrepeatable with different padding or a different reference."""
+    def test_it_replaces_the_images_in_place(self):
+        """It used to write a second dataset called "<name> faces". Every dataset then came in
+        pairs and the one you trained from was never the one you named (console#464). The
+        photographs stay in the bucket under the dataset's prefix; the dataset IS the crops."""
         import inspect
         from app.routes import datasets as mod
         src = inspect.getsource(mod.crop_faces)
-        assert "out = Dataset(" in src
-        assert "ds.images = uris" not in src
+        assert "ds.images = uris" in src
+        assert "out = Dataset(" not in src
+
+    def test_a_second_crop_cannot_overwrite_the_first_batch(self):
+        """A training job may still record the first batch's keys."""
+        import inspect
+        from app.routes import datasets as mod
+        assert 'faces-{uuid.uuid4().hex[:6]}' in inspect.getsource(mod.crop_faces)
+
+    def test_the_anchor_is_cleared_because_it_was_a_photograph(self):
+        import inspect
+        from app.routes import datasets as mod
+        assert "ds.anchor_uri = None" in inspect.getsource(mod.crop_faces)
+
+    def test_there_is_no_reference_and_no_gate(self):
+        """Scoring a mixed set against a reference dataset's MEAN separates nobody, and the
+        dropdown for naming one was the most confusing control on the page. Culling happens
+        afterwards against ONE anchor, with the numbers on screen."""
+        import inspect
+        from app.routes import datasets as mod
+        params = inspect.signature(mod.crop_faces).parameters
+        assert "reference_dataset_id" not in params
+        assert "gate" not in params
+        assert not hasattr(mod, "_mean_via_service")
 
     def test_how_many_faces_to_keep_is_a_choice(self):
         """A dataset of couples does not want only the largest face: "largest" is then whoever
-        stood closer to the camera, so the output silently interleaves two people. Which way it
-        defaults is asserted in TestKeepEverythingByDefault."""
+        stood closer to the camera, so the output silently interleaves two people."""
         import inspect
         from app.routes import datasets as mod
         assert "largest_only" in inspect.signature(mod.crop_faces).parameters
@@ -141,46 +171,21 @@ class TestCropping:
         assert '"largest_only": largest_only,' in src
         assert '"largest_only": True,' not in src
 
-    def test_the_new_dataset_records_which_mode_produced_it(self):
-        """Two crops of the same photographs differ in what they contain, not just how many —
-        a note saying only the count cannot tell them apart."""
+    def test_the_note_records_which_mode_produced_it(self):
         import inspect
         from app.routes import datasets as mod
         src = inspect.getsource(mod.crop_faces)
-        assert "largest only" in src and "every face" in src
+        assert "largest only" in src and "every face" in src and "with none detected" in src
 
     def test_an_unconfigured_service_says_so_rather_than_timing_out(self):
         import inspect
         from app.routes import datasets as mod
         assert "face_crop_url is empty" in inspect.getsource(mod.crop_faces)
 
-    def test_a_crop_with_no_reference_says_nothing_was_dropped(self):
-        """It used to score against the crops' own mean and call that a check — the l@ura set
-        scored 0.931 that way and it meant only "the swap held". Now it drops nothing and the
-        note says why, pointing at the anchor as the thing that would make it meaningful."""
+    def test_no_faces_at_all_is_an_error_not_an_empty_dataset(self):
         import inspect
         from app.routes import datasets as mod
-        src = inspect.getsource(mod.crop_faces)
-        assert "nothing dropped, no reference was given" in src
-        assert "internal consistency only" not in src
-
-    def test_everything_failing_the_gate_is_an_error_not_an_empty_dataset(self):
-        import inspect
-        from app.routes import datasets as mod
-        assert "either the reference is wrong" in inspect.getsource(mod.crop_faces)
-
-    def test_the_note_records_what_was_dropped(self):
-        """"10 of 38 had no face" is the number that tells you the source set is wrong."""
-        import inspect
-        from app.routes import datasets as mod
-        src = inspect.getsource(mod.crop_faces)
-        assert "with none detected" in src and "below the" in src
-
-    def test_the_mean_is_computed_here_not_round_tripped(self):
-        from app.routes.datasets import _cos, _mean_via_service
-        import asyncio
-        mu = asyncio.run(_mean_via_service([[1.0, 0.0], [0.0, 1.0]]))
-        assert _cos(mu, mu) == pytest.approx(1.0, abs=1e-6)
+        assert "no faces were detected" in inspect.getsource(mod.crop_faces)
 
     def test_an_absent_embedding_scores_below_any_floor(self):
         from app.routes.datasets import _cos
@@ -188,32 +193,13 @@ class TestCropping:
 
 
 class TestKeepEverythingByDefault:
-    """An unwanted crop is one click to remove; a missing one is a re-run. So the recoverable
-    default is to keep every face, and to delete nothing without something real to score
-    against."""
+    """An unwanted crop is one click to remove; a missing one is a re-run."""
 
     def test_every_face_is_kept_by_default(self):
         import inspect
         from app.routes import datasets as mod
         sig = inspect.signature(mod.crop_faces)
         assert sig.parameters["largest_only"].default is False
-
-    def test_nothing_is_dropped_without_a_reference(self):
-        """It used to fall back to the crops' own mean. On a set that still contains two people
-        that mean is a blend of both, so whichever person is in the minority scores lower for no
-        reason but being outnumbered — and got deleted."""
-        import inspect
-        from app.routes import datasets as mod
-        src = inspect.getsource(mod.crop_faces)
-        assert "gating = gate and bool(ref_embeddings)" in src
-
-    def test_the_own_mean_fallback_is_gone_not_just_unused(self):
-        import ast, inspect
-        from app.routes import datasets as mod
-        tree = ast.parse(inspect.getsource(mod.crop_faces).strip())
-        calls = [n.func.id for n in ast.walk(tree)
-                 if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)]
-        assert "_mean_via_service" not in calls
 
 
 @pytest.mark.asyncio

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -449,6 +449,48 @@ class TestACommitIsBelievedOnlyAfterLooking:
 class TestAFinishedRunCanBeDeleted:
     """Four failed and cancelled p@y rows sat above the one that worked, forever."""
 
+    def test_the_files_go_with_it_by_default(self):
+        """A deleted run whose checkpoints linger in the library is what someone deleting a
+        run does not expect (console#464)."""
+        import inspect
+        from app.routes.training import delete_training_job
+        sig = inspect.signature(delete_training_job)
+        assert sig.parameters["purge"].default is True
+        assert "s3.delete_object" in inspect.getsource(delete_training_job)
+
+    async def test_a_character_rendering_with_one_stops_the_purge(self, db, monkeypatch):
+        """Deleting the file under a character breaks every recipe that names it."""
+        from fastapi import HTTPException
+        from app.routes import training as mod
+        job = _job(status=TrainingStatus.COMPLETED,
+                   checkpoints=["s3://ltx-loras/character/pay_v2_final.safetensors"])
+        db.add(job)
+        db.add(LtxCharacter(name="p@y", char_lora="pay_v2_final", trigger="p@y"))
+        await db.commit()
+        deleted = []
+        monkeypatch.setattr(mod.s3, "delete_object", lambda uri: deleted.append(uri))
+
+        with pytest.raises(HTTPException) as e:
+            await mod.delete_training_job(job.id, purge=True, _user=None, db=db)
+        assert e.value.status_code == 409
+        assert "p@y" in e.value.detail
+        assert deleted == []
+        assert await db.get(TrainingJob, job.id) is not None
+
+    async def test_otherwise_the_files_are_deleted(self, db, monkeypatch):
+        from app.routes import training as mod
+        uris = ["s3://ltx-loras/character/pay_v2_e01.safetensors",
+                "s3://ltx-loras/character/pay_v2_final.safetensors"]
+        job = _job(status=TrainingStatus.COMPLETED, checkpoints=uris)
+        db.add(job)
+        await db.commit()
+        deleted = []
+        monkeypatch.setattr(mod.s3, "delete_object", lambda uri: deleted.append(uri))
+
+        await mod.delete_training_job(job.id, purge=True, _user=None, db=db)
+        assert sorted(deleted) == sorted(uris)
+        assert await db.get(TrainingJob, job.id) is None
+
     def test_a_live_job_is_refused(self):
         from fastapi import HTTPException
         from app.routes.training import delete_training_job
@@ -459,7 +501,7 @@ class TestAFinishedRunCanBeDeleted:
                 return job
 
         with pytest.raises(HTTPException) as e:
-            _run_sync(delete_training_job(job.id, _user=None, db=_DB()))
+            _run_sync(delete_training_job(job.id, purge=True, _user=None, db=_DB()))
         assert e.value.status_code == 409
 
     async def test_a_terminal_job_goes(self, db):
@@ -467,7 +509,7 @@ class TestAFinishedRunCanBeDeleted:
         job = _job(status=TrainingStatus.FAILED)
         db.add(job)
         await db.commit()
-        await delete_training_job(job.id, _user=None, db=db)
+        await delete_training_job(job.id, purge=False, _user=None, db=db)
         assert await db.get(TrainingJob, job.id) is None
 
 


### PR DESCRIPTION
The API half of wanly-console#464.

- **#2 (datasets show up in the Image Repo):** uploads now land under `datasets/<id>/` and `GET /images/folders` does not list that prefix. Keyed by id, so renaming moves nothing. Existing datasets keep their old `dataset-<name>` prefix and still work; only the one test dataset exists today.
- **#1 (rename):** `PATCH /datasets/{id}` with `name` already worked; it now refuses a duplicate name with a 409 instead of a 500. The console gets the control in DavidJBarnes/wanly-console#465.
- **#5 (crop makes a new dataset):** `POST /datasets/{id}/crop` replaces the dataset's images in place. Each crop batch goes in its own sub-folder so a re-crop cannot overwrite files a training job recorded. The anchor is cleared (it was a photograph).
- **#6 (crop dialog's dropdown):** the reference dataset and gate parameters are removed; culling is the anchor scoring that already exists.
- **#8 (deleting a training should remove the safetensors):** `DELETE /training/{id}` purges the run's checkpoints by default and refuses with a 409 naming the character when one renders with a checkpoint of the run.
- `delete_object` uses the per-bucket client (ltx-loras is in another region).

`pytest`: 695 passed.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW