### PR TITLE
Training: loss curve, every epoch on record, publish on demand, and a face for the LoRA

### DIFF
--- a/alembic/versions/093_training_loss_epochs_thumbnail.py
+++ b/alembic/versions/093_training_loss_epochs_thumbnail.py
@@ -1,0 +1,41 @@
+"""Loss curve, per-epoch checkpoints, publish-on-demand, and a face for the LoRA
+
+Revision ID: 093
+Revises: 092
+Create Date: 2026-09-08
+
+Three things asked for after the first end-to-end run (wanly-console#464 follow-up):
+
+  loss_log          [[step, avr_loss], ...] as the trainer reports it, so the console can draw it.
+  epochs            [{label, step, loss}, ...] -- every checkpoint the run wrote, published or
+                    not. Only the final one is uploaded by default; the others sit on the
+                    trainer until asked for.
+  publish_requests  [label, ...] the user asked to have uploaded after the fact.
+  thumbnail_uri     the dataset's anchor image at creation, so the LoRA has a face.
+
+  ltx_characters.image_uri  the same face, on the character, set when a run publishes.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "093"
+down_revision = "092"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("training_jobs", sa.Column("loss_log", JSONB(), nullable=True))
+    op.add_column("training_jobs", sa.Column("epochs", JSONB(), nullable=True))
+    op.add_column("training_jobs", sa.Column("publish_requests", JSONB(), nullable=True))
+    op.add_column("training_jobs", sa.Column("thumbnail_uri", sa.Text(), nullable=True))
+    op.add_column("ltx_characters", sa.Column("image_uri", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("ltx_characters", "image_uri")
+    op.drop_column("training_jobs", "thumbnail_uri")
+    op.drop_column("training_jobs", "publish_requests")
+    op.drop_column("training_jobs", "epochs")
+    op.drop_column("training_jobs", "loss_log")

--- a/app/models.py
+++ b/app/models.py
@@ -511,6 +511,19 @@ class TrainingJob(Base):
     checkpoints = mapped_column(JSONB, nullable=True)
     # The s3:// URI of the installed LoRA, once one is chosen.
     output_lora_path = mapped_column(Text, nullable=True)
+    # [[step, avr_loss], ...] sampled from the trainer's progress bar every report. Small --
+    # a report every 20 s over an hour is under two hundred points -- and it is what lets
+    # the console draw the curve rather than print the last number.
+    loss_log = mapped_column(JSONB, nullable=True)
+    # Every checkpoint the run WROTE, as [{label, step, loss}], published or not. Only the
+    # final one is uploaded by default: a 650 MB checkpoint takes ~18 minutes to leave the
+    # 3090, and "I often only want 1 or 2 epochs". The rest sit on the trainer until asked
+    # for through publish_requests, and `checkpoints` records the ones that arrived.
+    epochs = mapped_column(JSONB, nullable=True)
+    publish_requests = mapped_column(JSONB, nullable=True)
+    # The dataset's anchor image at creation -- the face this LoRA is of, for the console
+    # and for the character row it publishes to.
+    thumbnail_uri = mapped_column(Text, nullable=True)
 
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     claimed_at = mapped_column(DateTime(timezone=True), nullable=True)
@@ -538,6 +551,9 @@ class LtxCharacter(Base):
     # is a different configuration, not a simplification.
     strength_stage_1 = mapped_column(Float, nullable=False, server_default="0.8")
     strength_stage_2 = mapped_column(Float, nullable=False, server_default="1.5")
+    # A face for the LoRA: the anchor image of the dataset that trained it. Set when a
+    # training run publishes to this character, editable like everything else here.
+    image_uri = mapped_column(Text, nullable=True)
     created_at = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     # passive_deletes leaves the cascade to the database, where the FK already declares

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -80,11 +80,14 @@ async def create_training_job(
     # A dataset is the normal path; a raw list stays supported so a CLI or a curl can train
     # without creating one first.
     images = list(body.dataset_images)
+    thumbnail = None
     if body.dataset_id:
         ds = await db.get(Dataset, body.dataset_id)
         if not ds:
             raise HTTPException(status_code=404, detail="Dataset not found")
         images = list(ds.images)
+        # The anchor is the face the set was checked against; failing that, the first image.
+        thumbnail = ds.anchor_uri or (ds.images[0] if ds.images else None)
     # Checked here rather than on the schema, because it applies to whichever of the two was
     # given -- a schema minimum on dataset_images would reject every dataset_id request.
     if len(images) < MIN_DATASET_IMAGES:
@@ -116,9 +119,11 @@ async def create_training_job(
         version=body.version,
         dataset_images=images,
         config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": body.caption,
-                "lora_name": body.lora_name or _default_lora_name(body.character)},
+                "lora_name": body.lora_name or _default_lora_name(body.character),
+                "publish": body.publish},
         status=TrainingStatus.PENDING,
         total_steps=body.steps,
+        thumbnail_uri=thumbnail,
     )
     db.add(job)
     await db.commit()
@@ -285,7 +290,7 @@ async def update_training_job(
         raise HTTPException(status_code=404, detail="Training job not found")
 
     for field in ("progress_log", "step", "total_steps", "error_message",
-                  "checkpoints", "output_lora_path"):
+                  "checkpoints", "output_lora_path", "loss_log", "epochs"):
         value = getattr(body, field)
         if value is not None:
             setattr(job, field, value)
@@ -335,9 +340,12 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
     if existing:
         existing.char_lora = basename
         existing.trigger = job.trigger
+        if job.thumbnail_uri:
+            existing.image_uri = job.thumbnail_uri
         logger.info("character %s now points at %s", job.character, basename)
     else:
-        db.add(LtxCharacter(name=job.character, char_lora=basename, trigger=job.trigger))
+        db.add(LtxCharacter(name=job.character, char_lora=basename, trigger=job.trigger,
+                            image_uri=job.thumbnail_uri))
         logger.info("created character %s -> %s", job.character, basename)
 
 
@@ -519,6 +527,35 @@ async def upload_training_artifact(
     await db.refresh(job)
     logger.info("published %s (%.0f MB) for %s v%d",
                 uri, len(data) / 1024 ** 2, job.character, job.version)
+    return job
+
+
+@router.post("/training/{job_id}/publish", response_model=TrainingResponse)
+async def request_publish(
+    job_id: uuid.UUID,
+    label: str = Query(..., pattern=r"^(e\d{2}|final)$"),
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Ask for a checkpoint that stayed on the trainer to be uploaded after all.
+
+    Only the final checkpoint goes up by default ("I often only want 1 or 2 epochs"); the
+    rest sit in the run directory on the GPU box. The trainer polls its finished jobs for
+    this list and uploads what it finds, the same way as during a run.
+    """
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+    if not any(e.get("label") == label for e in (job.epochs or [])):
+        raise HTTPException(status_code=404, detail=f"this run has no checkpoint {label}")
+    tag = f"_{label}.safetensors"
+    if any(c.endswith(tag) for c in (job.checkpoints or [])):
+        raise HTTPException(status_code=409, detail=f"{label} is already in the bucket")
+    wanted = list(job.publish_requests or [])
+    if label not in wanted:
+        job.publish_requests = wanted + [label]
+        await db.commit()
+        await db.refresh(job)
     return job
 
 

--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -16,6 +16,7 @@ class LtxCharacterCreate(BaseModel):
     # Per-stage, never flat — stage 1 decides the body, stage 2 resolves the face.
     strength_stage_1: float = 0.8
     strength_stage_2: float = 1.5
+    image_uri: Optional[str] = None
 
 
 class LtxCharacterResponse(BaseModel):
@@ -27,6 +28,7 @@ class LtxCharacterResponse(BaseModel):
     trigger: str
     strength_stage_1: float
     strength_stage_2: float
+    image_uri: Optional[str] = None
 
 
 class LtxCharacterUpdate(BaseModel):
@@ -43,6 +45,7 @@ class LtxCharacterUpdate(BaseModel):
     trigger: Optional[str] = Field(default=None, min_length=1, max_length=64)
     strength_stage_1: Optional[float] = Field(default=None, ge=0)
     strength_stage_2: Optional[float] = Field(default=None, ge=0)
+    image_uri: Optional[str] = None
 
 
 class ContentLora(BaseModel):

--- a/app/schemas/training.py
+++ b/app/schemas/training.py
@@ -13,6 +13,8 @@ look up a STALE one.
 import uuid
 from datetime import datetime
 
+from typing import Literal
+
 from pydantic import BaseModel, Field, field_validator
 
 from app.enums import TrainingStatus
@@ -60,6 +62,11 @@ class TrainingCreate(BaseModel):
     #: a guess made silently at upload time.
     lora_name: str | None = Field(default=None, max_length=64,
                                   pattern=r"^[A-Za-z0-9._-]+$")
+    #: Which checkpoints to upload as they are written. "final" is the default: a 650 MB
+    #: checkpoint takes ~18 minutes to leave the 3090 and a five-epoch run's uploads
+    #: outlast the training, for epochs that mostly go unused. "all" uploads every one.
+    #: Either way every epoch stays on the trainer and can be published afterwards.
+    publish: Literal["final", "all"] = "final"
 
     @field_validator("character")
     @classmethod
@@ -98,6 +105,12 @@ class TrainingResponse(BaseModel):
     error_message: str | None = None
     checkpoints: list | None = None
     output_lora_path: str | None = None
+    loss_log: list | None = None
+    epochs: list | None = None
+    loss_log: list | None = None
+    epochs: list | None = None
+    publish_requests: list | None = None
+    thumbnail_uri: str | None = None
     created_at: datetime | None = None
     claimed_at: datetime | None = None
     completed_at: datetime | None = None
@@ -128,3 +141,5 @@ class TrainingProgress(BaseModel):
     error_message: str | None = None
     checkpoints: list | None = None
     output_lora_path: str | None = None
+    loss_log: list | None = None
+    epochs: list | None = None

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -616,3 +616,90 @@ class TestCancellingActuallyCancels:
 
         assert out.status == TrainingStatus.RUNNING
         assert out.step == 7
+
+
+class TestOnlyTheFinalGoesUpByDefault:
+    """A 650 MB checkpoint takes ~18 minutes to leave the 3090 and "I often only want 1 or 2
+    epochs". Every epoch stays on the trainer; the rest are asked for."""
+
+    def test_the_default_policy_is_final(self):
+        req = TrainingCreate(character="p@y", trigger="p@y", dataset_images=_images())
+        assert req.publish == "final"
+
+    def test_all_is_the_other_choice_and_nothing_else_is(self):
+        assert TrainingCreate(character="p@y", trigger="p@y", dataset_images=_images(),
+                              publish="all").publish == "all"
+        with pytest.raises(ValueError):
+            TrainingCreate(character="p@y", trigger="p@y", dataset_images=_images(),
+                           publish="some")
+
+    def test_the_policy_reaches_the_job_config(self):
+        import inspect
+        from app.routes import training as mod
+        assert '"publish": body.publish' in inspect.getsource(mod.create_training_job)
+
+    async def test_a_publish_request_is_recorded_once(self, db):
+        from app.routes.training import request_publish
+        job = _job(status=TrainingStatus.COMPLETED,
+                   epochs=[{"label": "e01", "step": 80, "loss": 0.7},
+                           {"label": "final", "step": 100, "loss": 0.68}],
+                   checkpoints=["s3://ltx-loras/character/pay_v1_final.safetensors"])
+        db.add(job)
+        await db.commit()
+        out = await request_publish(job.id, label="e01", _user=None, db=db)
+        out = await request_publish(job.id, label="e01", _user=None, db=db)
+        assert out.publish_requests == ["e01"]
+
+    async def test_a_checkpoint_the_run_never_wrote_is_refused(self, db):
+        from fastapi import HTTPException
+        from app.routes.training import request_publish
+        job = _job(status=TrainingStatus.COMPLETED, epochs=[{"label": "final", "step": 100}])
+        db.add(job)
+        await db.commit()
+        with pytest.raises(HTTPException) as e:
+            await request_publish(job.id, label="e07", _user=None, db=db)
+        assert e.value.status_code == 404
+
+    async def test_one_already_in_the_bucket_is_refused(self, db):
+        from fastapi import HTTPException
+        from app.routes.training import request_publish
+        job = _job(status=TrainingStatus.COMPLETED, epochs=[{"label": "final", "step": 100}],
+                   checkpoints=["s3://ltx-loras/character/pay_v1_final.safetensors"])
+        db.add(job)
+        await db.commit()
+        with pytest.raises(HTTPException) as e:
+            await request_publish(job.id, label="final", _user=None, db=db)
+        assert e.value.status_code == 409
+
+
+class TestTheLoraHasAFace:
+    async def test_the_dataset_anchor_is_snapshotted_at_creation(self, db):
+        from app.models import Dataset
+        from app.routes.training import create_training_job
+        ds = Dataset(name="faces", images=_images(), anchor_uri=_images()[3], prefix="x")
+        db.add(ds)
+        await db.commit()
+
+        class _U:
+            id = None
+            username = "t"
+        job = await create_training_job(
+            TrainingCreate(character="p@y", trigger="p@y", dataset_id=ds.id), user=_U(), db=db)
+        assert job.thumbnail_uri == _images()[3]
+
+    async def test_publishing_puts_the_face_on_the_character(self, db):
+        job = _job(character="p@y", output_lora_path="s3://ltx-loras/character/pay_v3_final.safetensors",
+                   thumbnail_uri="s3://wanly-images/datasets/x/anchor.jpg")
+        await _publish_character(db, job)
+        await db.commit()
+        from sqlalchemy import select
+        c = (await db.execute(select(LtxCharacter).where(LtxCharacter.name == "p@y"))).scalar_one()
+        assert c.image_uri == "s3://wanly-images/datasets/x/anchor.jpg"
+
+    def test_a_progress_report_can_carry_the_curve_and_the_epochs(self):
+        p = TrainingProgress(loss_log=[[10, 0.9], [20, 0.8]],
+                             epochs=[{"label": "e01", "step": 80, "loss": 0.7}])
+        assert p.loss_log[-1] == [20, 0.8]
+        import inspect
+        from app.routes import training as mod
+        assert '"loss_log", "epochs"' in inspect.getsource(mod.update_training_job)


### PR DESCRIPTION
The API half of three requests from the first end-to-end run:

1. **Only upload the epochs you want.** `TrainingCreate.publish` is `"final"` (default) or `"all"`. Every epoch the run writes is recorded on the job as `epochs` (label, step, loss) whether uploaded or not; `POST /training/{id}/publish?label=e03` asks for one that stayed on the trainer, and the trainer polls its finished jobs for `publish_requests` (DavidJBarnes/wanly-services#22).
2. **Loss.** `loss_log` is `[[step, avr_loss], ...]` as the trainer reports it.
3. **The anchor as the LoRA's face.** `thumbnail_uri` is snapshotted from the dataset's anchor (or first image) at creation, and copied to the new `ltx_characters.image_uri` when the run publishes.

Migration 093 adds the five columns. `pytest`: 699 passed.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW