### PR TITLE
A purge that cannot delete its files says what the role needs, and keeps the row

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -594,7 +594,18 @@ async def delete_training_job(
                 status_code=409,
                 detail=f"{names} renders with a checkpoint of this run — point the character "
                        f"at another LoRA first, or delete the run without its files")
-        await asyncio.gather(*(asyncio.to_thread(s3.delete_object, f) for f in files))
+        try:
+            await asyncio.gather(*(asyncio.to_thread(s3.delete_object, f) for f in files))
+        except Exception as e:
+            # The role needs s3:DeleteObject on ltx-loras/character/*, which it did not have
+            # the first time this ran -- the read policy is read-only by name and the write
+            # policy granted PutObject alone. A 500 here left the row in place and said
+            # nothing; say what is needed instead.
+            raise HTTPException(
+                status_code=503,
+                detail=f"could not delete the LoRA files ({type(e).__name__}: {e}); the run "
+                       f"is still here. The API's role needs s3:DeleteObject on the "
+                       f"character/ prefix.") from e
         logger.info("deleted %d checkpoint(s) of %s v%d", len(files), job.character, job.version)
     await db.delete(job)
     await db.commit()

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -477,6 +477,23 @@ class TestAFinishedRunCanBeDeleted:
         assert deleted == []
         assert await db.get(TrainingJob, job.id) is not None
 
+    async def test_a_file_that_cannot_be_deleted_keeps_the_row_and_says_why(self, db, monkeypatch):
+        """It 500'd in production: the role had PutObject on character/* and not DeleteObject."""
+        from fastapi import HTTPException
+        from app.routes import training as mod
+        job = _job(status=TrainingStatus.COMPLETED,
+                   checkpoints=["s3://ltx-loras/character/pay_v2_final.safetensors"])
+        db.add(job)
+        await db.commit()
+
+        def denied(uri):
+            raise PermissionError("AccessDenied")
+        monkeypatch.setattr(mod.s3, "delete_object", denied)
+        with pytest.raises(HTTPException) as e:
+            await mod.delete_training_job(job.id, purge=True, _user=None, db=db)
+        assert e.value.status_code == 503 and "DeleteObject" in e.value.detail
+        assert await db.get(TrainingJob, job.id) is not None
+
     async def test_otherwise_the_files_are_deleted(self, db, monkeypatch):
         from app.routes import training as mod
         uris = ["s3://ltx-loras/character/pay_v2_e01.safetensors",


### PR DESCRIPTION
Found deleting the smoke run from the console: `DELETE /training/{id}?purge=true` 500'd because the EC2 role's `s3-ltx-loras-write-character` policy granted `s3:PutObject` only. `s3:DeleteObject` on `ltx-loras/character/*` is granted now (same inline policy, same prefix). This PR makes the failure a 503 that names the permission and leaves the row in place, instead of a bare 500.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW