### PR TITLE
A run publishes its character with the LoRA stem, not the filename

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -333,7 +333,11 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
     """
     if not job.output_lora_path:
         return
-    basename = job.output_lora_path.rsplit("/", 1)[-1]
+    # THE STEM, NOT THE FILENAME. Every character row stores `pay_v2_e05`, the console's Use
+    # button writes the stem, and the character editor says "without .safetensors" -- the
+    # first auto-published character stored `david_v1_final.safetensors` and the page could
+    # not tell it was in use.
+    basename = job.output_lora_path.rsplit("/", 1)[-1].removesuffix(".safetensors")
     existing = (await db.execute(
         select(LtxCharacter).where(LtxCharacter.name == job.character)
     )).scalar_one_or_none()

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -169,7 +169,7 @@ class TestPublishing:
         from sqlalchemy import select
         row = (await db.execute(select(LtxCharacter).where(
             LtxCharacter.name == "pay"))).scalar_one()
-        assert row.char_lora == "pay_v1_e05.safetensors"
+        assert row.char_lora == "pay_v1_e05"
         assert row.trigger == "p@y"
 
     async def test_retraining_repoints_the_existing_character(self, db):
@@ -183,7 +183,7 @@ class TestPublishing:
         from sqlalchemy import select
         row = (await db.execute(select(LtxCharacter).where(
             LtxCharacter.name == "pay"))).scalar_one()
-        assert row.char_lora == "pay_v2_e03.safetensors"
+        assert row.char_lora == "pay_v2_e03"
         assert row.strength_stage_1 == 0.9, "hand-tuned strengths were overwritten"
 
     async def test_nothing_is_published_without_a_file(self, db):
@@ -268,7 +268,7 @@ class TestCharacterNaming:
         rows = (await db.execute(select(LtxCharacter).where(
             LtxCharacter.name == "p@y"))).scalars().all()
         assert len(rows) == 1
-        assert rows[0].char_lora == "pay_v3_e04.safetensors"
+        assert rows[0].char_lora == "pay_v3_e04"
 
 
 class TestTheLoraFilename:
@@ -687,6 +687,17 @@ class TestOnlyTheFinalGoesUpByDefault:
         with pytest.raises(HTTPException) as e:
             await request_publish(job.id, label="final", _user=None, db=db)
         assert e.value.status_code == 409
+
+
+class TestThePublishedCharacterStoresTheStem:
+    async def test_no_extension_on_the_row(self, db):
+        """Every other row stores `pay_v2_e05`; the console compares stems."""
+        job = _job(character="Me", output_lora_path="s3://ltx-loras/character/david_v1_final.safetensors")
+        await _publish_character(db, job)
+        await db.commit()
+        from sqlalchemy import select
+        c = (await db.execute(select(LtxCharacter).where(LtxCharacter.name == "Me"))).scalar_one()
+        assert c.char_lora == "david_v1_final"
 
 
 class TestTheLoraHasAFace:


### PR DESCRIPTION
Seen on the first real run: the auto-created `Me` character stored `david_v1_final.safetensors`, where every other row stores the bare stem (`pay_v2_e05`) and the console compares stems, so the page could not mark the checkpoint as in use. The row is corrected by hand; this fixes the publisher and the three tests that had asserted the extension.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW