### PR TITLE
Re-roll can override or drop the negative prompt

### DIFF
--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -1485,8 +1485,17 @@ async def cancel_segment(
     return segment
 
 
-def _recipe_for_take(old: Segment, prompt: str | None) -> dict | None:
-    """The outgoing take's recipe, marked if this roll changed the prompt.
+# Sentinel for "the re-roll request said nothing about the negative prompt". A distinct
+# object rather than None, because None is a REAL value here: the restored-to-default state
+# an explicit empty string asks for (console#449). A plain object() rather than a class
+# instance, because test_chain_seed reads this module as AST, and a module-level call to a
+# private name would read as a call to a definition that does not exist.
+_COPY = object()
+
+
+def _recipe_for_take(old: Segment, prompt: str | None,
+                     negative: str | None | object = _COPY) -> dict | None:
+    """The outgoing take's recipe, marked if this roll changed the prompt or the negative.
 
     A re-roll's premise is that the seed is the ONLY difference, which is what makes two takes
     comparable. Changing the prompt deliberately breaks that — and six takes later nothing
@@ -1497,15 +1506,25 @@ def _recipe_for_take(old: Segment, prompt: str | None) -> dict | None:
     which of a pose's defaults the user overrode. A copy, never a mutation — the archived take
     and its replacement share the dict otherwise, and marking one would rewrite the record of
     the other.
+
+    The negative is measured AFTER translation: a supplied empty string becomes the restored
+    NULL, and restoring when the archived take already had NULL is a no-op — nothing changed,
+    so nothing is marked.
     """
     recipe = old.ltx_recipe
-    if recipe is None or prompt is None or prompt == old.prompt:
+    codes = []
+    if prompt is not None and prompt != old.prompt:
+        codes.append("prompt")
+    if negative is not _COPY and negative != old.negative_prompt:
+        codes.append("negative")
+    if recipe is None or not codes:
         return recipe
-    return {**recipe, "edited": sorted({*(recipe.get("edited") or []), "prompt"})}
+    return {**recipe, "edited": sorted({*(recipe.get("edited") or []), *codes})}
 
 
 def _roll_new_take(job: Job, old: Segment, *, prompt: str | None = None,
-                   prompt_template: str | None = None) -> Segment:
+                   prompt_template: str | None = None,
+                   negative_prompt: str | None | object = _COPY) -> Segment:
     """Archive `old` and build its replacement.
 
     Was shared by a user-initiated re-roll and an automatic rule-driven one; the rule-driven
@@ -1575,11 +1594,14 @@ def _roll_new_take(job: Job, old: Segment, *, prompt: str | None = None,
         duration_seconds=old.duration_seconds,
         speed=old.speed,
         start_image=old.start_image,
-        negative_prompt=old.negative_prompt,
+        # Absent (the sentinel): the archived take's value, verbatim, which is what re-roll
+        # has always done. Provided: the request's value — including None from an explicit
+        # empty string, which is the deliberate "back to the live default" of console#449.
+        negative_prompt=old.negative_prompt if negative_prompt is _COPY else negative_prompt,
         # The recipe is what the take IS. Without it a re-rolled LTX segment renders free-form
         # — no character LoRA, no trigger, no per-stage strengths — and comes back looking like
         # a different shot, which is the opposite of a re-roll's entire purpose.
-        ltx_recipe=_recipe_for_take(old, prompt),
+        ltx_recipe=_recipe_for_take(old, prompt, negative_prompt),
         auto_finalize=old.auto_finalize,
     )
 
@@ -1593,7 +1615,7 @@ _REROLL_REFUSED_STATUSES = (JobStatus.FINALIZED, JobStatus.FINALIZING, JobStatus
 
 
 async def _reroll(db: AsyncSession, job: Job, old: Segment,
-                  prompt: str | None) -> Segment:
+                  prompt: str | None, negative_prompt: str | None = None) -> Segment:
     """Archive `old` and queue a fresh take of it. Shared by both routes.
 
     This is the "show me another take" button. Everything that defines the shot — LoRAs,
@@ -1602,8 +1624,14 @@ async def _reroll(db: AsyncSession, job: Job, old: Segment,
     already-resolved for the same reason: re-rolling the wildcards too would change two
     variables at once and make the comparison worth nothing.
 
-    Unless the caller asks for a different prompt, which is the point of console#424 and is
-    an explicit choice rather than a side effect. The recipe records that it happened.
+    Unless the caller asks for a different prompt or negative, which is the point of
+    console#424 and console#449. Both are explicit choices rather than side effects, and the
+    recipe records that they happened.
+
+    The negative is translated here, once, before anything sees it: absent stays the
+    sentinel that copies the archived take's value, a blank string becomes the restored NULL,
+    and anything else rides through as written (console#430 makes an explicit empty a
+    "drop it", never a "render with nothing").
 
     ONLY THE LAST LIVE SEGMENT. A segment with a live successor is the frame that successor
     continues from; replacing it would leave every one of them continuing from a frame that
@@ -1662,7 +1690,20 @@ async def _reroll(db: AsyncSession, job: Job, old: Segment,
         triggered = await _resolve_trigger(db, prompt, old.ltx_recipe)
         resolved, template = await _resolve_wildcards_outside_scene(db, triggered)
 
-    fresh = _roll_new_take(job, old, prompt=resolved, prompt_template=template)
+    if negative_prompt is None:
+        # Nothing asked for: the fresh take copies the archived one, verbatim, including a
+        # NULL — which is exactly the inheritance rule the append path applies.
+        negative_at = _COPY
+    elif not negative_prompt.strip():
+        # A blank field is the explicit "drop it" (console#449): back to NULL so the claim
+        # resolves Settings -> stack constant live again. Never stored as '' — the claim
+        # checks `is not None`, and an empty string would become a render with no negative.
+        negative_at = None
+    else:
+        negative_at = negative_prompt
+
+    fresh = _roll_new_take(job, old, prompt=resolved, prompt_template=template,
+                           negative_prompt=negative_at)
     db.add(fresh)
     await db.commit()
     await db.refresh(fresh)
@@ -1676,7 +1717,7 @@ async def reroll_segment(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Another take of this segment, optionally with a different prompt (console#424).
+    """Another take of this segment, optionally with a different prompt or negative.
 
     Addressed by SEGMENT rather than by job. "The job's one segment" was unambiguous while
     re-roll only served index 0; once any index can be the target, the caller has to be able
@@ -1696,7 +1737,8 @@ async def reroll_segment(
         select(Job).where(Job.id == segment.job_id).options(selectinload(Job.segments))
     )).scalar_one()
 
-    return await _reroll(db, job, segment, body.prompt if body else None)
+    return await _reroll(db, job, segment, body.prompt if body else None,
+                         body.negative_prompt if body else None)
 
 
 @router.post("/jobs/{job_id}/reroll", response_model=SegmentResponse)
@@ -1727,7 +1769,8 @@ async def reroll_current_segment(
                             detail="Job has no live segment to re-roll.")
 
     return await _reroll(db, job, max(live, key=lambda s: s.index),
-                         body.prompt if body else None)
+                         body.prompt if body else None,
+                         body.negative_prompt if body else None)
 
 
 @router.post("/segments/{segment_id}/discard", response_model=SegmentResponse)

--- a/app/schemas/segments.py
+++ b/app/schemas/segments.py
@@ -249,9 +249,17 @@ class RerollRequest(BaseModel):
     wording". Absent means a seed-only roll, which is what re-roll has always been and still
     is by default — the two takes then differ in one variable and are comparable. Present is
     an explicit choice to break that, and the new take's recipe records it.
+
+    negative_prompt (console#449) follows the same grammar. Absent: the fresh take copies
+    the archived take's value verbatim, because the re-roll's premise is one changed
+    variable. An EMPTY string is a deliberate "drop it": the fresh segment stores NULL and
+    the claim resolves the live default again — it can never mean "render with no negative",
+    which is the console#430 rule one level up. Only a segment row with a value can be
+    cleared this way; a blank field on a take that had none is no request at all.
     """
 
     prompt: Optional[str] = None
+    negative_prompt: Optional[str] = None
 
 
 class SegmentStatusUpdate(BaseModel):

--- a/tests/test_first_segment_fields.py
+++ b/tests/test_first_segment_fields.py
@@ -83,8 +83,11 @@ def test_every_client_supplied_segment_field_is_wired_into_both_paths():
 
 
 # What a segment IS, as opposed to what happened to it. Every construction of a Segment has to
-# carry these or the thing it builds is a different shot.
-_SHOT_DEFINING = {"prompt", "ltx_recipe"}
+# carry these or the thing it builds is a different shot. negative_prompt joined alongside
+# ltx_recipe with console#449: a take that renders against a different negative conditioning
+# is a different shot by the same argument — and the claim resolves NULL live, so an
+# _roll_new_take that copied nothing here would silently swap the live default in.
+_SHOT_DEFINING = {"prompt", "ltx_recipe", "negative_prompt"}
 
 # Sites that legitimately do not, each with its reason. Both are CARRIERS — a segment row used
 # to hang reprocess work off a job, at a sentinel index far above any real segment. They render
@@ -93,8 +96,8 @@ _SHOT_DEFINING = {"prompt", "ltx_recipe"}
 # The list is the point: an exemption has to be argued for here rather than happening by
 # omission, which is exactly how _roll_new_take lost ltx_recipe.
 _EXEMPT: dict[str, set[str]] = {
-    "make_hologram": {"ltx_recipe"},    # AR hologram carrier, index 1000
-    "create_smashcut": {"ltx_recipe"},  # ffmpeg concat carrier, index 2000
+    "make_hologram": {"ltx_recipe", "negative_prompt"},    # AR hologram carrier, index 1000
+    "create_smashcut": {"ltx_recipe", "negative_prompt"},  # ffmpeg concat carrier, index 2000
 }
 
 

--- a/tests/test_reroll_any_segment.py
+++ b/tests/test_reroll_any_segment.py
@@ -27,7 +27,7 @@ async def _user(db) -> User:
 
 
 async def _chain(db, user, *, length=3, status=JobStatus.AWAITING,
-                 recipe=None) -> tuple[Job, list[Segment]]:
+                 recipe=None, negative_prompt=None) -> tuple[Job, list[Segment]]:
     """A job of `length` completed segments — the shape re-roll could not touch before."""
     job = Job(user_id=user.id, name="job", width=480, height=832, fps=16, seed=1234,
               starting_image="s3://b/start.png", status=status)
@@ -39,6 +39,7 @@ async def _chain(db, user, *, length=3, status=JobStatus.AWAITING,
             job_id=job.id, index=i, prompt=f"take {i}",
             duration_seconds=5.0, speed=1.0, status=SegmentStatus.COMPLETED,
             output_path=f"s3://b/{i}.mp4", last_frame_path=f"s3://b/{i}.png",
+            negative_prompt=negative_prompt,
             ltx_recipe=recipe if recipe is not None else {"recipe": "Missionary Side"},
         )
         db.add(seg)
@@ -233,3 +234,107 @@ class TestRollingWithANewPrompt:
 
         assert body["prompt"] == "she is smiling"
         assert body["prompt_template"] == f"she is <{name}>"
+
+
+@pytest.mark.asyncio
+class TestRollingWithANewNegative:
+    """console#449: the re-roll dialog can override or drop the negative prompt.
+
+    The grammar matters more than the field: absent inherits (a seed-only roll stays one
+    variable), a written value is an override, and an emptied field on a take that HAD a
+    negative is a deliberate "drop it" back to NULL — which the claim resolves from the live
+    Settings default, never as "render with no negative" (console#430).
+    """
+
+    async def test_the_new_take_carries_the_new_negative(self, db):
+        user = await _user(db)
+        _, segs = await _chain(db, user, negative_prompt="blurry")
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"negative_prompt": "worse"})).json()
+
+        assert body["negative_prompt"] == "worse"
+
+    async def test_the_archived_take_keeps_the_negative_it_ran(self, db):
+        user = await _user(db)
+        _, segs = await _chain(db, user, negative_prompt="blurry")
+
+        await _post(db, user, f"/segments/{segs[-1].id}/reroll", {"negative_prompt": "worse"})
+
+        await db.refresh(segs[-1])
+        assert segs[-1].negative_prompt == "blurry"
+
+    async def test_no_negative_means_the_archived_value_is_copied(self, db):
+        """A seed-only roll must keep even the frozen copy — that is one of the one variables
+        re-roll exists not to touch, and `test_reroll_segment.py` pins the same convention."""
+        user = await _user(db)
+        _, segs = await _chain(db, user, negative_prompt="blurry")
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll")).json()
+
+        assert body["negative_prompt"] == "blurry"
+        assert (body["ltx_recipe"] or {}).get("edited") is None
+
+    async def test_a_changed_negative_is_recorded_on_the_recipe(self, db):
+        user = await _user(db)
+        _, segs = await _chain(db, user, negative_prompt="blurry")
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"negative_prompt": "worse"})).json()
+
+        assert "negative" in body["ltx_recipe"]["edited"]
+
+    async def test_resubmitting_the_same_negative_is_not_an_edit(self, db):
+        """The console omits unchanged fields, but a caller is free to send the value back.
+        Same value, same render — marking it would dress a seed-only roll up as an edit."""
+        user = await _user(db)
+        _, segs = await _chain(db, user, negative_prompt="blurry")
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"negative_prompt": "blurry"})).json()
+
+        assert "negative" not in (body["ltx_recipe"] or {}).get("edited", [])
+        assert body["negative_prompt"] == "blurry"
+
+    async def test_an_emptied_negative_restores_the_live_default(self, db):
+        """Stored as NULL, never as '': the claim checks `is not None`, so an empty string
+        would become a render with no negative at all — more than the user asked to drop."""
+        user = await _user(db)
+        _, segs = await _chain(db, user, negative_prompt="blurry")
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"negative_prompt": ""})).json()
+
+        assert body["negative_prompt"] is None
+        assert "negative" in body["ltx_recipe"]["edited"]
+
+    async def test_clearing_a_negative_that_was_never_set_changes_nothing(self, db):
+        """A blank field on a take that had none is no request at all — no value moved, so
+        the roll stays a seed-only roll in the record."""
+        user = await _user(db)
+        _, segs = await _chain(db, user)
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"negative_prompt": "   "})).json()
+
+        assert body["negative_prompt"] is None
+        assert "negative" not in (body["ltx_recipe"] or {}).get("edited", [])
+
+    async def test_marking_the_negative_does_not_rewrite_the_archived_one(self, db):
+        user = await _user(db)
+        _, segs = await _chain(db, user, negative_prompt="blurry",
+                               recipe={"recipe": "Missionary Side", "edited": []})
+
+        await _post(db, user, f"/segments/{segs[-1].id}/reroll", {"negative_prompt": "worse"})
+
+        await db.refresh(segs[-1])
+        assert segs[-1].ltx_recipe["edited"] == []
+
+    async def test_prompt_and_negative_together_record_both(self, db):
+        user = await _user(db)
+        _, segs = await _chain(db, user, negative_prompt="blurry")
+
+        body = (await _post(db, user, f"/segments/{segs[-1].id}/reroll",
+                            {"prompt": "different", "negative_prompt": "worse"})).json()
+
+        assert body["ltx_recipe"]["edited"] == ["negative", "prompt"]


### PR DESCRIPTION
Part of DavidJBarnes/wanly-console#449.

## Why

The re-roll dialog can nudge the prompt, but the negative prompt rides along as a frozen copy of the archived take (`_roll_new_take` line: `negative_prompt=old.negative_prompt`) — there is no way to change it, and because a segment row is where "what this ran" lives, a stale negative survives every take. The claim-time fallback (Settings default → stack constant) only fires on NULL, so copies also freeze the app out of an updated default.

## What

- `RerollRequest.negative_prompt: Optional[str] = None` — fully backward-compatible with both existing routes (`/segments/{id}/reroll` and the legacy `/jobs/{id}/reroll`, which share `_reroll`).
- Three-state grammar, decided in wanly-console#449:
  - **absent** → copy the archived take's value verbatim (re-roll stays one-variable, comparable);
  - **value** → override on the fresh take;
  - **empty/whitespace** → store **NULL**, the deliberate "drop it" — the claim then resolves Settings → stack constant live again. Never stored as `''`: the claim checks `is not None`, and an empty string would be a render with *no negative at all*, more than the user asked to drop (console#430's rule, one level up).
- `_recipe_for_take` unions a `"negative"` code into the copied `edited` list (sorted, copy-not-mutate), only when the post-translation value differs from the archived take's. Restoring NULL onto a take that already had NULL is a no-op and stays unmarked. `"negative"` rather than `"negative_prompt"` to match the word RecipeForm records and the console popover already translates.
- `negative_prompt` joins `_SHOT_DEFINING` in `test_first_segment_fields.py` (with argued exemptions for the two carrier sites), closing the gap where `_roll_new_take` could forget the field the way it once forgot `ltx_recipe`.
- The keep/override distinction uses a sentinel (`_COPY = object()`) rather than overloading `None`, since NULL is itself a real value here.

## Verification

- `pytest tests/test_reroll_any_segment.py tests/test_reroll_segment.py`: 38 passed against a real Postgres (9 new tests: new value propagated / archived take untouched / inheritance on absent / marker written / same-value-submit not marked / emptied restores NULL + marker / clearing a never-set negative is a no-op / archived recipe not rewritten / prompt+negative record both).
- Regressions proven catchable: the sentinel replaced with a blind copy → the two row-level tests failed; restored → green.
- Full suite `REQUIRE_DB=1`: 906 passed, **32 failed — byte-identical failure set to clean `main` stashed** (pre-existing local-env failures in `test_training_jobs.py` etc., timestamp-dependent). No new failures; a first run exposed my sentinel as a module-level private `_Copy()` call tripping `test_chain_seed`'s AST lint, which is why the sentinel is a bare `object()`.
- No migration; daemon/image untouched — the claim already delivers the negative it always did.
