### PR TITLE
Poses may name a second person with <TRIGGER2>

### DIFF
--- a/app/model_requirements.py
+++ b/app/model_requirements.py
@@ -31,6 +31,7 @@ second opinion about what a daemon can do.
 from dataclasses import dataclass
 
 from app.ltx_stack import LTX_STACK
+from app.recipe_blob import recipe_characters
 
 CHECKPOINT = "checkpoint"
 LORA = "lora"
@@ -89,7 +90,10 @@ def required_artifacts(ltx_recipe: dict | None) -> set[Artifact]:
     # (console#413/#416) and the stack's content_lora is the literal string "none". It means
     # no LoRA, so it must never become a requirement for a file called "none.safetensors",
     # which is precisely the bug wanly-gpu-docker#68 fixed downstream.
-    for raw in [ltx_recipe.get("char_lora"), *_content_lora_names(ltx_recipe)]:
+    # Every person's LoRA (wanly-console#473), read through the one reader of the blob's
+    # people, plus the pose's content LoRAs.
+    for raw in [*(c.get("char_lora") for c in recipe_characters(ltx_recipe)),
+                *_content_lora_names(ltx_recipe)]:
         name = canonical(str(raw or ""))
         if name and name.lower() != "none":
             out.add(Artifact(LORA, name))

--- a/app/recipe_blob.py
+++ b/app/recipe_blob.py
@@ -1,0 +1,86 @@
+"""The recipe blob's people, read one way everywhere (wanly-console#473).
+
+A segment's `ltx_recipe` names the people in the shot as
+
+    characters: [{name, trigger, char_lora, s1, s2}, ...]      # ordered, at most two
+
+with the older scalar keys -- `character`, `trigger`, `char_lora`, `char_s1`, `char_s2` --
+mirrored from the first entry so that everything written before the list existed, and
+everything that has not learned about it, keeps working. Slot 0 fills `<TRIGGER>` in a
+pose's prompt, slot 1 fills `<TRIGGER2>`; a pose is a two-person pose exactly when its
+template uses `<TRIGGER2>`.
+
+This module is the one reader of that shape. Three places used to each read the scalars on
+their own (the trigger fill, the claim's requirements, the console's mirror of both); a
+second person would have meant three copies of the list-or-scalar rule.
+"""
+from typing import Any, Sequence
+
+TRIGGER_PLACEHOLDER = "<TRIGGER>"
+TRIGGER2_PLACEHOLDER = "<TRIGGER2>"
+#: In slot order. Index i is filled by characters[i].
+TRIGGER_PLACEHOLDERS = (TRIGGER_PLACEHOLDER, TRIGGER2_PLACEHOLDER)
+MAX_CHARACTERS = len(TRIGGER_PLACEHOLDERS)
+
+
+def recipe_characters(ltx_recipe: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """The people in a recipe blob, `[{name, trigger, char_lora, s1, s2}, ...]`.
+
+    The list when it is there, else one entry synthesised from the scalars, else nothing.
+    Entries are returned as recorded -- including a `char_lora` of "none", which is a real
+    choice (render this slot on the base model) that the callers filter for themselves.
+    """
+    if not ltx_recipe:
+        return []
+    raw = ltx_recipe.get("characters")
+    if isinstance(raw, list) and raw:
+        return [dict(e) for e in raw if isinstance(e, dict)]
+    if not any(ltx_recipe.get(k) for k in ("character", "char_lora")):
+        return []
+    return [{
+        "name": ltx_recipe.get("character"),
+        "trigger": ltx_recipe.get("trigger"),
+        "char_lora": ltx_recipe.get("char_lora"),
+        "s1": ltx_recipe.get("char_s1"),
+        "s2": ltx_recipe.get("char_s2"),
+    }]
+
+
+def render_prompt(template: str, triggers: str | Sequence[str | None]) -> str:
+    """Fill a pose's placeholders with the characters' trigger words, slot by slot.
+
+    A single string is the one-person shorthand. A slot with no trigger leaves its
+    placeholder in place: rendering the literal text is bad, but silently dropping the token
+    that anchors a character LoRA is worse and much harder to notice. A template with no
+    placeholder at all is returned unchanged rather than rejected.
+    """
+    if isinstance(triggers, str):
+        triggers = [triggers]
+    out = template
+    for placeholder, trigger in zip(TRIGGER_PLACEHOLDERS, triggers):
+        if trigger:
+            out = out.replace(placeholder, trigger)
+    return out
+
+
+def placeholders_in(text: str) -> list[str]:
+    return [p for p in TRIGGER_PLACEHOLDERS if p in (text or "")]
+
+
+def recipe_problem(ltx_recipe: dict[str, Any] | None, prompt: str | None) -> str | None:
+    """Why this blob cannot render, or None.
+
+    Light on purpose: the blob stays an untyped record so that nothing written before this
+    is ever refused. Only the two things that would otherwise fail ten minutes into a
+    claimed segment are caught here -- more people than the engine has room for, and a
+    prompt still naming a second person the blob does not carry.
+    """
+    if not ltx_recipe:
+        return None
+    people = recipe_characters(ltx_recipe)
+    if len(people) > MAX_CHARACTERS:
+        return f"{len(people)} characters; a render takes at most {MAX_CHARACTERS}"
+    if TRIGGER2_PLACEHOLDER in (prompt or "") and len(people) < 2:
+        return (f"the prompt names a second person ({TRIGGER2_PLACEHOLDER}) but the recipe "
+                f"carries {len(people)} character{'' if len(people) == 1 else 's'}")
+    return None

--- a/app/routes/jobs.py
+++ b/app/routes/jobs.py
@@ -20,6 +20,7 @@ from app.database import get_db
 from app.enums import JOB_VALID_TRANSITIONS, JobStatus, SegmentStatus, VideoStatus
 from app.seeds import new_seed
 from app.estimation import estimate_segment_time, get_estimation_rates, sum_estimated_queue_time
+from app.recipe_blob import recipe_problem
 from app.models import Job, Segment, User, Video, Worker
 from app.model_requirements import (
     CHECKPOINT,
@@ -187,6 +188,9 @@ async def create_job(
         job.lynx_subject_image = job.starting_image
 
     seg = body.first_segment
+    problem = recipe_problem(seg.ltx_recipe, seg.prompt)
+    if problem:
+        raise HTTPException(status_code=422, detail=problem)
     # The console fills and strips its own <scene>…</scene> markers (console#427). Handled
     # again here because this path stores the prompt without going through _resolve_scene:
     # the markers come off, and the caption inside them is held back from the wildcard

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -59,17 +59,15 @@ async def _character(db: AsyncSession, character_id: uuid.UUID) -> LtxCharacter:
 # Two things close that. The trigger is substituted BEFORE wildcard resolution runs, so a
 # correctly-built prompt never reaches the resolver carrying this. And the name is reserved
 # in the wildcard routes, so the shadowing wildcard cannot be created in the first place.
-TRIGGER_PLACEHOLDER = "<TRIGGER>"
+#
+# A second person is <TRIGGER2> (wanly-console#473). Both live in app/recipe_blob.py with
+# the one reader of the blob's people; re-exported here because this is where they were.
+from app.recipe_blob import (  # noqa: E402
+    TRIGGER2_PLACEHOLDER, TRIGGER_PLACEHOLDER, TRIGGER_PLACEHOLDERS, render_prompt,
+)
 
-
-def render_prompt(template: str, trigger: str) -> str:
-    """Fill a pose's placeholder with a character's trigger word.
-
-    A template with no placeholder is returned unchanged rather than rejected — a pose whose
-    prompt genuinely does not name the character is unusual but not wrong, and failing here
-    would block a render for a stylistic choice.
-    """
-    return template.replace(TRIGGER_PLACEHOLDER, trigger)
+__all__ = ["router", "TRIGGER_PLACEHOLDER", "TRIGGER2_PLACEHOLDER", "TRIGGER_PLACEHOLDERS",
+           "render_prompt"]
 
 
 @router.get("/recipes")

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -26,6 +26,9 @@ from app.seeds import new_seed
 from app.enums import JobStatus, SegmentStatus, VideoStatus, WorkerKind
 from app.ltx_stack import LTX_STACK
 from app.model_requirements import CHECKPOINT, canonical
+from app.recipe_blob import (
+    TRIGGER_PLACEHOLDERS, placeholders_in, recipe_characters, recipe_problem, render_prompt,
+)
 from app.models import (
     AppSetting, ImageMeta, Job, LtxCharacter, Segment, User, Video, Wildcard, Worker,
 )
@@ -281,29 +284,35 @@ def _drop_scene(prompt: str) -> str:
 
 
 async def _resolve_trigger(db: AsyncSession, prompt: str, ltx_recipe: dict | None) -> str:
-    """Fill a pose's <TRIGGER> with the character's trigger word.
+    """Fill a pose's <TRIGGER> (and <TRIGGER2>) with the characters' trigger words.
 
-    Runs BEFORE _resolve_wildcards, and that order is the safeguard: <TRIGGER> shares syntax
-    with wildcards, so a Wildcard named TRIGGER would otherwise substitute a random option and
-    the render would quietly name the wrong character. Doing it first means the resolver never
-    sees the placeholder. (The name is also reserved in the wildcard routes, so both ends are
-    covered.)
+    Runs BEFORE _resolve_wildcards, and that order is the safeguard: the placeholders share
+    syntax with wildcards, so a Wildcard named TRIGGER would otherwise substitute a random
+    option and the render would quietly name the wrong character. Doing it first means the
+    resolver never sees a placeholder. (Both names are also reserved in the wildcard routes.)
+
+    Slot i is characters[i] (wanly-console#473): the row's current trigger when the row
+    still exists, else the trigger the blob recorded, else the placeholder is left in place
+    -- rendering the literal text is bad, but silently dropping the token that anchors a
+    character LoRA is worse and much harder to notice.
 
     The console normally substitutes at creation time; this catches a prompt that reaches the
-    API still carrying the placeholder — an edited prompt, or any caller that is not the
+    API still carrying a placeholder — an edited prompt, or any caller that is not the
     console.
     """
-    if "<TRIGGER>" not in prompt:
+    present = placeholders_in(prompt)
+    if not present:
         return prompt
-    name = (ltx_recipe or {}).get("character")
-    if not name:
-        # Leave it. Rendering the literal text "<TRIGGER>" is bad, but silently dropping the
-        # token that anchors the character LoRA is worse and much harder to notice.
-        return prompt
-    row = (await db.execute(
-        select(LtxCharacter).where(LtxCharacter.name == name)
-    )).scalar_one_or_none()
-    return prompt.replace("<TRIGGER>", row.trigger) if row else prompt
+    people = recipe_characters(ltx_recipe)
+    triggers: list[str | None] = []
+    for person in people[:len(TRIGGER_PLACEHOLDERS)]:
+        row = None
+        if person.get("name"):
+            row = (await db.execute(
+                select(LtxCharacter).where(LtxCharacter.name == person["name"])
+            )).scalar_one_or_none()
+        triggers.append(row.trigger if row else person.get("trigger"))
+    return render_prompt(prompt, triggers)
 
 
 async def _resolve_wildcards(db: AsyncSession, prompt: str) -> tuple[str, str | None]:
@@ -390,6 +399,9 @@ async def add_segment(
 
     next_index = max((s.index for s in job.segments), default=-1) + 1
 
+    problem = recipe_problem(body.ltx_recipe, body.prompt)
+    if problem:
+        raise HTTPException(status_code=422, detail=problem)
     prompt = await _resolve_trigger(db, body.prompt, body.ltx_recipe)
     resolved_prompt, prompt_template = await _resolve_wildcards_outside_scene(db, prompt)
     # After wildcards, deliberately — see _resolve_scene. The console resolves this itself

--- a/app/routes/wildcards.py
+++ b/app/routes/wildcards.py
@@ -28,7 +28,7 @@ router = APIRouter()
 # placeholder first, and a wildcard named SCENE WOULD substitute a random option before the
 # captioner is ever called. The render would look plausible and be wrong. So for SCENE this
 # reservation is not belt-and-braces; it is the only guard there is.
-RESERVED_WILDCARD_NAMES = {"TRIGGER", "SCENE"}
+RESERVED_WILDCARD_NAMES = {"TRIGGER", "TRIGGER2", "SCENE"}
 
 
 @router.get("/wildcards", response_model=list[WildcardResponse])

--- a/tests/test_two_characters.py
+++ b/tests/test_two_characters.py
@@ -1,0 +1,127 @@
+"""Two people in one shot (wanly-console#473).
+
+The blob names them as `characters: [...]`, slot 0 fills <TRIGGER> and slot 1 <TRIGGER2>,
+and the scalar keys stay mirrored from slot 0 so nothing written before the list is refused.
+"""
+import pytest
+
+from app.model_requirements import LORA, Artifact, required_artifacts
+from app.models import LtxCharacter
+from app.recipe_blob import (
+    MAX_CHARACTERS, TRIGGER2_PLACEHOLDER, recipe_characters, recipe_problem, render_prompt,
+)
+from app.routes.wildcards import RESERVED_WILDCARD_NAMES
+
+TWO = {
+    "recipe": "Bedroom, two", "character": "p@y", "trigger": "p@y", "char_lora": "pay_v2_e05",
+    "char_s1": 0.8, "char_s2": 1.5,
+    "characters": [
+        {"name": "p@y", "trigger": "p@y", "char_lora": "pay_v2_e05", "s1": 0.8, "s2": 1.5},
+        {"name": "Me", "trigger": "d@vid", "char_lora": "david_v1_final", "s1": 0.7, "s2": 1.2},
+    ],
+}
+ONE_SCALAR = {"recipe": "Missionary", "character": "p@y", "trigger": "p@y",
+              "char_lora": "pay_v2_e05", "char_s1": 0.8, "char_s2": 1.5}
+
+
+class TestRenderPrompt:
+    def test_fills_both_slots_in_order(self):
+        assert render_prompt("<TRIGGER2> behind <TRIGGER>", ["p@y", "d@vid"]) == "d@vid behind p@y"
+
+    def test_a_missing_second_trigger_is_left_literal_not_dropped(self):
+        assert render_prompt("<TRIGGER> and <TRIGGER2>", ["p@y"]) == "p@y and <TRIGGER2>"
+        assert render_prompt("<TRIGGER> and <TRIGGER2>", ["p@y", None]) == "p@y and <TRIGGER2>"
+
+    def test_still_takes_a_single_string(self):
+        assert render_prompt("<TRIGGER>, a woman", "p@y") == "p@y, a woman"
+
+    def test_trigger_does_not_eat_trigger2(self):
+        """"<TRIGGER>" is not a substring of "<TRIGGER2>", and this proves it stays so."""
+        assert render_prompt("<TRIGGER2>", ["p@y"]) == "<TRIGGER2>"
+
+
+class TestTheOneReader:
+    def test_the_list_wins(self):
+        assert [c["name"] for c in recipe_characters(TWO)] == ["p@y", "Me"]
+
+    def test_the_scalar_shape_is_one_person(self):
+        [one] = recipe_characters(ONE_SCALAR)
+        assert one == {"name": "p@y", "trigger": "p@y", "char_lora": "pay_v2_e05",
+                       "s1": 0.8, "s2": 1.5}
+
+    def test_nothing_is_nothing(self):
+        assert recipe_characters(None) == []
+        assert recipe_characters({"recipe": "x"}) == []
+        assert recipe_characters({"characters": []}) == []
+
+
+class TestRequirements:
+    def test_every_character_lora_is_a_requirement(self):
+        names = {a.name for a in required_artifacts(TWO) if a.kind == LORA}
+        assert {"pay_v2_e05", "david_v1_final"} <= names
+
+    def test_the_scalar_shape_still_yields_one(self):
+        names = {a.name for a in required_artifacts(ONE_SCALAR) if a.kind == LORA}
+        assert names == {"pay_v2_e05"}
+
+    def test_a_none_slot_is_not_a_file(self):
+        blob = dict(TWO, characters=[TWO["characters"][0], {"name": "x", "char_lora": "none"}])
+        names = {a.name for a in required_artifacts(blob) if a.kind == LORA}
+        assert names == {"pay_v2_e05"}
+
+
+class TestValidation:
+    def test_a_third_character_is_refused(self):
+        blob = dict(TWO, characters=TWO["characters"] + [{"name": "third", "char_lora": "t"}])
+        assert "at most 2" in recipe_problem(blob, "<TRIGGER>")
+        assert MAX_CHARACTERS == 2
+
+    def test_trigger2_in_the_prompt_needs_a_second_character(self):
+        assert "second person" in recipe_problem(ONE_SCALAR, "<TRIGGER> with <TRIGGER2>")
+
+    def test_a_two_person_blob_with_a_two_person_prompt_is_fine(self):
+        assert recipe_problem(TWO, "<TRIGGER> with <TRIGGER2>") is None
+
+    def test_old_blobs_are_never_refused(self):
+        assert recipe_problem(ONE_SCALAR, "p@y, a woman") is None
+        assert recipe_problem(None, "<TRIGGER2>") is None
+
+    def test_the_routes_check_before_resolving(self):
+        import inspect
+        from app.routes import jobs, segments
+        assert "recipe_problem(seg.ltx_recipe, seg.prompt)" in inspect.getsource(jobs.create_job)
+        src = inspect.getsource(segments)
+        assert src.index("recipe_problem(body.ltx_recipe, body.prompt)") < src.index(
+            "prompt = await _resolve_trigger(db, body.prompt, body.ltx_recipe)")
+
+    def test_trigger2_is_a_reserved_wildcard_name(self):
+        assert "TRIGGER2" in RESERVED_WILDCARD_NAMES
+
+
+@pytest.mark.asyncio
+class TestResolveTrigger:
+    async def test_fills_trigger2_from_the_second_character(self, db):
+        from app.routes.segments import _resolve_trigger
+        db.add(LtxCharacter(name="p@y", char_lora="pay_v2_e05", trigger="p@y"))
+        db.add(LtxCharacter(name="Me", char_lora="david_v1_final", trigger="d@vid"))
+        await db.commit()
+        out = await _resolve_trigger(db, "<TRIGGER2> stands behind <TRIGGER>", TWO)
+        assert out == "d@vid stands behind p@y"
+
+    async def test_the_rows_trigger_beats_the_recorded_one(self, db):
+        """A trigger corrected on the character row applies to the next render."""
+        from app.routes.segments import _resolve_trigger
+        db.add(LtxCharacter(name="Me", char_lora="david_v1_final", trigger="dav1d"))
+        await db.commit()
+        out = await _resolve_trigger(db, "<TRIGGER> and <TRIGGER2>", TWO)
+        assert out.endswith("and dav1d")
+
+    async def test_a_deleted_row_falls_back_to_what_was_recorded(self, db):
+        from app.routes.segments import _resolve_trigger
+        out = await _resolve_trigger(db, "<TRIGGER> and <TRIGGER2>", TWO)
+        assert out == "p@y and d@vid"
+
+    async def test_a_scalar_blob_still_fills_one(self, db):
+        from app.routes.segments import _resolve_trigger
+        out = await _resolve_trigger(db, "<TRIGGER>, a woman", ONE_SCALAR)
+        assert out == "p@y, a woman"


### PR DESCRIPTION
PR 3 of 4 for DavidJBarnes/wanly-console#473. After wanly-gpu-docker#84 (engine) and wanly-gpu-daemon#181 (daemon), both merged.

- `app/recipe_blob.py`: the one reader of the blob's people. `characters: [{name, trigger, char_lora, s1, s2}, …]` (max 2) with the scalar keys mirrored from slot 0; `recipe_characters()` prefers the list and falls back to the scalars; `render_prompt()` takes a list of triggers (or the one-person string); `recipe_problem()` is the light validation.
- `_resolve_trigger` fills `<TRIGGER>` and `<TRIGGER2>` slot by slot: the row's current trigger, else the recorded one, else the literal stays. Still runs before wildcards on both call sites.
- `required_artifacts` lists every person's LoRA.
- `TRIGGER2` reserved as a wildcard name.
- Segment POST and `POST /jobs` refuse (422) a third person, or a prompt naming `<TRIGGER2>` with fewer than two characters. Old blobs are never refused.
- No migration.

`pytest`: 701 passed (18 new in `tests/test_two_characters.py`; DB-backed ones run in CI).

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW