### PR TITLE
A training caption that lacks the trigger gets it prepended

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -112,13 +112,22 @@ async def create_training_job(
             detail=f"{body.character} v{body.version} is already {dupe.status}. "
                    f"Cancel it, or pick another version.")
 
+    # THE CAPTION MUST CARRY THE TRIGGER, or the trigger is never learned. The first run
+    # trained with the caption "man" -- typed literally into a field whose placeholder
+    # said "trigger, woman" -- so its trigger word meant nothing to the model and the
+    # identity bound to "man" instead. A caption that does not mention the trigger gets it
+    # prepended here, the way the trainer's own default ("<trigger>, woman") is shaped.
+    caption = (body.caption or "").strip() or None
+    if caption and body.trigger not in caption:
+        caption = f"{body.trigger}, {caption}"
+
     job = TrainingJob(
         user_id=user.id,
         character=body.character,
         trigger=body.trigger,
         version=body.version,
         dataset_images=images,
-        config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": body.caption,
+        config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": caption,
                 "lora_name": body.lora_name or _default_lora_name(body.character),
                 "publish": body.publish},
         status=TrainingStatus.PENDING,

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -731,3 +731,30 @@ class TestTheLoraHasAFace:
         import inspect
         from app.routes import training as mod
         assert '"loss_log", "epochs"' in inspect.getsource(mod.update_training_job)
+
+
+class TestTheCaptionCarriesTheTrigger:
+    """Me v1 trained with the caption "man": the trigger d@vid was never in a caption, so the
+    model never learned it and the identity bound to "man" instead."""
+
+    async def _create(self, db, caption):
+        from app.routes.training import create_training_job
+
+        class _U:
+            id = None
+            username = "t"
+        return await create_training_job(
+            TrainingCreate(character="Me", trigger="d@vid", dataset_images=_images(),
+                           caption=caption), user=_U(), db=db)
+
+    async def test_a_caption_without_the_trigger_gets_it_prepended(self, db):
+        job = await self._create(db, "man")
+        assert job.config["caption"] == "d@vid, man"
+
+    async def test_a_caption_that_names_it_is_left_alone(self, db):
+        job = await self._create(db, "portrait of d@vid, man")
+        assert job.config["caption"] == "portrait of d@vid, man"
+
+    async def test_no_caption_stays_none_for_the_trainers_default(self, db):
+        job = await self._create(db, "   ")
+        assert job.config["caption"] is None


### PR DESCRIPTION
`Me v1` trained with the caption `man`, so the trigger `d@vid` was never in a training caption and means nothing to the model. Any caption that does not mention the trigger now trains as `<trigger>, <caption>`; a blank caption still falls to the trainer's default. Pairs with a console change that shows exactly what will train.

`pytest`: 41 passed in the training suite (3 new).

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW