### PR TITLE
An explicit gender decides the training caption

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -118,7 +118,9 @@ async def create_training_job(
     # identity bound to "man" instead. A caption that does not mention the trigger gets it
     # prepended here, the way the trainer's own default ("<trigger>, woman") is shaped.
     caption = (body.caption or "").strip() or None
-    if caption and body.trigger not in caption:
+    if body.gender:
+        caption = f"{body.trigger}, {body.gender}"
+    elif caption and body.trigger not in caption:
         caption = f"{body.trigger}, {caption}"
 
     job = TrainingJob(
@@ -128,6 +130,7 @@ async def create_training_job(
         version=body.version,
         dataset_images=images,
         config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": caption,
+                "gender": body.gender,
                 "lora_name": body.lora_name or _default_lora_name(body.character),
                 "publish": body.publish},
         status=TrainingStatus.PENDING,

--- a/app/schemas/training.py
+++ b/app/schemas/training.py
@@ -49,6 +49,10 @@ class TrainingCreate(BaseModel):
     #: the better answer -- all 13 of p@y's read "p@y, woman" over close-ups, so the trigger
     #: carries close-up framing as part of its identity.
     caption: str | None = Field(default=None, max_length=500)
+    #: The console's way of saying the caption: every image is captioned "<trigger>, <gender>".
+    #: Explicit because a free caption field was filled in with "man" alone and the trigger
+    #: was never learned. When given, it decides the caption.
+    gender: Literal["woman", "man", "person"] | None = None
     steps: int = Field(default=1200, ge=100, le=6000)
     #: The filename stem the LoRA installs under. ASKED, NOT DERIVED.
     #:

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -758,3 +758,19 @@ class TestTheCaptionCarriesTheTrigger:
     async def test_no_caption_stays_none_for_the_trainers_default(self, db):
         job = await self._create(db, "   ")
         assert job.config["caption"] is None
+
+    async def test_gender_writes_the_whole_caption(self, db):
+        from app.routes.training import create_training_job
+
+        class _U:
+            id = None
+            username = "t"
+        job = await create_training_job(
+            TrainingCreate(character="Me", trigger="d@vid", dataset_images=_images(),
+                           gender="man"), user=_U(), db=db)
+        assert job.config["caption"] == "d@vid, man"
+        assert job.config["gender"] == "man"
+
+    def test_gender_is_one_of_three(self):
+        with pytest.raises(ValueError):
+            TrainingCreate(character="Me", trigger="d@vid", dataset_images=_images(), gender="boy")


### PR DESCRIPTION
`TrainingCreate.gender` (`woman` | `man` | `person`). When given, every image is captioned exactly `<trigger>, <gender>` and that is what the console sends now; the free `caption` stays for the CLI and still gets the trigger prepended when it lacks it (#292). Recorded in the job config.

`pytest`: 42 passed in the training suite.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW