### PR TITLE
Stitch carries the audio LTX renders include

### DIFF
--- a/app/stitch.py
+++ b/app/stitch.py
@@ -19,6 +19,51 @@ logger = logging.getLogger(__name__)
 FADE_DURATION = 1.0
 FLASH_DURATION = 1.0
 
+# Real LTX renders carry AAC 48 kHz stereo (ffprobe of a 2026-09-08 segment, console#475).
+# Everything in a stitch list must agree on that shape for `-c copy` to work, so silent
+# entries are synthesized at the same rate; this constant states the agreed value once.
+AUDIO_SAMPLE_RATE = 48000
+
+
+def _has_audio_stream(path: str) -> bool:
+    """Whether a media file carries an audio stream, per ffprobe.
+
+    Decides what audio means for a stitch (console#475): either every clip has it and the
+    result keeps it, or the result is honestly silent. The shape between those — a mixed
+    list — used to be worse than either: `-c copy` rejects inhomogeneous streams, so a
+    job mixing pre-audio and audio-bearing segments failed the whole stitch, and the
+    crossfade path answered the same input with a silent `-an` output, no warning.
+    """
+    probe = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "a",
+         "-show_entries", "stream=index", "-of", "csv=p=0", path],
+        capture_output=True, timeout=60,
+    )
+    return probe.returncode == 0 and bool(probe.stdout.decode(errors="replace").strip())
+
+
+def _pad_silent_track(input_path: str, output_path: str) -> None:
+    """Mux a silent AAC track of the agreed layout under a clip that has no audio.
+
+    Video is stream-copied; the silent source is synthesized infinite and `-shortest` cut
+    to the video's length, so the result matches the audio-bearing neighbors and the
+    literal concat pair works again.
+    """
+    cmd = [
+        "ffmpeg", "-y",
+        "-i", input_path,
+        "-f", "lavfi", "-i",
+        f"anullsrc=r={AUDIO_SAMPLE_RATE}:cl=stereo",
+        "-map", "0:v", "-map", "1:a",
+        "-shortest",
+        "-c:v", "copy",
+        "-c:a", "aac",
+        output_path,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, timeout=300)
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffmpeg silent-track mux failed: {proc.stderr.decode()[-500:]}")
+
 
 def _apply_fades(input_path: str, output_path: str, duration: float,
                  fade_in: bool, fade_out: bool) -> None:
@@ -44,12 +89,20 @@ def _apply_fades(input_path: str, output_path: str, duration: float,
 
 
 def _generate_black(output_path: str, duration: float, width: int, height: int, fps: int) -> None:
-    """Generate a short black video clip."""
+    """Generate a short black video clip.
+
+    Carries a silent AAC track at the stitch's agreed layout (console#475): the clip sits in
+    a `-c copy` concat list between audio-bearing LTX segments, and a stream-copy list
+    requires every entry to have the same streams — a naked video-only clip in that list is
+    what used to reject the whole stitch or, at best, mute it.
+    """
     cmd = [
         "ffmpeg", "-y",
         "-f", "lavfi", "-i", f"color=c=black:s={width}x{height}:d={duration}:r={fps}",
+        "-f", "lavfi", "-i", f"anullsrc=r={AUDIO_SAMPLE_RATE}:cl=stereo",
+        "-shortest",
         "-c:v", "libx264", "-preset", "fast", "-crf", "18",
-        "-an",
+        "-c:a", "aac",
         output_path,
     ]
     proc = subprocess.run(cmd, capture_output=True, timeout=60)
@@ -92,13 +145,21 @@ def _apply_trim(input_path: str, output_path: str, fps: int,
 
 
 def _crossfade_concat(input_paths: list[str], durations: list[float],
-                      crossfade: float, fps: int, output_path: str) -> float:
+                      crossfade: float, fps: int, output_path: str,
+                      carry_audio: bool = False) -> float:
     """Blend consecutive segments with an xfade crossfade (overlapping seam) and
     re-encode to a single clip. Returns the total output duration.
 
     Each boundary overlaps by ``d`` seconds, so the output is shorter than the sum
     of the parts by ``d * (n - 1)``. ``d`` is clamped to fit the shortest segment.
     Raises ValueError if a crossfade can't be applied (too few clips / too short).
+
+    carry_audio (console#475) is the caller's all-or-nothing answer to "do these clips
+    have sound": True chains an acrossfade pass parallel to the xfade pass — the same
+    overlap arithmetic, so picture and sound shorten together — and encodes AAC. False
+    keeps the old video-only output, which is the honest treatment of a list any entry
+    of which is silent: acrossfade needs a stream on every input, and padding one edge
+    to fake uniformity would invent silence where LTX wrote audio for everything else.
     """
     n = len(input_paths)
     if n < 2:
@@ -127,11 +188,28 @@ def _crossfade_concat(input_paths: list[str], durations: list[float],
         running = running + durations[i] - d
         prev_label = out_label
 
+    maps = ["-map", "[out]"]
+
+    if carry_audio:
+        # Same overlap arithmetic as the video chain, one stream behind it.
+        filters += [
+            f"[{i}:a]aformat=sample_fmts=fltp:sample_rates={AUDIO_SAMPLE_RATE}:"
+            f"channel_layouts=stereo[a{i}]"
+            for i in range(n)
+        ]
+        a_prev = "a0"
+        for i in range(1, n):
+            a_out = "aout" if i == n - 1 else f"xa{i}"
+            filters.append(f"[{a_prev}][a{i}]acrossfade=d={d:.4f}[{a_out}]")
+            a_prev = a_out
+        maps += ["-map", "[aout]", "-c:a", "aac"]
+    else:
+        maps += ["-an"]
+
     cmd += [
         "-filter_complex", ";".join(filters),
-        "-map", "[out]",
+        *maps,
         "-c:v", "libx264", "-preset", "fast", "-crf", "18",
-        "-an",
         output_path,
     ]
     proc = subprocess.run(cmd, capture_output=True, timeout=600)
@@ -245,6 +323,13 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
 
                 if use_crossfade:
                     try:
+                        # All-or-nothing by probe: every clip audible -> keep sound (the
+                        # crossfade graph fades it through the seams); any silent clip ->
+                        # the old video-only output, honestly silent. See _crossfade_concat.
+                        audio_flags = []
+                        for f in local_files:
+                            audio_flags.append(await asyncio.to_thread(
+                                _has_audio_stream, str(tmppath / f)))
                         total_duration = await asyncio.to_thread(
                             _crossfade_concat,
                             [str(tmppath / f) for f in local_files],
@@ -252,10 +337,11 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
                             crossfade,
                             job.fps,
                             str(output_path),
+                            all(audio_flags),
                         )
                         logger.info(
-                            "Stitched job %s with %.2fs crossfade across %d segments",
-                            job_id, crossfade, len(segments),
+                            "Stitched job %s with %.2fs crossfade across %d segments (audio: %s)",
+                            job_id, crossfade, len(segments), all(audio_flags),
                         )
                     except ValueError as e:
                         logger.warning("Crossfade skipped (%s); using hard-cut concat", e)
@@ -296,6 +382,31 @@ async def stitch_video(video_id: UUID, job_id: UUID) -> None:
 
                     # Write ffmpeg concat list
                     concat_list = tmppath / "concat.txt"
+
+                    # A stream-copy list requires every file to have the same streams
+                    # (console#475). Audio-bearing LTX segments mixed with anything silent —
+                    # an old pre-audio take, a bare black clip before this change — used to
+                    # fail the copy outright. Pad the silent entries with synthesized
+                    # silence at the agreed layout so the list is uniform again; the user
+                    # gets what the segments actually contain, and the copy survives.
+                    flags = []
+                    for name in concat_names:
+                        flags.append(await asyncio.to_thread(
+                            _has_audio_stream, str(tmppath / name)))
+                    if any(flags) and not all(flags):
+                        padded = []
+                        for name, has_audio in zip(concat_names, flags):
+                            if has_audio:
+                                padded.append(name)
+                            else:
+                                padded_name = f"silent_{name}"
+                                await asyncio.to_thread(
+                                    _pad_silent_track,
+                                    str(tmppath / name),
+                                    str(tmppath / padded_name),
+                                )
+                                padded.append(padded_name)
+                        concat_names = padded
                     concat_list.write_text(
                         "\n".join(f"file '{name}'" for name in concat_names)
                     )

--- a/tests/test_stitch_audio.py
+++ b/tests/test_stitch_audio.py
@@ -1,0 +1,214 @@
+"""Audio through the stitch (console#475).
+
+LTX renders carry AAC 48 kHz stereo, and the rule is deliberately binary: every clip
+audible -> the final keeps it with sound; any clip silent -> concat entries get padded
+with synthesized silence so the `-c copy` list stays uniform. The tests run REAL ffmpeg
+against synthesized clips — the failure modes here were all command-level (a silent black
+clip inside a copy list, an `-an` crossfade), and argv-shape assertions would have let a
+filter-graph typo pass silently.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from app.stitch import (
+    AUDIO_SAMPLE_RATE,
+    _crossfade_concat,
+    _generate_black,
+    _has_audio_stream,
+    _pad_silent_track,
+)
+from app import stitch as stitch_module
+
+FFMPEG = shutil.which("ffmpeg")
+FFPROBE = shutil.which("ffprobe")
+
+NEEDS_FFMPEG = pytest.mark.skipif(not FFMPEG or not FFPROBE, reason="no ffmpeg/ffprobe")
+
+
+def _encoders() -> str:
+    if not FFMPEG:
+        return ""
+    try:
+        return subprocess.run([FFMPEG, "-hide_banner", "-encoders"],
+                              capture_output=True, text=True).stdout
+    except Exception:
+        return ""
+
+
+HAS_LIBX264 = "libx264" in _encoders()
+
+
+@pytest.fixture
+def any_encoder(request, monkeypatch):
+    """Run _crossfade_concat/_generate_black regardless of libx264 availability.
+
+    app.stitch hardcodes libx264; CI runners and the deployed container have it, a stock
+    workstation ffmpeg may not. When it is missing, argv gets libx264 swapped for mpeg4
+    and the test runs anyway — the premise under test is the filter graph, the maps and
+    the stream layout, and per-version encoder substitution states itself instead of
+    pretending. A no-op where libx264 exists.
+    """
+    if HAS_LIBX264:
+        yield
+        return
+    real_run = subprocess.run
+
+    def swapped(cmd, **kwargs):
+        if isinstance(cmd, list) and "libx264" in cmd:
+            cmd = ["mpeg4" if c == "libx264" else c for c in cmd]
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(stitch_module.subprocess, "run", swapped)
+    yield
+
+
+def _stream_probe(path: str) -> list[dict]:
+    """Every stream {codec_type, codec_name, sample_rate} of an output file."""
+    proc = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries",
+         "stream=codec_type,codec_name,sample_rate", "-of", "json", path],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(proc.stdout)["streams"]
+
+
+def _audio_streams(path: str) -> list[dict]:
+    return [s for s in _stream_probe(path) if s["codec_type"] == "audio"]
+
+
+def _make_clip(path: str, audible: bool) -> None:
+    """A 1-second test clip: testsrc video, sine+48k stereo audio if audible."""
+    cmd = [
+        "ffmpeg", "-y", "-v", "error",
+        "-f", "lavfi", "-i", "testsrc=s=64x64:d=1",
+    ]
+    if audible:
+        cmd += ["-f", "lavfi", "-i", "sine=f=440:d=1"]
+    cmd += ["-c:v", "mpeg4"]
+    if audible:
+        cmd += ["-c:a", "aac", "-ar", str(AUDIO_SAMPLE_RATE), "-ac", "2"]
+    subprocess.run(cmd + ["-shortest", path], check=True)
+
+
+class TestProbeHasAudioStream:
+    @NEEDS_FFMPEG
+    def test_audible_yes_silent_no(self, tmp_path):
+        audible = str(tmp_path / "a.mp4")
+        _make_clip(audible, audible=True)
+        assert _has_audio_stream(audible) is True
+
+        silent = str(tmp_path / "s.mp4")
+        _make_clip(silent, audible=False)
+        assert _has_audio_stream(silent) is False
+
+
+class TestPadSilentTrack:
+    @NEEDS_FFMPEG
+    def test_a_padded_clip_matches_the_stitch_layout(self, tmp_path):
+        """Either every entry of the copy list has audio or none does. Padding synthesizes
+        silence AT THE AGREED LAYOUT — a silent AAC whose rate differs from the audible
+        neighbors would make the copy list uniform in stream PRESENCE only, which is not
+        uniform enough for `-c copy`."""
+        silent = str(tmp_path / "s.mp4")
+        _make_clip(silent, audible=False)
+        padded = str(tmp_path / "p.mp4")
+        _pad_silent_track(silent, padded)
+
+        audio = _audio_streams(padded)
+        assert audio and audio[0]["codec_name"] == "aac"
+        assert audio[0]["sample_rate"] == str(AUDIO_SAMPLE_RATE)
+
+    @NEEDS_FFMPEG
+    def test_the_padded_video_is_untouched(self, tmp_path):
+        """-c:v copy keeps the padding from re-encoding picture: cheap, and no quality loss."""
+        silent = str(tmp_path / "s.mp4")
+        _make_clip(silent, audible=False)
+        padded = str(tmp_path / "p.mp4")
+        _pad_silent_track(silent, padded)
+        assert [s["codec_name"] for s in _stream_probe(padded) if s["codec_type"] == "video"] == ["mpeg4"]
+
+
+class TestUniformConcatCopy:
+    @NEEDS_FFMPEG
+    def test_an_audio_uniform_list_copies_with_sound(self, tmp_path):
+        """The shape a modern all-LTX job stitches in: every entry has AAC 48k stereo, so
+        `-c copy` carries it — no re-encode, no `-an`, no silent出品 surprise."""
+        a, p, b = str(tmp_path / "a.mp4"), str(tmp_path / "p.mp4"), str(tmp_path / "b.mp4")
+        _make_clip(a, audible=True)
+        _pad_silent_track(a, p)
+        _make_clip(b, audible=True)
+
+        lst = tmp_path / "concat.txt"
+        lst.write_text(f"file '{a}'\nfile '{p}'\nfile '{b}'\n")
+        out = str(tmp_path / "final.mp4")
+        subprocess.run(
+            ["ffmpeg", "-y", "-v", "error", "-f", "concat", "-safe", "0",
+             "-i", str(lst), "-c", "copy", out],
+            check=True,
+        )
+
+        audio = _audio_streams(out)
+        assert audio and audio[0]["codec_name"] == "aac"
+        assert audio[0]["sample_rate"] == str(AUDIO_SAMPLE_RATE)
+        # 3 x 1s in; nothing re-encoded, nothing lost.
+        assert 2.9 < _duration(out) < 3.15
+
+
+def _duration(path: str) -> float:
+    proc = subprocess.run(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "default=noprint_wrappers=1:nokey=1", path],
+        capture_output=True, text=True, check=True,
+    )
+    return float(proc.stdout.strip())
+
+
+@pytest.mark.skipif(not HAS_LIBX264, reason="the black clip really re-encodes; no libx264 here")
+class TestBlackClip:
+    @NEEDS_FFMPEG
+    def test_the_black_clip_carries_silence_at_the_stitch_layout(self, tmp_path):
+        """A black insert sits in the copy list BETWEEN audible segments; pre-#475 it was
+        video-only with `-an`, and a copy list requires uniform streams. This is the test
+        that would have caught that — assert the stream is present and shaped to match."""
+        out = str(tmp_path / "black.mp4")
+        _generate_black(out, 1.0, 64, 64, 25)
+
+        audio = _audio_streams(out)
+        assert audio and audio[0]["codec_name"] == "aac"
+        assert audio[0]["sample_rate"] == str(AUDIO_SAMPLE_RATE)
+
+
+@pytest.mark.usefixtures("any_encoder")
+class TestCrossfadeAudio:
+    @NEEDS_FFMPEG
+    def test_carry_audio_fades_the_sound_through_the_seams(self, tmp_path):
+        """carry_audio=True (every clip audible): audio is chained per-boundary with the
+        same overlap arithmetic as the video, so picture and sound shorten together."""
+        a, b = str(tmp_path / "a.mp4"), str(tmp_path / "b.mp4")
+        _make_clip(a, audible=True)
+        _make_clip(b, audible=True)
+
+        out = str(tmp_path / "x.mp4")
+        total = _crossfade_concat([a, b], [1.0, 1.0], 0.5, 25, out, carry_audio=True)
+
+        assert abs(total - 1.5) < 0.05
+        audio = _audio_streams(out)
+        assert audio and audio[0]["codec_name"] == "aac"
+        assert abs(_duration(out) - 1.5) < 0.1
+
+    @NEEDS_FFMPEG
+    def test_without_audio_the_output_is_honestly_silent(self, tmp_path):
+        """carry_audio=False is the fallback when any clip lacks a stream: video-only, by
+        decision, not by accident. An artifact of that shape declares it, instead of the
+        old `-an` silent behavior with no flag on the record."""
+        a, b = str(tmp_path / "a.mp4"), str(tmp_path / "b.mp4")
+        _make_clip(a, audible=True)
+        _make_clip(b, audible=True)
+
+        out = str(tmp_path / "x.mp4")
+        _crossfade_concat([a, b], [1.0, 1.0], 0.5, 25, out, carry_audio=False)
+        assert _audio_streams(out) == []


### PR DESCRIPTION
Part of DavidJBarnes/wanly-console#475 (with wanly-gpu-daemon#183 and wanly-console#478).

## Why

LTX renders now ship AAC 48 kHz stereo (measured: ffprobe of a fresh 2026-09-08 segment), and the stitched `final.mp4` — which is also the **hologram source** — was the biggest hole: the crossfade path hard-coded `-an`, the black/flash insert was video-only *inside a `-c copy` list*, and a mixed list (pre-audio take beside audio-bearing takes) had no story at all.

## What

- **`_crossfade_concat` gains `carry_audio`** (all-or-nothing from per-input ffprobe): True chains an `acrossfade` pass over an `aformat` normalization (48 kHz stereo) parallel to the xfade chain — the same overlap arithmetic, so picture and sound shorten together — and maps `[aout]` with `-c:a aac`. False keeps the old video-only output, deliberately: `acrossfade` needs a stream on every input, and faking uniformity would invent the silence LTX didn't ask for.
- **`_generate_black` carries a silent AAC track** at the stitch's agreed layout (48 kHz stereo, `anullsrc`), so a flash insert no longer makes the copy list inhomogeneous.
- **Mixed concat lists are padded, not defeated**: any entry without audio gets `_pad_silent_track` — video stream-copied, synthesized silence at the agreed layout, `-shortest` cut. Uniform before the copy, whatever ffmpeg version the host runs (measured: ffmpeg 8 tolerates mixed copy; not every version does, and determinism costs three stream-copied clips).
- `AUDIO_SAMPLE_RATE = 48000` is a single constant stating the measured contract once.

## Verification

- New `tests/test_stitch_audio.py` runs **real ffmpeg** (not arg-shape mocks): probe true/false, padded-clip layout (aac, 48 kHz) + untouched video stream, a padded uniform list copy-concatenating with sound and the right duration, the black clip's silent AAC track, and both crossfade modes (sound through the seam; honestly-silent fallback). The crossfade/black tests are encoder-agnostic by fixture — libx264 runs the argv as written (CI, deployed container); elsewhere mpeg4 stands in because the graph, not the codec, is the premise. With no libx264 locally the black-clip test skips with a reason; it runs in CI.
- Full suite `REQUIRE_DB=1` against a **freshly rebuilt** test database: **971 passed, 1 skipped, 0 failures**. (The pre-existing "flaky" 32–40 failures in earlier runs were the *shared test database's stale schema* — bases and models had gained columns (`thumbnail_uri`, `loss_log`, gender fields) that `create_all` never back-fills; dropping and recreating `wanly_test` fixed all of them. Worth remembering the next time the shared DB lies.)
- No migration; `/files`, `hologram_upload` and `smashcut_upload` are untouched byte-passes.
