### PR TITLE
A worker may be several kinds at once (wanly-gpu-docker#83, PR C1)

### DIFF
--- a/alembic/versions/094_worker_kinds.py
+++ b/alembic/versions/094_worker_kinds.py
@@ -1,0 +1,29 @@
+"""A worker may be several kinds at once
+
+Revision ID: 094
+Revises: 093
+Create Date: 2026-09-08
+
+One container per GPU (wanly-gpu-docker#83) runs the render stack AND the trainer, and
+registers once. `kind` stays -- every gate and the console read it -- and becomes the
+first of `kinds`, with `render` always first when present so the render gates and the
+queue-health count keep meaning what they mean. `kinds` is what the training gate reads
+and what the Workers page lists.
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "094"
+down_revision = "093"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("workers", sa.Column("kinds", JSONB(), nullable=True))
+    op.execute("UPDATE workers SET kinds = jsonb_build_array(kind) WHERE kinds IS NULL")
+
+
+def downgrade() -> None:
+    op.drop_column("workers", "kinds")

--- a/app/enums.py
+++ b/app/enums.py
@@ -96,6 +96,31 @@ class WorkerKind(StrEnum):
 WORKER_KIND_RENDER = str(WorkerKind.RENDER)
 
 
+def worker_kinds(worker) -> list[str]:
+    """Every kind a worker is. Rows from before `kinds` existed are their one `kind`."""
+    return list(worker.kinds) if worker.kinds else [str(worker.kind)]
+
+
+def worker_can(worker, kind: "WorkerKind | str") -> bool:
+    """Is this worker one of `kind`? The training gate reads this, because a box that is
+    render AND trainer carries `kind = render` (render first, always) and the trainer half
+    lives only in `kinds`. The render gates keep reading `kind` -- it is render exactly when
+    render is among the kinds."""
+    return str(kind) in worker_kinds(worker)
+
+
+def ordered_kinds(kinds: list) -> list[str]:
+    """Render first, then the rest in the order given, de-duplicated. `kind` is the first."""
+    out: list[str] = []
+    for k in [str(k) for k in kinds]:
+        if k not in out:
+            out.append(k)
+    if WorkerKind.RENDER in out:
+        out.remove(str(WorkerKind.RENDER))
+        out.insert(0, str(WorkerKind.RENDER))
+    return out
+
+
 class WorkerStatus(StrEnum):
     """Worker statuses, across both kinds.
 

--- a/app/models.py
+++ b/app/models.py
@@ -307,6 +307,11 @@ class Worker(Base):
     #
     # Defaulting to `render` keeps every existing row and every current daemon meaning exactly
     # what it meant before this column existed.
+    # Every kind this worker is (wanly-gpu-docker#83): a box running the render stack and the
+    # trainer registers once as ["render", "trainer"]. `kind` below is the first of these,
+    # with render first whenever present, so the render gates and the console keep reading
+    # one word. Nullable: rows from before the column are read as [kind].
+    kinds: Mapped[list | None] = mapped_column(JSONB, nullable=True, default=None)
     kind: Mapped[str] = mapped_column(String(20), nullable=False, default=WORKER_KIND_RENDER,
                                       server_default=WORKER_KIND_RENDER)
     # WHAT IT RUNS, for display: ["ltx-engine"], ["joycaption", "qwen-edit"]. A list because a

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -27,7 +27,7 @@ from app import s3
 from app.auth import get_current_user, verify_api_key, verify_api_key_or_bearer
 from app.config import settings
 from app.database import get_db
-from app.enums import TRAINING_TERMINAL, TrainingStatus, WorkerKind
+from app.enums import TRAINING_TERMINAL, TrainingStatus, WorkerKind, worker_can
 from app.models import Dataset, LtxCharacter, TrainingJob, User, Worker
 from app.schemas.training import (
     MIN_DATASET_IMAGES, TrainingClaimResponse, TrainingCreate, TrainingProgress,
@@ -173,7 +173,9 @@ async def claim_next_training_job(
     is not an error and a poller should not have to distinguish it from one.
     """
     worker = await db.get(Worker, worker_id)
-    if worker is None or worker.kind != WorkerKind.TRAINER:
+    # `worker_can`, not `kind ==`: a box that runs the render stack and the trainer in one
+    # container registers as ["render", "trainer"] with kind = render (wanly-gpu-docker#83).
+    if worker is None or not worker_can(worker, WorkerKind.TRAINER):
         # Not an error the poller can fix by retrying differently, but not fatal either: a
         # worker that registered before this existed simply gets nothing.
         return None

--- a/app/routes/workers.py
+++ b/app/routes/workers.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import verify_api_key, verify_api_key_or_bearer
 from app.database import get_db
-from app.enums import JobStatus, SegmentStatus, WorkerKind, WorkerStatus
+from app.enums import JobStatus, SegmentStatus, WorkerKind, WorkerStatus, ordered_kinds
 from app.models import Job, Segment, Worker
 from app.queue_health import COUNTED_KINDS, assess
 from app.schemas.workers import QueueHealthResponse, WorkerDrain, WorkerHeartbeat, WorkerRegister, WorkerRename, WorkerResponse, WorkerStatusUpdate
@@ -41,6 +41,9 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
         select(Worker).where(Worker.friendly_name == body.friendly_name)
     )
     worker = result.scalar_one_or_none()
+    # Every kind this box is, render first (wanly-gpu-docker#83). A daemon that predates
+    # `kinds` sends one `kind`, and that is the whole list.
+    kinds = ordered_kinds(body.kinds or [body.kind])
     if worker:
         worker.hostname = body.hostname
         worker.ip_address = body.ip_address
@@ -48,7 +51,8 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
         # Re-registering can legitimately change what a box is: the same host could stop
         # running services and start running an engine. Taken from the request rather than
         # preserved, so the row follows reality instead of the first thing it ever saw.
-        worker.kind = body.kind
+        worker.kind = kinds[0]
+        worker.kinds = kinds
         if body.provides is not None:
             worker.provides = body.provides
         # Re-registering after a container restart can land on a new pod id.
@@ -73,10 +77,11 @@ async def register_worker(body: WorkerRegister, db: AsyncSession = Depends(get_d
             ip_address=body.ip_address,
             comfyui_running=body.comfyui_running,
             runpod_pod_id=body.runpod_pod_id,
-            kind=body.kind,
+            kind=kinds[0],
+            kinds=kinds,
             provides=body.provides,
             # Same reason as above: the column default is online-idle, which is a render word.
-            status=(WorkerStatus.ONLINE_IDLE if body.kind == WorkerKind.RENDER
+            status=(WorkerStatus.ONLINE_IDLE if kinds[0] == WorkerKind.RENDER
                     else WorkerStatus.ONLINE),
         )
         db.add(worker)

--- a/app/schemas/workers.py
+++ b/app/schemas/workers.py
@@ -21,6 +21,9 @@ class WorkerRegister(BaseModel):
     # offered a segment it cannot do -- loudly -- rather than the reverse, which is a render
     # worker silently claiming nothing.
     kind: WorkerKind = WorkerKind.RENDER
+    # Every kind at once (wanly-gpu-docker#83). Absent from every daemon before it; then it
+    # is [kind]. `kind` is derived from it when both are sent, render first.
+    kinds: list[WorkerKind] | None = None
     # WHAT IT RUNS: ["ltx-engine"], ["joycaption", "qwen-edit"]. Optional, and None means
     # "never reported" rather than "runs nothing" -- the distinction every other optional
     # worker field here already draws.
@@ -96,6 +99,7 @@ class WorkerResponse(BaseModel):
     # #269. `kind` is never null -- the column is NOT NULL with a default -- so the console
     # can rely on it and does not need a fallback branch for "unclassified worker".
     kind: str
+    kinds: list[str] | None = None
     provides: list[str] | None = None
     comfyui_running: bool
     gpu_stats: dict[str, Any] | None = None

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -84,7 +84,7 @@ class TestTheClaimGate:
         import inspect
         from app.routes import training as mod
         src = inspect.getsource(mod.claim_next_training_job)
-        assert "worker.kind != WorkerKind.TRAINER" in src
+        assert "not worker_can(worker, WorkerKind.TRAINER)" in src  # reads kinds, not kind (094)
         assert kind != WorkerKind.TRAINER
 
     def test_the_gate_runs_before_the_reclaim_and_the_select(self):

--- a/tests/test_worker_kind.py
+++ b/tests/test_worker_kind.py
@@ -105,7 +105,7 @@ class TestRegistration:
         follow reality rather than the first thing it ever saw."""
         from app.routes import workers as mod
         src = inspect.getsource(mod.register_worker)
-        assert "worker.kind = body.kind" in src
+        assert "worker.kind = kinds[0]" in src  # kinds[0] is body.kind when the daemon sends one kind (094)
 
     def test_provides_is_a_conditional_write_on_register(self):
         from app.routes import workers as mod
@@ -177,7 +177,7 @@ class TestAServiceIsNeverCalledIdle:
         import inspect
         from app.routes import workers as mod
         src = inspect.getsource(mod.register_worker)
-        assert "WorkerStatus.ONLINE_IDLE if body.kind == WorkerKind.RENDER" in src
+        assert "WorkerStatus.ONLINE_IDLE if kinds[0] == WorkerKind.RENDER" in src
 
     def test_a_re_registering_service_is_set_online(self):
         import inspect

--- a/tests/test_worker_kinds_list.py
+++ b/tests/test_worker_kinds_list.py
@@ -1,0 +1,78 @@
+"""A worker may be several kinds at once (wanly-gpu-docker#83).
+
+One container per GPU registers once as ["render", "trainer"]. `kind` stays the first of
+those, render first whenever present, so every render gate and the queue-health count keep
+reading one word; the trainer half is visible only through `kinds`, which is what the
+training gate reads.
+"""
+import uuid
+
+import pytest
+
+from app.enums import WorkerKind, ordered_kinds, worker_can, worker_kinds
+from app.models import Worker
+from app.schemas.workers import WorkerRegister
+
+
+def _worker(**kw):
+    base = dict(id=uuid.uuid4(), friendly_name="3090.zero", hostname="h", ip_address="1.2.3.4",
+                kind="render", kinds=None, status="online-idle")
+    base.update(kw)
+    return Worker(**base)
+
+
+class TestTheOneReader:
+    def test_a_row_from_before_the_column_is_its_one_kind(self):
+        w = _worker(kind="trainer", kinds=None)
+        assert worker_kinds(w) == ["trainer"]
+        assert worker_can(w, WorkerKind.TRAINER) and not worker_can(w, WorkerKind.RENDER)
+
+    def test_a_box_that_is_both_is_both(self):
+        w = _worker(kind="render", kinds=["render", "trainer"])
+        assert worker_can(w, WorkerKind.RENDER) and worker_can(w, WorkerKind.TRAINER)
+
+    def test_render_is_always_first(self):
+        """`kind` is kinds[0], and the render gates and queue-health read `kind`."""
+        assert ordered_kinds(["trainer", "render"]) == ["render", "trainer"]
+        assert ordered_kinds(["trainer", "trainer"]) == ["trainer"]
+        assert ordered_kinds([WorkerKind.SERVICE]) == ["service"]
+
+
+class TestRegistration:
+    def test_an_old_daemon_sends_one_kind_and_that_is_the_list(self):
+        body = WorkerRegister(friendly_name="x", hostname="h", ip_address="1.2.3.4")
+        assert body.kinds is None and body.kind == WorkerKind.RENDER
+
+    def test_kinds_are_validated(self):
+        with pytest.raises(ValueError):
+            WorkerRegister(friendly_name="x", hostname="h", ip_address="1.2.3.4", kinds=["renderer"])
+
+    def test_the_route_derives_kind_from_kinds_render_first(self):
+        import inspect
+        from app.routes import workers as mod
+        src = inspect.getsource(mod.register_worker)
+        assert "kinds = ordered_kinds(body.kinds or [body.kind])" in src
+        assert "worker.kind = kinds[0]" in src and "worker.kinds = kinds" in src
+
+    async def test_a_box_registering_as_both_gets_the_render_vocabulary(self, db):
+        from app.routes.workers import register_worker
+        w = await register_worker(WorkerRegister(
+            friendly_name="3090.zero", hostname="h", ip_address="1.2.3.4",
+            kinds=[WorkerKind.TRAINER, WorkerKind.RENDER]), db=db)
+        assert w.kind == "render" and w.kinds == ["render", "trainer"]
+        assert w.status == "online-idle"
+
+
+class TestTheTrainingGate:
+    def test_reads_kinds_not_kind(self):
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.claim_next_training_job)
+        assert "worker_can(worker, WorkerKind.TRAINER)" in src
+        assert "worker.kind != WorkerKind.TRAINER" not in src
+
+    def test_the_render_gate_still_reads_kind_because_render_is_first(self):
+        """No change needed there: kind == render exactly when render is among the kinds."""
+        import inspect
+        from app.routes import segments as mod
+        assert "worker.kind != WorkerKind.RENDER" in inspect.getsource(mod._model_gate)


### PR DESCRIPTION
Part of wanly-gpu-docker#83: one container per GPU registers once as `["render", "trainer"]`.

- `Worker.kinds` JSONB (migration 094, backfilled from `kind`); `kind` = `kinds[0]`, render first whenever present, so every render gate and the queue-health count keep reading one word.
- `WorkerRegister.kinds: list[WorkerKind] | None` — absent (every daemon today) means `[kind]`.
- `worker_can(worker, kind)` behind the training claim gate; the render gates are unchanged because `kind == render` exactly when render is among the kinds.
- `WorkerResponse.kinds` for the console.

Additive: an old register body produces the same row it did before.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW