### PR TITLE
image-description on the 3090; refuse an interactive caption while it renders (wanly-gpu-docker#83)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
 
 
@@ -17,11 +18,21 @@ class Settings(BaseSettings):
     aws_region: str = "us-west-2"
     api_key: str = ""
     civitai_api_token: str = ""
-    # JoyCaption, for the <SCENE> placeholder (console#405). Runs on the 2070 rather than a
-    # render box: the 3090 sits at ~23 of 24 GB while rendering LTX, and loading a vision
-    # model beside that OOMs a segment ten minutes in.
-    joycaption_url: str = "http://2070.zero:11434"
-    joycaption_model: str = "joycaption:beta-one"
+    # image-description, for the <SCENE> placeholder (console#405) and dataset tagging. Named
+    # for the capability (wanly-gpu-docker#83): today it is JoyCaption served by ollama inside
+    # the GPU container, and that can change without renaming anything here. The old
+    # JOYCAPTION_* names are still read from the environment.
+    #
+    # It runs on the 3090 beside the render stack. A caption loads a ~6 GB vision model, and
+    # the card sits at ~23 of 24 GB while rendering -- so an interactive caption is REFUSED
+    # while that box is online-busy (see busy_render_beside_the_captioner in app/joycaption.py)
+    # rather than OOMing a segment ten minutes in.
+    image_description_url: str = Field(
+        "http://3090.zero:11434",
+        validation_alias=AliasChoices("image_description_url", "joycaption_url"))
+    image_description_model: str = Field(
+        "joycaption:beta-one",
+        validation_alias=AliasChoices("image_description_model", "joycaption_model"))
     # Deliberately tiny. sd.service (Automatic1111) shares that GPU and spikes several GB
     # generating SDXL, and a resident 5.5 GB JoyCaption would starve it. The two are never
     # meant to run at once, so the model should hold the card only while it is actually
@@ -35,10 +46,12 @@ class Settings(BaseSettings):
     # So releasing VRAM after every caption costs ~2.9 s on the next one. 5s still coalesces
     # a burst of images captioned back to back, while giving SD the card back essentially as
     # soon as captioning stops.
-    joycaption_keep_alive: str = "5s"
+    image_description_keep_alive: str = Field(
+        "5s", validation_alias=AliasChoices("image_description_keep_alive", "joycaption_keep_alive"))
     # Generous next to a 4.5 s cold caption. It is here to stop a wedged or unreachable
     # captioner holding a request open, not to bound normal work.
-    joycaption_timeout_s: int = 60
+    image_description_timeout_s: int = Field(
+        60, validation_alias=AliasChoices("image_description_timeout_s", "joycaption_timeout_s"))
     # Automatic1111 on the same 2070, so a caption can ask it for the card back.
     #
     # The keep_alive above makes JoyCaption yield to A1111. Nothing made A1111 yield back,
@@ -52,7 +65,7 @@ class Settings(BaseSettings):
     #
     # Empty disables cropping from the console, which is the honest state anywhere the service
     # is not deployed — the button says so rather than timing out.
-    face_crop_url: str = "http://2070.zero:8084"
+    face_crop_url: str = "http://3090.zero:8084"
     # Generous. It is per REQUEST, and a request carries a whole dataset — 50 images at a
     # second or two each on CPU.
     face_crop_timeout_s: int = 300

--- a/app/joycaption.py
+++ b/app/joycaption.py
@@ -15,9 +15,15 @@ WHY AN UNCENSORED MODEL
     prompt needs and exactly what a general-purpose model will not say.
 
 WHERE IT RUNS
-    The 2070, not a render box. The 3090 sits at ~23 of 24 GB while rendering. The 2070 also
-    hosts Automatic1111, which is why keep_alive is short: a resident 5.5 GB model would
-    starve image generation. Sharing goes both ways now — see _yield_the_gpu.
+    Since wanly-gpu-docker#83, inside the GPU container on the 3090 as the image-description
+    service -- the same card the render stack uses, which sits at ~23 of 24 GB while
+    rendering. keep_alive is short so the model holds VRAM only during a caption, and an
+    INTERACTIVE caption is refused while that box is rendering (busy_render_beside_the_captioner)
+    until the local VRAM lease lands. Before #83 it ran on the 2070 beside Automatic1111;
+    _yield_the_gpu is that arrangement's half of the sharing and still applies wherever
+    a1111_url points at a box that also captions.
+
+    This module keeps its file name; the service it talks to is image-description.
 """
 import base64
 import hashlib
@@ -160,18 +166,69 @@ async def _yield_the_gpu() -> bool:
     return True
 
 
+class CaptionerBusy(CaptionError):
+    """The box that captions is rendering right now; ask again when it finishes."""
+
+
+def captioner_host() -> str:
+    """The host part of image_description_url: `3090.zero` for http://3090.zero:11434."""
+    from urllib.parse import urlsplit
+    return (urlsplit(settings.image_description_url).hostname or "").lower()
+
+
+def render_worker_beside_the_captioner(workers) -> "object | None":
+    """The render-capable worker row that shares a card with the captioner, or None.
+
+    Matched by what the row SAYS it runs first: since wanly-gpu-docker#83 the box registers
+    once with `provides` listing image-description, which is the truth from the box itself.
+    A row whose friendly_name is the URL's host is the fallback for a daemon that does not
+    report provides. A row that cannot render is never a collision -- a captioner-only box
+    has nothing to wait for.
+    """
+    from app.enums import WorkerKind, worker_can
+    host = captioner_host()
+    fallback = None
+    for w in workers:
+        if not worker_can(w, WorkerKind.RENDER):
+            continue
+        if "image-description" in (w.provides or []):
+            return w
+        if fallback is None and (w.friendly_name or "").lower() == host:
+            fallback = w
+    return fallback
+
+
+async def busy_render_beside_the_captioner(db) -> str | None:
+    """The friendly_name of the render worker sharing the captioner's card, if it is
+    rendering right now; else None. The interactive caption routes refuse on it.
+
+    Refuse, not wait: a 720p render is ~30 minutes and the request sits behind a 60 s proxy
+    timeout, so a wait would surface as a 504 that reads like a dead captioner. A clear
+    "3090.zero is rendering" the person can act on is worth more. Claim-time <SCENE>
+    resolution does NOT go through this: the worker has just been handed the segment and
+    has not loaded the render yet, and a failed caption there is non-fatal by design.
+    """
+    from sqlalchemy import select
+    from app.models import Worker
+    rows = (await db.execute(select(Worker).where(Worker.status != "offline"))).scalars().all()
+    w = render_worker_beside_the_captioner(rows)
+    if w is not None and w.status == "online-busy":
+        return w.friendly_name
+    return None
+
+
 async def describe(image_bytes: bytes, instruction: str) -> str:
     """Caption one image. Raises CaptionError; callers must treat that as non-fatal."""
     payload = {
-        "model": settings.joycaption_model,
+        "model": settings.image_description_model,
         "prompt": instruction,
         "images": [base64.b64encode(image_bytes).decode()],
         "stream": False,
-        "keep_alive": settings.joycaption_keep_alive,
+        "keep_alive": settings.image_description_keep_alive,
     }
-    url = f"{settings.joycaption_url.rstrip('/')}/api/generate"
+    url = f"{settings.image_description_url.rstrip('/')}/api/generate"
     try:
-        async with httpx.AsyncClient(timeout=settings.joycaption_timeout_s) as client:
+        async with httpx.AsyncClient(timeout=settings.image_description_timeout_s) as client:
             resp = await client.post(url, json=payload)
             # ollama answers 500 for a runner that died loading, which on this box is
             # almost always the GPU rather than the model. Ask the other tenant to let go
@@ -180,7 +237,7 @@ async def describe(image_bytes: bytes, instruction: str) -> str:
             if resp.status_code == 500 and await _yield_the_gpu():
                 resp = await client.post(url, json=payload)
     except httpx.HTTPError as e:
-        raise CaptionError(f"captioner unreachable at {settings.joycaption_url}: {e}") from e
+        raise CaptionError(f"captioner unreachable at {settings.image_description_url}: {e}") from e
     if resp.status_code != 200:
         raise CaptionError(f"captioner returned {resp.status_code}: {resp.text[:200]}")
 

--- a/app/routes/captions.py
+++ b/app/routes/captions.py
@@ -14,7 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import s3
 from app.auth import get_current_user
 from app.database import get_db
-from app.joycaption import CaptionError, describe, instruction_for
+from app.joycaption import (CaptionError, CaptionerBusy, busy_render_beside_the_captioner,
+                            describe, instruction_for)
 from app.models import User
 from app.routes.app_settings import _get_all_settings
 from app.schemas.captions import CaptionRequest, CaptionResponse
@@ -25,13 +26,24 @@ router = APIRouter()
 
 async def caption_image_bytes(db: AsyncSession, image: bytes,
                               style: str | None = None,
-                              instruction: str | None = None) -> tuple[str, str]:
+                              instruction: str | None = None,
+                              interactive: bool = True) -> tuple[str, str]:
     """Caption bytes using the configured style. Returns (caption, instruction_used).
 
     The instruction is returned as well as the caption so a segment can record HOW it was
     described, not just what was said. A caption written under "terse" and one written under
     "rich" are different artefacts, and a rated panel should be able to tell them apart.
     """
+    # THE CAPTIONER SHARES A CARD WITH A RENDER WORKER (wanly-gpu-docker#83). Loading the
+    # vision model beside a 720p render OOMs one of them. An INTERACTIVE caption is refused
+    # with the box's name while it is rendering. Claim-time <SCENE> resolution passes
+    # interactive=False: the worker was just handed the segment and has not loaded the
+    # render, and a failed caption there is non-fatal by design.
+    busy = await busy_render_beside_the_captioner(db) if interactive else None
+    if busy:
+        raise CaptionerBusy(
+            f"{busy} is rendering, and the captioner shares its GPU. "
+            f"Try again when the render finishes.")
     if instruction is None:
         cfg = await _get_all_settings(db)
         instruction = instruction_for(style or cfg.get("caption_style", ""),

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -148,7 +148,7 @@ async def _resolve_scene(db: AsyncSession, prompt: str, image_uri: str | None,
 
     try:
         image = await asyncio.to_thread(s3.download_bytes, image_uri)
-        caption, instruction = await caption_image_bytes(db, image)
+        caption, instruction = await caption_image_bytes(db, image, interactive=False)
     except Exception as e:
         # Never fatal. A captioner that is down must not stop a render — the pose still has
         # its arc, and a generic scene is what every pose used before this existed.

--- a/tests/test_caption_busy_box.py
+++ b/tests/test_caption_busy_box.py
@@ -1,0 +1,89 @@
+"""An interactive caption is refused while the box it shares a card with is rendering.
+
+wanly-gpu-docker#83 put image-description inside the GPU container on the 3090. A caption
+loads a ~6 GB vision model; a 720p render holds ~23 of 24 GB. Until the local VRAM lease,
+the API keeps them apart on the interactive path by refusing with the box's name -- not by
+waiting, because the request sits behind a 60 s proxy timeout and a wait would read as a
+dead captioner.
+"""
+import uuid
+
+import pytest
+
+from app.config import settings
+from app.joycaption import captioner_host, render_worker_beside_the_captioner
+from app.models import Worker
+
+
+def _w(name, status="online-idle", kind="render", kinds=None, provides=None):
+    return Worker(id=uuid.uuid4(), friendly_name=name, hostname="h", ip_address="1.2.3.4",
+                  kind=kind, kinds=kinds, provides=provides, status=status)
+
+
+@pytest.fixture(autouse=True)
+def _url(monkeypatch):
+    monkeypatch.setattr(settings, "image_description_url", "http://3090.zero:11434")
+
+
+class TestWhichRowSharesTheCard:
+    def test_the_host_comes_from_the_url(self):
+        assert captioner_host() == "3090.zero"
+
+    def test_the_row_that_says_it_provides_the_captioner_wins(self):
+        """One row per box: the box itself reports what it runs, and that beats a name."""
+        box = _w("3090.zero", kinds=["render", "trainer"],
+                 provides=["ltx-engine", "lora-trainer", "image-description"])
+        other = _w("3090.zero-old")
+        assert render_worker_beside_the_captioner([other, box]) is box
+
+    def test_a_row_named_for_the_url_host_is_the_fallback(self):
+        """A daemon that does not report provides yet."""
+        box = _w("3090.zero", provides=None)
+        pod = _w("runpod-abc", provides=None)
+        assert render_worker_beside_the_captioner([pod, box]) is box
+
+    def test_a_captioner_only_box_is_never_a_collision(self):
+        """The 2070-style deployment: a service row that cannot render has nothing to wait
+        for, whatever it provides."""
+        svc = _w("2070.zero/services", kind="service", kinds=["service"],
+                 provides=["image-description"], status="online")
+        assert render_worker_beside_the_captioner([svc]) is None
+
+    def test_nothing_matches_means_nothing_to_refuse_on(self):
+        assert render_worker_beside_the_captioner([_w("runpod-abc")]) is None
+
+
+class TestTheRefusal:
+    def test_the_interactive_path_refuses_by_name_and_claim_time_does_not(self):
+        import inspect
+        from app.routes import captions, segments
+        src = inspect.getsource(captions.caption_image_bytes)
+        assert "busy_render_beside_the_captioner(db) if interactive else None" in src
+        assert "raise CaptionerBusy" in src
+        # Claim-time <SCENE> resolution opts out: the worker was just handed the segment and
+        # has not loaded the render; a failed caption there is non-fatal by design.
+        assert "caption_image_bytes(db, image, interactive=False)" in inspect.getsource(segments)
+
+    def test_it_is_a_caption_error_so_the_route_answers_503_with_the_message(self):
+        from app.joycaption import CaptionError, CaptionerBusy
+        assert issubclass(CaptionerBusy, CaptionError)
+
+    async def test_a_busy_box_is_named_and_an_idle_one_is_not(self, db):
+        from app.joycaption import busy_render_beside_the_captioner
+        box = _w("3090.zero", status="online-busy", kinds=["render", "trainer"],
+                 provides=["ltx-engine", "image-description"])
+        db.add(box); await db.commit()
+        assert await busy_render_beside_the_captioner(db) == "3090.zero"
+        box.status = "online-idle"; await db.commit()
+        assert await busy_render_beside_the_captioner(db) is None
+
+
+class TestTheConfigIsNamedForTheCapability:
+    def test_the_old_names_are_still_read_from_the_environment(self, monkeypatch):
+        """JOYCAPTION_URL in an existing .env keeps working for one release."""
+        from app.config import Settings
+        monkeypatch.setenv("JOYCAPTION_URL", "http://old:11434")
+        monkeypatch.setenv("DATABASE_URL", "sqlite://"); monkeypatch.setenv("JWT_SECRET", "x")
+        assert Settings(_env_file=None).image_description_url == "http://old:11434"
+        monkeypatch.setenv("IMAGE_DESCRIPTION_URL", "http://new:11434")
+        assert Settings(_env_file=None).image_description_url == "http://new:11434"

--- a/tests/test_caption_gpu_yield.py
+++ b/tests/test_caption_gpu_yield.py
@@ -143,4 +143,4 @@ async def _boom(self, url):
 
 @pytest.fixture(autouse=True)
 def _point_at_a_test_captioner(monkeypatch):
-    monkeypatch.setattr(settings, "joycaption_url", "http://2070.test:11434")
+    monkeypatch.setattr(settings, "image_description_url", "http://2070.test:11434")


### PR DESCRIPTION
API half of PR B in wanly-gpu-docker#83.

- Config is named for the capability: `image_description_url` / `_model` / `_keep_alive` / `_timeout_s`. The `JOYCAPTION_*` env names are still accepted (`AliasChoices`). Defaults move to `3090.zero`, as does `face_crop_url`.
- `caption_image_bytes` refuses an **interactive** caption while the render worker that shares the captioner's card is `online-busy`, naming the box. The row is matched by the `provides` it reports (one row per box), falling back to a row named for the URL's host; a captioner-only service row is never a collision. Claim-time `<SCENE>` resolution passes `interactive=False`.
- Refuse rather than wait: a 720p render is ~30 min and the request sits behind a 60 s proxy timeout.

Tests: pure-logic matching, the route pins, one DB-backed test for the busy/idle answer, and the env alias.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW