### PR TITLE
artifact-commit reads the safetensors header before recording a checkpoint

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -484,6 +484,13 @@ async def commit_training_artifact(
             status_code=409,
             detail=f"{uri} is {head['Size']} bytes — a rank-32 character LoRA is ~650 MB, so "
                    f"this is a truncated upload")
+    # AND REALLY A LORA, not just big enough to be one. See s3.safetensors_header_ok for the
+    # zero-filled final that a size check waved through.
+    if not await asyncio.to_thread(s3.safetensors_header_ok, uri):
+        raise HTTPException(
+            status_code=422,
+            detail=f"{uri} is in the bucket but has no safetensors header (a zero-filled or "
+                   f"truncated file). Not recording it; the trainer should regenerate it.")
     _record_checkpoint(job, uri)
     await db.commit()
     await db.refresh(job)

--- a/app/s3.py
+++ b/app/s3.py
@@ -1,6 +1,8 @@
 import logging
 import mimetypes
 
+import json
+
 import boto3
 
 from app.config import settings
@@ -286,6 +288,29 @@ def generate_presigned_put(uri: str, expires: int = 21600) -> str:
         ExpiresIn=expires,
         HttpMethod="PUT",
     )
+
+
+def safetensors_header_ok(uri: str) -> bool:
+    """Does the object start with a safetensors header? A ranged GET of the first eight
+    bytes (the little-endian header length) and then the header itself, parsed as JSON.
+
+    A commit that checks only size lets a zero-filled file through: 2026-09-08 the host
+    hard-reset right after the final checkpoint was written, ext4 kept its size and zeroed
+    its contents, the trainer published it, and every render with that character failed
+    inside ComfyUI. Two small ranged reads here instead of 650 MB.
+    """
+    bucket, key = parse_s3_uri(uri)
+    client = _client_for_bucket(bucket)
+    try:
+        first = client.get_object(Bucket=bucket, Key=key, Range="bytes=0-7")["Body"].read()
+        n = int.from_bytes(first, "little")
+        if not 0 < n < 64 * 1024 * 1024:
+            return False
+        header = client.get_object(Bucket=bucket, Key=key, Range=f"bytes=8-{7 + n}")["Body"].read()
+        json.loads(header)
+        return True
+    except Exception:
+        return False
 
 
 def head_object(uri: str) -> dict | None:

--- a/tests/test_commit_checks_header.py
+++ b/tests/test_commit_checks_header.py
@@ -1,0 +1,55 @@
+"""artifact-commit believes a checkpoint only after reading its header (2026-09-08).
+
+A zero-filled 654 MB file passed the size check, was recorded as Me_v2_final, and every
+render with that character then failed inside ComfyUI with "Expecting value: line 1 column 1".
+"""
+import inspect
+import json
+import struct
+
+from app import s3
+from app.routes import training
+
+
+class _Body:
+    def __init__(self, b): self._b = b
+    def read(self): return self._b
+
+
+class _Client:
+    def __init__(self, blob): self.blob = blob; self.ranges = []
+    def get_object(self, Bucket, Key, Range):
+        self.ranges.append(Range)
+        a, b = Range.split("=")[1].split("-")
+        return {"Body": _Body(self.blob[int(a):int(b) + 1])}
+
+
+def _install(monkeypatch, blob):
+    c = _Client(blob)
+    monkeypatch.setattr(s3, "_client_for_bucket", lambda bucket: c)
+    return c
+
+
+def test_a_real_header_passes_with_two_small_reads(monkeypatch):
+    header = json.dumps({"__metadata__": {}, "w": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}}).encode()
+    c = _install(monkeypatch, struct.pack("<Q", len(header)) + header + b"\0" * 4)
+    assert s3.safetensors_header_ok("s3://ltx-loras/character/x.safetensors")
+    assert c.ranges == ["bytes=0-7", f"bytes=8-{7 + len(header)}"]
+
+
+def test_a_zero_filled_file_fails(monkeypatch):
+    _install(monkeypatch, b"\0" * 4096)
+    assert not s3.safetensors_header_ok("s3://ltx-loras/character/Me_v2_final.safetensors")
+
+
+def test_a_truncated_header_fails(monkeypatch):
+    _install(monkeypatch, struct.pack("<Q", 500) + b"{\"a\":")
+    assert not s3.safetensors_header_ok("s3://ltx-loras/character/x.safetensors")
+
+
+def test_commit_checks_the_header_after_presence_and_before_recording():
+    src = inspect.getsource(training.commit_training_artifact)
+    assert "s3.safetensors_header_ok, uri" in src
+    # After presence and size (a truncated PUT keeps its 409), before anything is recorded.
+    assert (src.index("head_object, uri") < src.index("MIN_ARTIFACT_BYTES")
+            < src.index("safetensors_header_ok, uri") < src.index("_record_checkpoint(job, uri)"))

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -438,12 +438,32 @@ class TestACommitIsBelievedOnlyAfterLooking:
         await db.commit()
         monkeypatch.setattr(mod.s3, "head_object",
                             lambda uri: {"Key": "k", "Size": 650 * 1024 * 1024})
+        # Present, big enough, AND a real safetensors header (the 2026-09-08 zero-filled
+        # final passed the first two).
+        monkeypatch.setattr(mod.s3, "safetensors_header_ok", lambda uri: True)
 
         out = await mod.commit_training_artifact(
             job.id, uri="s3://ltx-loras/character/pay_v2_final.safetensors", db=db)
 
         assert out.checkpoints == ["s3://ltx-loras/character/pay_v2_final.safetensors"]
         assert out.output_lora_path == "s3://ltx-loras/character/pay_v2_final.safetensors"
+
+    async def test_a_headerless_object_is_refused_and_records_nothing(self, db, monkeypatch):
+        """The zero-filled Me_v2_final of 2026-09-08: right size, no header."""
+        import pytest
+        from fastapi import HTTPException
+        from app.routes import training as mod
+        job = self._job()
+        db.add(job)
+        await db.commit()
+        monkeypatch.setattr(mod.s3, "head_object",
+                            lambda uri: {"Key": "k", "Size": 650 * 1024 * 1024})
+        monkeypatch.setattr(mod.s3, "safetensors_header_ok", lambda uri: False)
+        with pytest.raises(HTTPException) as e:
+            await mod.commit_training_artifact(
+                job.id, uri="s3://ltx-loras/character/pay_v2_final.safetensors", db=db)
+        assert e.value.status_code == 422 and "no safetensors header" in e.value.detail
+        assert not (job.checkpoints or [])
 
 
 class TestAFinishedRunCanBeDeleted:


### PR DESCRIPTION
Incident 2026-09-08: the host hard-reset right after the trainer wrote the final ComfyUI-format checkpoint; ext4 kept its size and zeroed the contents; the commit's size check accepted it and `Me_v2_final` pointed at a file with no header. Every render with that character failed inside ComfyUI.

- `s3.safetensors_header_ok(uri)`: ranged GET of the first 8 bytes (header length), ranged GET of the header, JSON parse. Two small reads, not 650 MB.
- `commit_training_artifact` runs it after the presence and size checks (a truncated PUT keeps its 409) and before `_record_checkpoint`; failure is a 422 naming the cause.
- Tests: fake S3 client asserting the two ranges; zero-filled and truncated rejected; route ordering pinned.

Companion: wanly-gpu-docker#89.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW