### PR TITLE
Captions fall back to the 2070's captioner while the 3090 renders

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,11 @@ class Settings(BaseSettings):
     image_description_url: str = Field(
         "http://3090.zero:11434",
         validation_alias=AliasChoices("image_description_url", "joycaption_url"))
+    # A second captioner used while the box above is rendering: the 2070's, which shares its
+    # card with nothing that renders LTX. Interactive captions go there when the 3090 is
+    # busy instead of being refused; claim-time captions go there first, because the box
+    # that claimed is about to load a render. Empty means "refuse while busy".
+    image_description_fallback_url: str = "http://2070.zero:11434"
     image_description_model: str = Field(
         "joycaption:beta-one",
         validation_alias=AliasChoices("image_description_model", "joycaption_model"))

--- a/app/joycaption.py
+++ b/app/joycaption.py
@@ -217,8 +217,28 @@ async def busy_render_beside_the_captioner(db) -> str | None:
     return None
 
 
-async def describe(image_bytes: bytes, instruction: str) -> str:
+def captioner_for(busy: str | None, interactive: bool) -> str | None:
+    """Which captioner URL to use, or None to refuse.
+
+    The 3090's captioner shares its card with the render stack (wanly-gpu-docker#83), so:
+      * interactive, box idle      -> the primary
+      * interactive, box rendering -> the fallback if there is one, else refuse (None)
+      * claim-time                 -> the fallback first if there is one: the claiming box
+                                      is about to load a 23 GB render, and a caption that
+                                      races it timed out on the first night; else the primary
+    """
+    primary = settings.image_description_url
+    fallback = (settings.image_description_fallback_url or "").strip()
+    if not interactive:
+        return fallback or primary
+    if busy:
+        return fallback or None
+    return primary
+
+
+async def describe(image_bytes: bytes, instruction: str, base_url: str | None = None) -> str:
     """Caption one image. Raises CaptionError; callers must treat that as non-fatal."""
+    base = (base_url or settings.image_description_url).rstrip("/")
     payload = {
         "model": settings.image_description_model,
         "prompt": instruction,
@@ -226,7 +246,7 @@ async def describe(image_bytes: bytes, instruction: str) -> str:
         "stream": False,
         "keep_alive": settings.image_description_keep_alive,
     }
-    url = f"{settings.image_description_url.rstrip('/')}/api/generate"
+    url = f"{base}/api/generate"
     try:
         async with httpx.AsyncClient(timeout=settings.image_description_timeout_s) as client:
             resp = await client.post(url, json=payload)
@@ -237,7 +257,7 @@ async def describe(image_bytes: bytes, instruction: str) -> str:
             if resp.status_code == 500 and await _yield_the_gpu():
                 resp = await client.post(url, json=payload)
     except httpx.HTTPError as e:
-        raise CaptionError(f"captioner unreachable at {settings.image_description_url}: {e}") from e
+        raise CaptionError(f"captioner unreachable at {base}: {e!r}") from e
     if resp.status_code != 200:
         raise CaptionError(f"captioner returned {resp.status_code}: {resp.text[:200]}")
 

--- a/app/routes/captions.py
+++ b/app/routes/captions.py
@@ -15,7 +15,7 @@ from app import s3
 from app.auth import get_current_user
 from app.database import get_db
 from app.joycaption import (CaptionError, CaptionerBusy, busy_render_beside_the_captioner,
-                            describe, instruction_for)
+                            captioner_for, describe, instruction_for)
 from app.models import User
 from app.routes.app_settings import _get_all_settings
 from app.schemas.captions import CaptionRequest, CaptionResponse
@@ -35,20 +35,24 @@ async def caption_image_bytes(db: AsyncSession, image: bytes,
     "rich" are different artefacts, and a rated panel should be able to tell them apart.
     """
     # THE CAPTIONER SHARES A CARD WITH A RENDER WORKER (wanly-gpu-docker#83). Loading the
-    # vision model beside a 720p render OOMs one of them. An INTERACTIVE caption is refused
-    # with the box's name while it is rendering. Claim-time <SCENE> resolution passes
-    # interactive=False: the worker was just handed the segment and has not loaded the
-    # render, and a failed caption there is non-fatal by design.
+    # vision model beside a 720p render OOMs one of them. While the box is rendering an
+    # interactive caption goes to the fallback captioner (the 2070's) when one is
+    # configured, and is otherwise refused with the box's name. Claim-time <SCENE>
+    # resolution passes interactive=False and prefers the fallback outright: the claiming
+    # box is about to load the render. See captioner_for.
     busy = await busy_render_beside_the_captioner(db) if interactive else None
-    if busy:
+    base = captioner_for(busy, interactive)
+    if base is None:
         raise CaptionerBusy(
             f"{busy} is rendering, and the captioner shares its GPU. "
             f"Try again when the render finishes.")
+    if busy:
+        logger.info("%s is rendering; captioning on the fallback captioner %s", busy, base)
     if instruction is None:
         cfg = await _get_all_settings(db)
         instruction = instruction_for(style or cfg.get("caption_style", ""),
                                       cfg.get("caption_instruction", ""))
-    return await describe(image, instruction), instruction
+    return await describe(image, instruction, base_url=base), instruction
 
 
 @router.post("/captions/describe", response_model=CaptionResponse)

--- a/tests/test_caption_busy_box.py
+++ b/tests/test_caption_busy_box.py
@@ -59,7 +59,9 @@ class TestTheRefusal:
         from app.routes import captions, segments
         src = inspect.getsource(captions.caption_image_bytes)
         assert "busy_render_beside_the_captioner(db) if interactive else None" in src
+        assert "base = captioner_for(busy, interactive)" in src
         assert "raise CaptionerBusy" in src
+        assert "describe(image, instruction, base_url=base)" in src
         # Claim-time <SCENE> resolution opts out: the worker was just handed the segment and
         # has not loaded the render; a failed caption there is non-fatal by design.
         assert "caption_image_bytes(db, image, interactive=False)" in inspect.getsource(segments)
@@ -87,3 +89,38 @@ class TestTheConfigIsNamedForTheCapability:
         assert Settings(_env_file=None).image_description_url == "http://old:11434"
         monkeypatch.setenv("IMAGE_DESCRIPTION_URL", "http://new:11434")
         assert Settings(_env_file=None).image_description_url == "http://new:11434"
+
+
+class TestWhichCaptionerIsUsed:
+    """The 2070's captioner is the fallback while the 3090 renders (the first night's
+    "Request failed with status code 503" on every describe during a render)."""
+
+    def test_idle_box_interactive_uses_the_primary(self, monkeypatch):
+        from app.joycaption import captioner_for
+        monkeypatch.setattr(settings, "image_description_fallback_url", "http://2070.zero:11434")
+        assert captioner_for(None, True) == "http://3090.zero:11434"
+
+    def test_busy_box_interactive_uses_the_fallback(self, monkeypatch):
+        from app.joycaption import captioner_for
+        monkeypatch.setattr(settings, "image_description_fallback_url", "http://2070.zero:11434")
+        assert captioner_for("3090.zero", True) == "http://2070.zero:11434"
+
+    def test_busy_box_with_no_fallback_refuses(self, monkeypatch):
+        from app.joycaption import captioner_for
+        monkeypatch.setattr(settings, "image_description_fallback_url", "")
+        assert captioner_for("3090.zero", True) is None
+
+    def test_claim_time_prefers_the_fallback(self, monkeypatch):
+        """The claiming box is about to load a 23 GB render; a caption racing it timed out."""
+        from app.joycaption import captioner_for
+        monkeypatch.setattr(settings, "image_description_fallback_url", "http://2070.zero:11434")
+        assert captioner_for(None, False) == "http://2070.zero:11434"
+        monkeypatch.setattr(settings, "image_description_fallback_url", "")
+        assert captioner_for(None, False) == "http://3090.zero:11434"
+
+    def test_describe_honours_the_base_url(self):
+        import inspect
+        from app import joycaption
+        src = inspect.getsource(joycaption.describe)
+        assert 'base = (base_url or settings.image_description_url).rstrip("/")' in src
+        assert 'url = f"{base}/api/generate"' in src


### PR DESCRIPTION
Tonight's "Request failed with status code 503" on every describe during a render: the captioner now shares the 3090 with the render stack (wanly-gpu-docker#83) and an interactive caption was refused while it rendered.

- `image_description_fallback_url` (default `http://2070.zero:11434`, the wanly-services captioner that is still running there).
- `captioner_for(busy, interactive)`: interactive + idle → primary; interactive + rendering → fallback, refused only when none is configured; claim-time → fallback first (the claiming box is about to load a 23 GB render, and a claim-time caption racing it timed out tonight).
- `describe(..., base_url=)`.

Consequence: the 2070's wanly-services container stays up as the fallback captioner rather than being retired now.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW