### PR TITLE
The captioner's box is matched by host only; caption timeout 180 s

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -55,8 +55,11 @@ class Settings(BaseSettings):
         "5s", validation_alias=AliasChoices("image_description_keep_alive", "joycaption_keep_alive"))
     # Generous next to a 4.5 s cold caption. It is here to stop a wedged or unreachable
     # captioner holding a request open, not to bound normal work.
+    # 180, not 60: on the 3090 the vision model is read from disk on every caption (the
+    # renders evict it from the page cache) and a cold caption measured 46 s; the next one
+    # went past 60 and surfaced as "captioner unreachable ... ReadTimeout".
     image_description_timeout_s: int = Field(
-        60, validation_alias=AliasChoices("image_description_timeout_s", "joycaption_timeout_s"))
+        180, validation_alias=AliasChoices("image_description_timeout_s", "joycaption_timeout_s"))
     # Automatic1111 on the same 2070, so a caption can ask it for the card back.
     #
     # The keep_alive above makes JoyCaption yield to A1111. Nothing made A1111 yield back,

--- a/app/joycaption.py
+++ b/app/joycaption.py
@@ -179,23 +179,20 @@ def captioner_host() -> str:
 def render_worker_beside_the_captioner(workers) -> "object | None":
     """The render-capable worker row that shares a card with the captioner, or None.
 
-    Matched by what the row SAYS it runs first: since wanly-gpu-docker#83 the box registers
-    once with `provides` listing image-description, which is the truth from the box itself.
-    A row whose friendly_name is the URL's host is the fallback for a daemon that does not
-    report provides. A row that cannot render is never a collision -- a captioner-only box
-    has nothing to wait for.
+    Matched by HOST: the row whose friendly_name is the host in image_description_url.
+    Not by what a row says it provides -- the 3090 provides image-description, so a
+    provides-match picked the 3090's row even when the URL pointed at the 2070, and a
+    caption during a render was then sent to the box that was rendering. A row that cannot
+    render is never a collision: a captioner-only box has nothing to wait for.
     """
     from app.enums import WorkerKind, worker_can
     host = captioner_host()
-    fallback = None
     for w in workers:
         if not worker_can(w, WorkerKind.RENDER):
             continue
-        if "image-description" in (w.provides or []):
+        if (w.friendly_name or "").lower() == host:
             return w
-        if fallback is None and (w.friendly_name or "").lower() == host:
-            fallback = w
-    return fallback
+    return None
 
 
 async def busy_render_beside_the_captioner(db) -> str | None:

--- a/tests/test_caption_busy_box.py
+++ b/tests/test_caption_busy_box.py
@@ -29,18 +29,20 @@ class TestWhichRowSharesTheCard:
     def test_the_host_comes_from_the_url(self):
         assert captioner_host() == "3090.zero"
 
-    def test_the_row_that_says_it_provides_the_captioner_wins(self):
-        """One row per box: the box itself reports what it runs, and that beats a name."""
+    def test_the_row_named_for_the_url_host_is_the_one(self):
         box = _w("3090.zero", kinds=["render", "trainer"],
                  provides=["ltx-engine", "lora-trainer", "image-description"])
-        other = _w("3090.zero-old")
-        assert render_worker_beside_the_captioner([other, box]) is box
-
-    def test_a_row_named_for_the_url_host_is_the_fallback(self):
-        """A daemon that does not report provides yet."""
-        box = _w("3090.zero", provides=None)
         pod = _w("runpod-abc", provides=None)
         assert render_worker_beside_the_captioner([pod, box]) is box
+
+    def test_provides_does_not_override_the_host(self, monkeypatch):
+        """With the URL pointing at the 2070, the 3090's row (which provides
+        image-description) is NOT the captioner's box -- matching it sent a caption during
+        a render to the box that was rendering (2026-09-08)."""
+        monkeypatch.setattr(settings, "image_description_url", "http://2070.zero:11434")
+        box = _w("3090.zero", kinds=["render", "trainer"],
+                 provides=["ltx-engine", "lora-trainer", "image-description"])
+        assert render_worker_beside_the_captioner([box]) is None
 
     def test_a_captioner_only_box_is_never_a_collision(self):
         """The 2070-style deployment: a service row that cannot render has nothing to wait


### PR DESCRIPTION
Second night-time caption failure: with the card idle the request went to the 3090's captioner, whose model load from disk took ~60 s (`Load failed` at the client's 60 s disconnect; the renders evict the 5.8 GB model from the page cache every time).

- `render_worker_beside_the_captioner` matches by the URL's host only. The provides-match picked the 3090's row whenever it provides image-description, including when the URL pointed at the 2070 -- which would have sent a caption during a render to the rendering box.
- `image_description_timeout_s` default 60 → 180.
- Production `.env` now points captions at the 2070 (warm model, seconds per caption) with no fallback; the 3090's captioner stays deployed for when the 2070 is retired.

https://claude.ai/code/session_01YPQVy6BsvYgHVwBnrUy5dW