### PR TITLE
Notes on a training run, written only by a human

### DIFF
--- a/alembic/versions/095_training_notes.py
+++ b/alembic/versions/095_training_notes.py
@@ -1,0 +1,25 @@
+"""Notes on a training run
+
+Revision ID: 095
+Revises: 094
+Create Date: 2026-09-09
+
+A free-form operator warning on TrainingJob (wanly-console#484), exactly as Dataset.notes
+carries it: what was learned by eye -- why a checkpoint was picked, what was rejected.
+Written only through the console's own route; the trainer's report channel cannot reach it.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "095"
+down_revision = "094"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("training_jobs", sa.Column("notes", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("training_jobs", "notes")

--- a/app/models.py
+++ b/app/models.py
@@ -526,6 +526,11 @@ class TrainingJob(Base):
     # for through publish_requests, and `checkpoints` records the ones that arrived.
     epochs = mapped_column(JSONB, nullable=True)
     publish_requests = mapped_column(JSONB, nullable=True)
+    # Free-form operator notes, exactly as Dataset.notes: what was learned about this run,
+    # why a checkpoint was picked. Written only by a human through the console's own route --
+    # not through the trainer's PATCH, whose conditional writes must never be able to clobber
+    # a date an editor typed.
+    notes = mapped_column(Text, nullable=True)
     # The dataset's anchor image at creation -- the face this LoRA is of, for the console
     # and for the character row it publishes to.
     thumbnail_uri = mapped_column(Text, nullable=True)

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -30,8 +30,8 @@ from app.database import get_db
 from app.enums import TRAINING_TERMINAL, TrainingStatus, WorkerKind, worker_can
 from app.models import Dataset, LtxCharacter, TrainingJob, User, Worker
 from app.schemas.training import (
-    MIN_DATASET_IMAGES, TrainingClaimResponse, TrainingCreate, TrainingProgress,
-    TrainingResponse,
+    MIN_DATASET_IMAGES, TrainingClaimResponse, TrainingCreate, TrainingNotes,
+    TrainingProgress, TrainingResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -329,6 +329,30 @@ async def update_training_job(
             if body.status == TrainingStatus.COMPLETED:
                 await _publish_character(db, job)
 
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+@router.patch("/training/{job_id}/notes", response_model=TrainingResponse)
+async def set_training_notes(
+    job_id: uuid.UUID,
+    body: TrainingNotes,
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Operator notes on a run, whole-field replace (wanly-console#484).
+
+    ITS OWN ROUTE, NOT A FIELD ON THE TRAINER'S PATCH, and that is the whole design: the
+    trainer's PATCH writes only fields it was handed (a report that omits a field must never
+    blank what an earlier one set) and is keyed to the shared worker API key. A note is a
+    human write that the reports must never be able to undo, so it keys to a console JWT
+    instead and accepts an explicit blank as a deliberate clear.
+    """
+    job = await db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+    job.notes = body.notes
     await db.commit()
     await db.refresh(job)
     return job

--- a/app/schemas/training.py
+++ b/app/schemas/training.py
@@ -109,11 +109,19 @@ class TrainingResponse(BaseModel):
     error_message: str | None = None
     checkpoints: list | None = None
     output_lora_path: str | None = None
+    # [[step, avr_loss], ...] sampled from the trainer's progress bar, for the curve.
     loss_log: list | None = None
-    epochs: list | None = None
-    loss_log: list | None = None
+    # Every checkpoint the run WROTE, as [{label, step, loss}], published or not. Only the
+    # final one is uploaded by default: a 650 MB checkpoint takes ~18 minutes to leave the
+    # 3090, and "I often only want 1 or 2 epochs". The rest sit on the trainer until asked
+    # for through publish_requests, and `checkpoints` records the ones that arrived.
     epochs: list | None = None
     publish_requests: list | None = None
+    # Operator notes, written through the console's own route (wanly-console#484). The
+    # trainer's PATCH deliberately cannot reach this: its conditional writes exist so a
+    # report that omits a field never blanks a previous one, and a human note deserves the
+    # stronger guarantee that no report can blank it at all.
+    notes: str | None = None
     thumbnail_uri: str | None = None
     created_at: datetime | None = None
     claimed_at: datetime | None = None
@@ -147,3 +155,14 @@ class TrainingProgress(BaseModel):
     output_lora_path: str | None = None
     loss_log: list | None = None
     epochs: list | None = None
+
+
+class TrainingNotes(BaseModel):
+    """Operator notes, whole-field replace.
+
+    NOT part of TrainingProgress deliberately: that model is the trainer's report channel,
+    whose conditional writes exist so an omitted field never blanks what came before. A note
+    wants the opposite contract -- an explicit write that the reports can never touch -- and
+    so it has its own tiny shape and its own route.
+    """
+    notes: str | None = Field(default=None, max_length=20000)

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -655,6 +655,61 @@ class TestCancellingActuallyCancels:
         assert out.step == 7
 
 
+class TestOperatorNotes:
+    """A note is a human write on a machine-reported row (wanly-console#484).
+
+    The reason it is its own route rather than a field on the trainer's PATCH: TrainingProgress
+    writes only what it is handed, which is exactly the wrong contract for a note -- a report
+    that simply does not mention it would look like a clear. Here the whole field is the unit,
+    and an explicit blank is a deliberate clear rather than an accident of omission.
+    """
+
+    async def _set(self, db, job, notes):
+        from app.routes.training import set_training_notes
+        from app.schemas.training import TrainingNotes
+        return await set_training_notes(job.id, TrainingNotes(notes=notes), _user=None, db=db)
+
+    async def test_a_note_is_set_and_returned(self, db):
+        job = _job()
+        db.add(job)
+        await db.commit()
+
+        out = await self._set(db, job, "e03 was the one that looked right; e04 plastic")
+
+        assert out.notes == "e03 was the one that looked right; e04 plastic"
+
+    async def test_a_trainer_report_cannot_touch_the_note(self, db):
+        """The guarantee the separate route exists for: the report channel omits what it
+        does not have, and omission must never mean clear."""
+        job = _job(notes="picked e03 by eye at seed 42")
+        db.add(job)
+        await db.commit()
+
+        from app.routes.training import update_training_job
+        out = await update_training_job(
+            job.id, TrainingProgress(step=99, progress_log="step 99"), db=db)
+
+        assert out.step == 99
+        assert out.notes == "picked e03 by eye at seed 42"
+
+    async def test_an_explicit_blank_clears_it(self, db):
+        job = _job(notes="obsolete")
+        db.add(job)
+        await db.commit()
+
+        out = await self._set(db, job, None)
+
+        assert out.notes is None
+
+    async def test_an_oversized_note_is_refused(self):
+        """A localStorage spill-out can be half a DVD image; a note is a note."""
+        import pydantic
+        from app.schemas.training import TrainingNotes
+        with pytest.raises(pydantic.ValidationError, match="at most 20000"):
+            TrainingNotes(notes="x" * 20001)
+
+
+
 class TestOnlyTheFinalGoesUpByDefault:
     """A 650 MB checkpoint takes ~18 minutes to leave the 3090 and "I often only want 1 or 2
     epochs". Every epoch stays on the trainer; the rest are asked for."""


### PR DESCRIPTION
Closes the API half of wanly-console#484.

**What.** `training_jobs.notes` (nullable free text), alembic migration 095, `PATCH /training/{id}/notes` keyed to the console's JWT, and `notes` on the training response.

**Why its own route.** `PATCH /training/{id}` is the trainer's report channel: shared worker API key, conditional writes — an omitted field never blanks what came before. That is precisely the wrong contract for a human note, where omission would read as a clear. The notes route takes the whole field and treats an explicit blank as deliberate; the trainer's reports cannot reach the column at all.

**Verified.** Migration applied on a real Postgres (094 → 095, plus stamp-path validation against a `create_all`-built schema). 4 new tests: set and read back; a trainer report cannot touch the note; explicit blank clears; oversized refused. Full suite 1003 passed against real Postgres; ruff F821 clean.