### PR TITLE
A character renders its trigger with the gender its LoRA trained on (console#487)

### DIFF
--- a/alembic/versions/095_character_gender.py
+++ b/alembic/versions/095_character_gender.py
@@ -1,0 +1,40 @@
+"""A character carries the gender its LoRA trained on
+
+Revision ID: 095
+Revises: 094
+Create Date: 2026-09-09
+
+Every LoRA trains on the caption "<trigger>, <gender>" (093/#293), but a pose's <TRIGGER>
+was filled with the bare trigger, so the word the identity was bound to never reached a
+render prompt (wanly-console#487). The column is what lets the fill say "p@yton, woman".
+
+Backfilled from each character's latest completed training run, which is the only record
+of what actually trained. Characters that predate the trainer stay NULL and render exactly
+as they did; the character dialog can set them.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "095"
+down_revision = "094"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ltx_characters", sa.Column("gender", sa.String(16), nullable=True))
+    op.execute("""
+        UPDATE ltx_characters c
+        SET gender = t.gender
+        FROM (
+            SELECT DISTINCT ON (character) character, config->>'gender' AS gender
+            FROM training_jobs
+            WHERE status = 'completed' AND config->>'gender' IS NOT NULL
+            ORDER BY character, created_at DESC
+        ) t
+        WHERE c.name = t.character AND c.gender IS NULL
+    """)
+
+
+def downgrade() -> None:
+    op.drop_column("ltx_characters", "gender")

--- a/app/models.py
+++ b/app/models.py
@@ -556,6 +556,12 @@ class LtxCharacter(Base):
     # and a trigger swap" — this is the trigger half, and it is why a new LoRA is never
     # locked out: every pose works for it the moment the row exists.
     trigger = mapped_column(String(64), nullable=False)
+    # The other half of the caption this LoRA trained on. Every run captions its images
+    # "<trigger>, <gender>", so the identity is bound to the PAIR; filling <TRIGGER> with
+    # the trigger alone left the binding word out of every render prompt, which is what
+    # decides who is who when two identity LoRAs share the weights (wanly-console#487).
+    # NULL for a character that predates the trainer: it renders the bare trigger as before.
+    gender = mapped_column(String(16), nullable=True)
     # Per-stage, never flat. Stage 1 generates at half size from noise; stage 2 refines the
     # 2x-upscaled latent and is where facial detail resolves. Collapsing them to one number
     # is a different configuration, not a simplification.

--- a/app/recipe_blob.py
+++ b/app/recipe_blob.py
@@ -2,7 +2,7 @@
 
 A segment's `ltx_recipe` names the people in the shot as
 
-    characters: [{name, trigger, char_lora, s1, s2}, ...]      # ordered, at most two
+    characters: [{name, trigger, gender, char_lora, s1, s2}, ...]   # ordered, at most two
 
 with the older scalar keys -- `character`, `trigger`, `char_lora`, `char_s1`, `char_s2` --
 mirrored from the first entry so that everything written before the list existed, and
@@ -24,7 +24,9 @@ MAX_CHARACTERS = len(TRIGGER_PLACEHOLDERS)
 
 
 def recipe_characters(ltx_recipe: dict[str, Any] | None) -> list[dict[str, Any]]:
-    """The people in a recipe blob, `[{name, trigger, char_lora, s1, s2}, ...]`.
+    """The people in a recipe blob, `[{name, trigger, gender, char_lora, s1, s2}, ...]`.
+
+    `gender` is recorded since wanly-console#487 and absent before; readers use `.get`.
 
     The list when it is there, else one entry synthesised from the scalars, else nothing.
     Entries are returned as recorded -- including a `char_lora` of "none", which is a real
@@ -44,6 +46,29 @@ def recipe_characters(ltx_recipe: dict[str, Any] | None) -> list[dict[str, Any]]
         "s1": ltx_recipe.get("char_s1"),
         "s2": ltx_recipe.get("char_s2"),
     }]
+
+
+def trigger_phrase(trigger: str | None, gender: str | None) -> str | None:
+    """What fills a placeholder: the trigger AND the word its LoRA bound it to.
+
+    Every run captions its images "<trigger>, <gender>" (wanly-api#293), so "p@yton, woman"
+    is the token pair the identity actually learned, and the render prompt has to say the
+    same thing. With two identity LoRAs summed into the same weights this pair is the only
+    thing that says which face goes on which body (wanly-console#487).
+
+    No trigger means no phrase -- the "no character" slot never grows a gender -- and no
+    gender means the bare trigger, which is exactly what every character rendered before.
+    """
+    if not trigger:
+        return trigger
+    if not gender:
+        return trigger
+    return f"{trigger}, {gender}"
+
+
+def character_phrase(person: dict[str, Any]) -> str | None:
+    """`trigger_phrase` for one entry of `recipe_characters`."""
+    return trigger_phrase(person.get("trigger"), person.get("gender"))
 
 
 def render_prompt(template: str, triggers: str | Sequence[str | None]) -> str:

--- a/app/routes/ltx_recipes.py
+++ b/app/routes/ltx_recipes.py
@@ -141,6 +141,7 @@ async def get_recipe_book(
                 "name": c.name,
                 "char_lora": c.char_lora,
                 "trigger": c.trigger,
+                "gender": c.gender,
                 "strength_stage_1": c.strength_stage_1,
                 "strength_stage_2": c.strength_stage_2,
             }

--- a/app/routes/segments.py
+++ b/app/routes/segments.py
@@ -27,7 +27,8 @@ from app.enums import JobStatus, SegmentStatus, VideoStatus, WorkerKind
 from app.ltx_stack import LTX_STACK
 from app.model_requirements import CHECKPOINT, canonical
 from app.recipe_blob import (
-    TRIGGER_PLACEHOLDERS, placeholders_in, recipe_characters, recipe_problem, render_prompt,
+    TRIGGER_PLACEHOLDERS, character_phrase, placeholders_in, recipe_characters, recipe_problem,
+    render_prompt, trigger_phrase,
 )
 from app.models import (
     AppSetting, ImageMeta, Job, LtxCharacter, Segment, User, Video, Wildcard, Worker,
@@ -296,6 +297,10 @@ async def _resolve_trigger(db: AsyncSession, prompt: str, ltx_recipe: dict | Non
     -- rendering the literal text is bad, but silently dropping the token that anchors a
     character LoRA is worse and much harder to notice.
 
+    What is filled in is the trigger PHRASE, "p@yton, woman" -- the caption the LoRA trained
+    on, gender included (wanly-console#487). The row's gender when the row exists, else the
+    one the blob recorded, else the bare trigger as before.
+
     The console normally substitutes at creation time; this catches a prompt that reaches the
     API still carrying a placeholder — an edited prompt, or any caller that is not the
     console.
@@ -311,7 +316,8 @@ async def _resolve_trigger(db: AsyncSession, prompt: str, ltx_recipe: dict | Non
             row = (await db.execute(
                 select(LtxCharacter).where(LtxCharacter.name == person["name"])
             )).scalar_one_or_none()
-        triggers.append(row.trigger if row else person.get("trigger"))
+        triggers.append(trigger_phrase(row.trigger, row.gender) if row
+                        else character_phrase(person))
     return render_prompt(prompt, triggers)
 
 

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -368,6 +368,10 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
     Upsert on name: retraining a character replaces which LoRA it points at, which is the whole
     point of a v2. The strengths are left alone if the row exists, because they may have been
     tuned by hand.
+
+    The gender travels with the LoRA, not the row: it is the caption THIS file trained on, and
+    a v2 captioned differently must render differently (wanly-console#487). A run that recorded
+    none leaves the row's alone -- it may have been set by hand for a LoRA that predates it.
     """
     if not job.output_lora_path:
         return
@@ -379,15 +383,18 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
     existing = (await db.execute(
         select(LtxCharacter).where(LtxCharacter.name == job.character)
     )).scalar_one_or_none()
+    gender = (job.config or {}).get("gender") or None
     if existing:
         existing.char_lora = basename
         existing.trigger = job.trigger
+        if gender:
+            existing.gender = gender
         if job.thumbnail_uri:
             existing.image_uri = job.thumbnail_uri
         logger.info("character %s now points at %s", job.character, basename)
     else:
         db.add(LtxCharacter(name=job.character, char_lora=basename, trigger=job.trigger,
-                            image_uri=job.thumbnail_uri))
+                            gender=gender, image_uri=job.thumbnail_uri))
         logger.info("created character %s -> %s", job.character, basename)
 
 

--- a/app/schemas/ltx.py
+++ b/app/schemas/ltx.py
@@ -2,9 +2,13 @@
 
 import uuid
 from datetime import datetime
-from typing import Optional, List
+from typing import Literal, Optional, List
 
 from pydantic import BaseModel, ConfigDict, Field
+
+#: The word a LoRA's caption bound its trigger to (wanly-console#487). The same three the
+#: training request takes, because this is what that request's caption recorded.
+Gender = Literal["woman", "man", "person"]
 
 
 class LtxCharacterCreate(BaseModel):
@@ -13,6 +17,8 @@ class LtxCharacterCreate(BaseModel):
     # Fills every pose's <TRIGGER> placeholder. Defaults to the character's own name, which
     # is what all three seeded characters use.
     trigger: Optional[str] = Field(default=None, max_length=64)
+    # Renders beside the trigger, "p@yton, woman", exactly as the LoRA's caption read.
+    gender: Optional[Gender] = None
     # Per-stage, never flat — stage 1 decides the body, stage 2 resolves the face.
     strength_stage_1: float = 0.8
     strength_stage_2: float = 1.5
@@ -26,6 +32,7 @@ class LtxCharacterResponse(BaseModel):
     name: str
     char_lora: str
     trigger: str
+    gender: Optional[Gender] = None
     strength_stage_1: float
     strength_stage_2: float
     image_uri: Optional[str] = None
@@ -43,6 +50,9 @@ class LtxCharacterUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=64)
     char_lora: Optional[str] = Field(default=None, min_length=1)
     trigger: Optional[str] = Field(default=None, min_length=1, max_length=64)
+    # Sent as null, it clears: a character whose LoRA trained on a bare caption should not
+    # keep rendering a gender it never bound.
+    gender: Optional[Gender] = None
     strength_stage_1: Optional[float] = Field(default=None, ge=0)
     strength_stage_2: Optional[float] = Field(default=None, ge=0)
     image_uri: Optional[str] = None

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -186,6 +186,32 @@ class TestPublishing:
         assert row.char_lora == "pay_v2_e03"
         assert row.strength_stage_1 == 0.9, "hand-tuned strengths were overwritten"
 
+    async def test_the_gender_the_run_captioned_lands_on_the_row(self, db):
+        """The caption was "p@y, woman"; the row must say so or <TRIGGER> renders the
+        trigger without the word the identity was bound to (wanly-console#487)."""
+        j = _job(config={"gender": "woman", "caption": "p@y, woman"},
+                 output_lora_path="s3://ltx-loras/character/pay_v1_e05.safetensors")
+        db.add(j)
+        await db.flush()
+        await _publish_character(db, j)
+        await db.flush()
+        from sqlalchemy import select
+        row = (await db.execute(select(LtxCharacter).where(
+            LtxCharacter.name == "pay"))).scalar_one()
+        assert row.gender == "woman"
+
+    async def test_a_run_without_a_gender_leaves_a_hand_set_one_alone(self, db):
+        db.add(LtxCharacter(name="pay", char_lora="pay_v1_e05", trigger="p@y", gender="woman"))
+        await db.flush()
+        j = _job(version=2, config={"caption": "p@y, close-up"},
+                 output_lora_path="s3://ltx-loras/character/pay_v2_e03.safetensors")
+        await _publish_character(db, j)
+        await db.flush()
+        from sqlalchemy import select
+        row = (await db.execute(select(LtxCharacter).where(
+            LtxCharacter.name == "pay"))).scalar_one()
+        assert row.gender == "woman"
+
     async def test_nothing_is_published_without_a_file(self, db):
         j = _job(output_lora_path=None)
         await _publish_character(db, j)

--- a/tests/test_two_characters.py
+++ b/tests/test_two_characters.py
@@ -8,7 +8,8 @@ import pytest
 from app.model_requirements import LORA, Artifact, required_artifacts
 from app.models import LtxCharacter
 from app.recipe_blob import (
-    MAX_CHARACTERS, TRIGGER2_PLACEHOLDER, recipe_characters, recipe_problem, render_prompt,
+    MAX_CHARACTERS, TRIGGER2_PLACEHOLDER, character_phrase, recipe_characters, recipe_problem,
+    render_prompt, trigger_phrase,
 )
 from app.routes.wildcards import RESERVED_WILDCARD_NAMES
 
@@ -38,6 +39,33 @@ class TestRenderPrompt:
     def test_trigger_does_not_eat_trigger2(self):
         """"<TRIGGER>" is not a substring of "<TRIGGER2>", and this proves it stays so."""
         assert render_prompt("<TRIGGER2>", ["p@y"]) == "<TRIGGER2>"
+
+
+class TestTriggerPhrase:
+    """What fills the placeholder is the caption the LoRA trained on, gender included
+    (wanly-console#487): "p@yton, woman", not "p@yton"."""
+
+    def test_the_phrase_is_the_training_caption(self):
+        assert trigger_phrase("p@yton", "woman") == "p@yton, woman"
+        assert trigger_phrase("d@vid", "man") == "d@vid, man"
+
+    def test_no_gender_is_the_bare_trigger_as_before(self):
+        assert trigger_phrase("k3llydw", None) == "k3llydw"
+        assert trigger_phrase("k3llydw", "") == "k3llydw"
+
+    def test_the_no_character_slot_never_grows_a_gender(self):
+        assert trigger_phrase("", "woman") == ""
+        assert trigger_phrase(None, "woman") is None
+
+    def test_a_blob_entry_renders_its_recorded_gender(self):
+        person = {"name": "Payton", "trigger": "p@yton", "gender": "woman"}
+        assert character_phrase(person) == "p@yton, woman"
+        assert character_phrase({"name": "Me", "trigger": "d@vid"}) == "d@vid"
+
+    def test_both_people_render_bound_to_their_gender(self):
+        people = [{"trigger": "p@yton", "gender": "woman"}, {"trigger": "d@vid", "gender": "man"}]
+        assert render_prompt("<TRIGGER> and <TRIGGER2>", [character_phrase(p) for p in people]) \
+            == "p@yton, woman and d@vid, man"
 
 
 class TestTheOneReader:
@@ -125,3 +153,22 @@ class TestResolveTrigger:
         from app.routes.segments import _resolve_trigger
         out = await _resolve_trigger(db, "<TRIGGER>, a woman", ONE_SCALAR)
         assert out == "p@y, a woman"
+
+    async def test_the_rows_gender_renders_beside_the_trigger(self, db):
+        """The caption was "p@y, woman" / "d@vid, man"; the prompt says the same pair
+        (wanly-console#487)."""
+        from app.routes.segments import _resolve_trigger
+        db.add(LtxCharacter(name="p@y", char_lora="pay_v2_e05", trigger="p@y", gender="woman"))
+        db.add(LtxCharacter(name="Me", char_lora="david_v1_final", trigger="d@vid", gender="man"))
+        await db.commit()
+        out = await _resolve_trigger(db, "<TRIGGER2> stands behind <TRIGGER>", TWO)
+        assert out == "d@vid, man stands behind p@y, woman"
+
+    async def test_a_deleted_row_renders_the_gender_the_blob_recorded(self, db):
+        from app.routes.segments import _resolve_trigger
+        blob = {**TWO, "characters": [
+            {**TWO["characters"][0], "gender": "woman"},
+            {**TWO["characters"][1], "gender": "man"},
+        ]}
+        out = await _resolve_trigger(db, "<TRIGGER> and <TRIGGER2>", blob)
+        assert out == "p@y, woman and d@vid, man"


### PR DESCRIPTION
Tracks DavidJBarnes/wanly-console#487. Pairs with the console PR of the same name.

## Why

Two-person renders load and fuse both character LoRAs correctly (verified on the 3090: `payton_v1_final` and `Me_v2_final` both fused 480/480). What was missing is the prompt binding. Every LoRA trains on the caption `<trigger>, <gender>` since #293, but `<TRIGGER>` was filled with the bare trigger, so `p@yton` rendered without the `woman` its identity was bound to. With two identity LoRAs summed into the same weights, that pair is the only thing that says which face goes on which body.

## What

- `ltx_characters.gender` (woman / man / person, nullable). Migration 095 backfills it from each character's latest completed training run; characters that predate the trainer stay NULL and render the bare trigger as before.
- `_publish_character` sets it from the run's config, and leaves a hand-set one alone when the run recorded none.
- `recipe_blob.trigger_phrase` / `character_phrase`: `p@yton, woman` when a gender is known. `_resolve_trigger` fills with the phrase from the row, else from the blob's recorded `gender`, so a re-roll survives the row being deleted.
- Recipe book and character create/update/response schemas carry `gender`. PATCH with `null` clears it.

## Verified

- `REQUIRE_DB=1` full suite: 1012 passed against the local test postgres.
- Backfill SQL executed (rolled back) against the test schema.
- On the live DB the backfill will set Payton → woman and Me → man (from `training_jobs.config`); k3lly2026 / k3llydw stay NULL until set in the character dialog.

https://claude.ai/code/session_01EtkWwkD41G2TfmnXfm2YXK