### PR TITLE
Migration 096: the character gender column follows 095 (training notes)

### DIFF
--- a/alembic/versions/096_character_gender.py
+++ b/alembic/versions/096_character_gender.py
@@ -1,7 +1,7 @@
 """A character carries the gender its LoRA trained on
 
-Revision ID: 095
-Revises: 094
+Revision ID: 096
+Revises: 095
 Create Date: 2026-09-09
 
 Every LoRA trains on the caption "<trigger>, <gender>" (093/#293), but a pose's <TRIGGER>
@@ -15,8 +15,8 @@ as they did; the character dialog can set them.
 import sqlalchemy as sa
 from alembic import op
 
-revision = "095"
-down_revision = "094"
+revision = "096"
+down_revision = "095"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
#301 landed its migration as a second `095` beside `095_training_notes` (#300), so the deploy's `alembic upgrade head` stopped on "Multiple head revisions" before running anything. The old API container is still up; the live DB is at 095 with no `gender` column yet.

Same migration, renumbered to 096 with `down_revision = "095"`. `alembic heads` now reports a single head.

Tracks DavidJBarnes/wanly-console#487.

https://claude.ai/code/session_01EtkWwkD41G2TfmnXfm2YXK