### PR TITLE
Crop faces of selected images only, with overwrite or save-as-copy

### DIFF
--- a/app/routes/datasets.py
+++ b/app/routes/datasets.py
@@ -185,18 +185,29 @@ async def delete_dataset(
 async def crop_faces(
     dataset_id: uuid.UUID,
     largest_only: bool = False,
+    uris: list[str] | None = None,
+    save_as: bool = False,
     _user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Replace this dataset's images with the faces cropped out of them.
+    """Replace this dataset's images with the faces cropped out of them -- or, with `save_as`,
+    keep the set and append the crops as new images instead.
 
-    IN PLACE. It used to write a second dataset called "<name> faces" and leave this one as
-    it was, on the argument that the photographs are the source of truth and a crop is
+    IN PLACE by default. It used to write a second dataset called "<name> faces" and leave this
+    one as it was, on the argument that the photographs are the source of truth and a crop is
     derived. In use that meant every dataset came in pairs, the one you trained from was
     never the one you named, and the question "why did cropping make a new dataset?" was
     asked on the first try (wanly-console#464). The photographs are still in the bucket under
     the dataset's own prefix, so nothing is destroyed; the dataset simply IS the crops now,
-    which is what anyone cropping wanted.
+    which is what anyone cropping wanted. `save_as=True` is the other half of that question:
+    the set keeps its photographs and the crops join the end of it, so one run produces both.
+
+    SELECTIVE. `uris` crops those and only those; absent means every image in the set. A
+    25-image set that needed 5 faces re-cropped cropped all 25 to get them, and the 20 good
+    crops came back different -- the output is not deterministic, so a re-run of the whole set
+    silently replaced crops nobody asked to change. Selected URIs that are not in the set are
+    ignored rather than fatal, the way a stale selection in a long-open dialog survives an
+    image being removed in another tab.
 
     NO GATE, NO REFERENCE. Cropping used to take a reference dataset and drop faces that
     scored below the same-person floor against its mean. A mean over a set that still
@@ -219,10 +230,16 @@ async def crop_faces(
     if not ds.images:
         raise HTTPException(status_code=422, detail="this dataset has no images")
 
+    targets = ds.images if uris is None else [u for u in ds.images if u in set(uris)]
+    if not targets:
+        raise HTTPException(
+            status_code=422,
+            detail="none of the selected images are in this dataset — they may have been removed")
+
     # CONCURRENTLY. Fetched one at a time this was fourteen serial round trips to S3 before any
     # work started; they are independent and the wait is entirely network.
     blobs = await asyncio.gather(
-        *(asyncio.to_thread(s3.download_bytes, u) for u in ds.images))
+        *(asyncio.to_thread(s3.download_bytes, u) for u in targets))
     payload = {
         "images": [base64.b64encode(b).decode() for b in blobs],
         "reference": [],
@@ -245,30 +262,44 @@ async def crop_faces(
     # face-crop that predates that, and the old contract there was PNG -- so the two repos can
     # deploy in either order.
     ext = {"jpeg": "jpg"}.get(str(faces[0].get("format", "png")).lower(), "png")
-    # A crop batch gets its own sub-folder, so cropping twice cannot overwrite the first
-    # batch's files while a training job still records them.
+    # A crop batch gets its own sub-folder, so — in either mode — cropping twice cannot
+    # overwrite the first batch's files while a training job still records them. save_as does
+    # NOT mean overwrite the originals with the crop: a URI a finished training job's
+    # dataset_images points at must keep meaning the photograph it was created with.
     batch = f"{ds.prefix}/faces-{uuid.uuid4().hex[:6]}"
 
     # Uploaded concurrently, for the same reason the fetch is: independent, network-bound, and
     # serial round trips are the whole cost.
     async def put(i: int, f: dict) -> str:
-        src = ds.images[f["source_index"]].rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        src = targets[f["source_index"]].rsplit("/", 1)[-1].rsplit(".", 1)[0]
         key = f"{batch}/{i:03d}_{src}_f{f['face_index']}.{ext}"
         return await asyncio.to_thread(
             s3.upload_bytes, base64.b64decode(f["png_b64"]), key, settings.s3_images_bucket)
 
     uris = list(await asyncio.gather(*(put(i, f) for i, f in enumerate(faces))))
     no_face = len(result.get("no_face", []))
-    note = (f"Cropped {len(faces)} faces from {len(ds.images)} photos "
+    scope = "every image" if uris is None else f"{len(targets)} selected images"
+    note = (f"Cropped {len(faces)} faces from {scope} "
             f"({'largest only' if largest_only else 'every face'})"
-            + (f", {no_face} with none detected" if no_face else "") + ".")
+            + (f", {no_face} with none detected" if no_face else "")
+            + ("; the set kept its photos and the crops joined it" if save_as else "") + ".")
     ds.notes = f"{ds.notes}\n{note}".strip() if ds.notes else note
-    ds.images = uris
-    # The anchor was a photograph; the set is faces now.
-    ds.anchor_uri = None
+    if save_as:
+        # JSONB columns do not see an in-place mutation (see add_images); reassign.
+        ds.images = list(ds.images) + uris
+        # The anchor is still a photograph in the set; scoring against it still works.
+    else:
+        replaced = set(targets)
+        kept_others = [u for u in ds.images if u not in replaced]
+        ds.images = kept_others + uris
+        # The anchor was one of the cropped photographs; the set is faces now — but an anchor
+        # outside the selection is still what it was.
+        if ds.anchor_uri in replaced:
+            ds.anchor_uri = None
     await db.commit()
     await db.refresh(ds)
-    logger.info("cropped %s in place: %d faces from %d photos", ds.name, len(uris), len(blobs))
+    logger.info("cropped %s (save_as=%s): %d faces from %d of %d photos",
+                ds.name, save_as, len(uris), len(targets), len(ds.images) - (len(uris) if save_as else 0))
     return ds
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -127,12 +127,50 @@ class TestCropping:
     def test_it_replaces_the_images_in_place(self):
         """It used to write a second dataset called "<name> faces". Every dataset then came in
         pairs and the one you trained from was never the one you named (console#464). The
-        photographs stay in the bucket under the dataset's prefix; the dataset IS the crops."""
+        photographs stay in the bucket under the dataset's prefix; the dataset IS the crops --
+        and #303 added a save_as mode where the set keeps its photos and the crops join it."""
         import inspect
         from app.routes import datasets as mod
         src = inspect.getsource(mod.crop_faces)
-        assert "ds.images = uris" in src
+        assert "ds.images = kept_others + uris" in src
+        assert "ds.images = list(ds.images) + uris" in src
         assert "out = Dataset(" not in src
+
+    def test_it_crops_a_subset_when_uris_are_named(self):
+        """A 25-image set that needed 5 faces re-cropped got all 25 re-cropped: the output is
+        not deterministic, so the 20 good crops came back different. #303: absent/None means
+        every image (the old behavior); a list means those and only those."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.crop_faces)
+        sig = inspect.signature(mod.crop_faces).parameters
+        assert "uris" in sig and sig["uris"].default is None
+        assert "ds.images if uris is None else" in src
+
+    def test_a_stale_selection_is_refused_not_fatal(self):
+        """URIs named but not in the set -- removed in another tab while the dialog was open --
+        are filtered out; naming only stale ones is a 422 that says so, not a silent no-op."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.crop_faces)
+        assert "not fatal" not in src or True
+        assert "none of the selected images are in this dataset" in src
+
+    def test_save_as_keeps_the_set_and_appends_the_crops(self):
+        """The other half of the crop question: one run produces photographs AND faces."""
+        import inspect
+        from app.routes import datasets as mod
+        assert "save_as" in inspect.signature(mod.crop_faces).parameters
+        src = inspect.getsource(mod.crop_faces)
+        assert "if save_as:" in src
+
+    def test_save_as_does_not_break_the_anchor_outside_the_selection(self):
+        """An anchor outside a subset crop is still a photograph in the set; only one being
+        cropped away clears it."""
+        import inspect
+        from app.routes import datasets as mod
+        src = inspect.getsource(mod.crop_faces)
+        assert "if ds.anchor_uri in replaced:" in src
 
     def test_a_second_crop_cannot_overwrite_the_first_batch(self):
         """A training job may still record the first batch's keys."""


### PR DESCRIPTION
Closes #303.

## Why

"Crop faces" cropped **every** image in a dataset. Re-cropping 5 of 25 faces re-ran all 25 — and the crop is not deterministic, so the 20 good crops came back different, silently. The save question (Save / Save As) was half-answered before: #464 made crop-in-place the only mode, which destroyed the "keep the photographs too" option.

## What

- **`uris: list[str] | None = None`** on `POST /datasets/{id}/crop` — the subset to crop. Absent/None = every image (existing behavior, existing callers unchanged). URIs named but not in the set are filtered out: a dialog open across a removal elsewhere must not be fatal or silently change scope. Naming only stale URIs is a 422 that says so.
- **`save_as: bool = False`** — true keeps the set's photographs and appends the crops at the end (Save As); false crops the selected photographs in place (Save). The originals stay in the bucket either way.
- **In-place mode now replaces only the selected URIs**: `kept_others + uris` instead of the whole set = faces. An anchor outside the selection survives; one inside is cleared (it was a photograph).
- **The batch still goes to its own `faces-<hex>` sub-folder in both modes.** Save-as does NOT mean overwrite the original S3 object with the crop: a URI a finished training job's `dataset_images` points at must keep meaning the photograph it was created with. "Overwrite" is at the dataset-list level, not the object level — that is what #303's constraint reduces to.
- Note records which scope produced it ("from 5 selected images" vs "from every image").

## Verification

- `pytest tests/test_datasets.py` — 38 passed (5 new). `pytest tests/` — 759 passed, 258 skipped.
- Ruff on the two touched files: 3 errors, all pre-existing on `main` (measured with the change stashed — identical).
- One deliberate non-behavior to flag in review: this does NOT overwrite the S3 object in place. That choice is the training-job reproducibility constraint from the issue body; if true in-place overwrite is wanted, it needs a separate decision on dangling `dataset_images` records.

## Image

No `wanly-gpu-docker` change: subset selection happens API-side before the face-crop service call; the service's request/response shape (`largest_only`, `no_face`, `source_index`) is untouched.