### PR TITLE
Dataset membership blocks deleting an image from the repo

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -15,7 +15,7 @@ from app.routes.datasets import DATASETS_PREFIX
 from app.database import get_db
 from app.joycaption import CaptionError
 from app.enums import TRAINING_TERMINAL
-from app.models import Favorite, ImageMeta, Job, Segment, TrainingJob, User
+from app.models import Dataset, Favorite, ImageMeta, Job, Segment, TrainingJob, User
 from app.routes.captions import caption_image_bytes
 from app.schemas.images import ImageSceneRequest, ImageSceneResponse, ImageTagsUpdate
 from app.tag_filter import like_escape
@@ -120,7 +120,7 @@ async def find_image_references(db: AsyncSession, paths: list[str]) -> dict[str,
         if not path or path not in wanted:
             return
         entry = refs.setdefault(path, {"job_ids": [], "segment_ids": [],
-                                       "training_ids": []})
+                                       "training_ids": [], "dataset_ids": []})
         if str(holder_id) not in entry[kind]:
             entry[kind].append(str(holder_id))
 
@@ -157,6 +157,21 @@ async def find_image_references(db: AsyncSession, paths: list[str]) -> dict[str,
     for job_id, images in train_rows.all():
         for value in images or []:
             _hold(value, "training_ids", job_id)
+
+    # DATASET MEMBERSHIP COUNTS TOO (wanly-api#305). A photograph in a dataset that could be
+    # deleted from the repo silently vanished from every set holding it: the set keeps a dead
+    # URI, the count changes with no name, and training fetches a 404. Same Python-side JSONB
+    # matching as the training check above -- one row per dataset ever, so a containment query
+    # would be machinery the problem does not deserve.
+    #
+    # Unlike an in-flight training run, membership is ordinary state: someone rebuilding a set
+    # legitimately wants the originals gone afterwards. That is what DELETE /datasets/{id}
+    # (purge) and removing the image FROM the dataset are for -- this gate says which sets
+    # hold it, and force=true stays the escape, named (wanly-api#156).
+    ds_rows = await db.execute(select(Dataset.id, Dataset.images))
+    for ds_id, images in ds_rows.all():
+        for value in images or []:
+            _hold(value, "dataset_ids", ds_id)
 
     return refs
 
@@ -426,6 +441,7 @@ async def delete_image(
                     "path": path,
                     "job_ids": refs[path]["job_ids"],
                     "segment_ids": refs[path]["segment_ids"],
+                    "dataset_ids": refs[path]["dataset_ids"],
                 },
             )
     await asyncio.to_thread(delete_object, path)

--- a/tests/test_image_delete_refs.py
+++ b/tests/test_image_delete_refs.py
@@ -21,7 +21,7 @@ from app.auth import get_current_user
 from app.database import get_db
 from app.enums import JobStatus
 from app.main import app
-from app.models import Job, Segment, User
+from app.models import Dataset, Job, Segment, User
 
 _fake_user = User(id=uuid.uuid4(), username="testuser", password_hash="x")
 
@@ -45,10 +45,16 @@ class _FakeSession:
     It reads the selected columns and the bound IN values off the statement rather than
     matching a hardcoded query, so it does not have to be rewritten every time the helper's
     column list widens — which is exactly the change this ticket is about.
+
+    Rows are returned when any STRING column value is in the statement's wanted set. A
+    datasets row is returned unconditionally: its `images` is a JSON list the helper matches
+    in Python, so there is no string column for the row filter to key on — the helper itself
+    does the narrowing via _hold.
     """
 
-    def __init__(self, jobs=(), segments=()):
-        self._rows = {"jobs": list(jobs), "segments": list(segments)}
+    def __init__(self, jobs=(), segments=(), datasets=()):
+        self._rows = {"jobs": list(jobs), "segments": list(segments),
+                      "datasets": list(datasets)}
 
     async def execute(self, query):
         table = query.get_final_froms()[0].name
@@ -63,7 +69,8 @@ class _FakeSession:
         rows = []
         for obj in self._rows.get(table, []):
             values = tuple(getattr(obj, name, None) for name in columns)
-            if any(isinstance(v, str) and v in wanted for v in values):
+            if table == "datasets" or any(
+                    isinstance(v, str) and v in wanted for v in values):
                 rows.append(values)
         return _FakeResult(rows)
 
@@ -164,6 +171,52 @@ class TestDeleteRefusesReferencedImages:
 
         assert resp.status_code == 200
         deleter.assert_called_once_with(LOOSE)
+
+    @pytest.mark.asyncio
+    async def test_dataset_membership_returns_409(self):
+        """A photograph in a dataset that could be deleted from the repo silently vanished
+        from every set holding it: the set kept a dead URI and training fetched a 404."""
+        ds = Dataset(id=uuid.uuid4(), name="set", images=[FACE])
+        _override(_FakeSession(datasets=[ds]))
+
+        resp, deleter = await _delete(FACE)
+
+        assert resp.status_code == 409
+        assert str(ds.id) in resp.json()["detail"]["dataset_ids"]
+        deleter.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dataset_membership_names_the_set_in_the_409(self):
+        """The point of the body is to say what to fix — the set is the thing to go look at."""
+        ds = Dataset(id=uuid.uuid4(), name="set", images=["s3://b/other.png", FACE])
+        _override(_FakeSession(datasets=[ds]))
+
+        resp, _ = await _delete(FACE)
+
+        detail = resp.json()["detail"]
+        assert detail["dataset_ids"] == [str(ds.id)]
+
+    @pytest.mark.asyncio
+    async def test_force_still_deletes_a_dataset_member(self):
+        """Membership is ordinary state, not a run in flight: rebuilding a set legitimately
+        wants the originals gone afterwards. force=true stays the escape."""
+        ds = Dataset(id=uuid.uuid4(), name="set", images=[FACE])
+        _override(_FakeSession(datasets=[ds]))
+
+        resp, deleter = await _delete(FACE, force="true")
+
+        assert resp.status_code == 200
+        deleter.assert_called_once_with(FACE)
+
+    @pytest.mark.asyncio
+    async def test_a_dataset_holding_other_images_does_not_gate_this_one(self):
+        ds = Dataset(id=uuid.uuid4(), name="set", images=["s3://b/other.png"])
+        _override(_FakeSession(datasets=[ds]))
+
+        resp, deleter = await _delete(FACE)
+
+        assert resp.status_code == 200
+        deleter.assert_called_once_with(FACE)
 
     @pytest.mark.asyncio
     async def test_wrong_bucket_still_rejected_before_any_db_work(self):


### PR DESCRIPTION
Closes #305.

## Why

`DELETE /images` refused when a job, segment or in-flight training job pointed at an image — but **`Dataset.images` itself was unchecked**. A photograph sitting in a dataset could be deleted from the repo today: the set keeps a dead URI, its count changes with nothing to point at, and training fetches a 404 — the same silent failure #156's gate was built for, one holder kind narrower.

## What

- `Dataset.images` joins `find_image_references` (`Dataset` row scan, same Python-side JSONB matching as the training check — one row per dataset ever, no containment SQL).
- The 409 detail gains `dataset_ids`, so the console can say "in 2 datasets" alongside jobs/segments.
- **`force=true` stays the deliberate escape**: membership is ordinary state, not a run in flight. Someone rebuilding a set legitimately wants the originals gone — that's what `DELETE /datasets/{id} (purge)` and removing the image *from* the dataset are for. This gate says *which* sets hold it; it does not make images undeletable.

## Verification

- `pytest tests/` — 763 passed (4 new in test_image_delete_refs.py: membership 409s, the 409 names the set, force still deletes a member, an unrelated dataset does not gate).
- One test-infrastructure fix worth noting: `_FakeSession` filtered rows on string columns matching the wanted paths, but a datasets row has no string column to key on (its `images` is a JSON list matched in Python) — dataset rows returned nothing and the first cut of the gate appeared dead in tests. Rows from the `datasets` table are now returned unconditionally; the narrowing happens in `_hold`, where the production code does it.
- Ruff: repo-wide error count identical (63) with the change stashed — the 2 in touched files are pre-existing on `main`.

## Image

No `wanly-gpu-docker` change: the daemon never deletes repo images; this is API-side gating only.