### PR TITLE
Image descriptions are searchable

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from fastapi.responses import Response
-from sqlalchemy import func, not_, or_, select, true
+from sqlalchemy import and_, func, not_, or_, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user, verify_api_key_or_bearer, verify_api_key_or_token
@@ -597,14 +597,27 @@ def search_pattern(q: str) -> str:
 
 
 def path_clause(q: str):
-    """Match the S3 key as a substring.
+    """Match the S3 key OR the description as a substring.
 
     Fragment matching is right here and wrong for tags. Images arrive named
     "00111-1696092597-swapped.png" and get referred to by that number in job configs and notes,
     so "which folder was 00111 in" has to be answerable -- and a partially remembered filename is
-    the only handle there is. Tags have exact controls of their own, so they no longer share this.
+    the only handle there is.
+
+    The description joins under the same OR (wanly-console#447): a description is prose saying
+    WHAT is in the image, and "the one where she's wearing the red dress" is a search by content
+    that neither the filename nor an exact tag can answer. Descriptions are ~40 words of
+    JoyCaption output, so substring is right and no index or tsvector is warranted at repo scale.
+    Tags still do not share this clause -- they have exact controls of their own, and a tag
+    matching by substring is the #kelly/2,057 mistake measured on 2026-08-14.
+
+    NULL descriptions (never described) fall out of the OR naturally: the path clause still
+    matches, so an undescribed image remains findable by filename.
     """
-    return ImageMeta.path.ilike(search_pattern(q), escape="\\")
+    return or_(
+        ImageMeta.path.ilike(search_pattern(q), escape="\\"),
+        ImageMeta.scene_description.ilike(search_pattern(q), escape="\\"),
+    )
 
 
 def tag_clause(tag: str):
@@ -646,11 +659,20 @@ def repo_images_only():
     a filename search would HEAD one, find it, and put a render's intermediate frame in the
     Image Repo, which is why console#427 refused to store them at all.
 
+    Training datasets share the images bucket and are excluded too: the folder listing hides
+    the datasets/ prefix (wanly-console#464), so a search that still returned them would make
+    the two look connected -- and with descriptions now searched by content (wanly-console#447),
+    a described dataset staging copy would fill results from the repo search box. Narrows rather
+    than excludes: repo folders keep their s3:// path, so one LIKE still covers every real image.
+
     Separate from image_filter deliberately: that function returns the USER's criteria, and
     an empty list is how the route knows nothing was asked for and answers 400 rather than
     serving the whole repo. Folding this in would make it never empty.
     """
-    return ImageMeta.path.like(f"s3://{settings.s3_images_bucket}/%")
+    return and_(
+        ImageMeta.path.like(f"s3://{settings.s3_images_bucket}/%"),
+        not_(ImageMeta.path.like(f"s3://{settings.s3_images_bucket}/{DATASETS_PREFIX}/%")),
+    )
 
 
 @router.get("/images/search", dependencies=[Depends(get_current_user)])
@@ -663,12 +685,12 @@ async def search_images(
     db: AsyncSession = Depends(get_db),
     user = Depends(get_current_user),
 ):
-    """Find images by whole tags (AND) and/or a filename fragment.
+    """Find images by whole tags (AND) and/or a filename or description fragment.
 
     Two controls with two different jobs. `tags` and `exclude` match a tag in full, so Kelly
-    stops dragging in KellyYoung; `q` matches the S3 key as a substring, because a half-recalled
-    filename is often the only handle there is, and it is the only way an untagged image can be
-    found at all.
+    stops dragging in KellyYoung; `q` matches the S3 key or the description as a substring --
+    a half-recalled filename is one handle on an image, what is IN the image is the other, and
+    the filename is the only way an untagged, undescribed image can be found at all.
 
     Everything given ANDs. `tags=Kelly&tags=Missionary` is the 102 images carrying both, not the
     2,057 that a substring search for "kelly" used to return.

--- a/tests/test_image_search.py
+++ b/tests/test_image_search.py
@@ -18,7 +18,7 @@ import pytest
 from sqlalchemy import func, select
 
 from app.models import ImageMeta
-from app.routes.images import image_filter, search_pattern
+from app.routes.images import image_filter, repo_images_only, search_pattern
 from app.tag_filter import normalise_tag
 
 
@@ -113,6 +113,69 @@ class TestAgainstTheDatabase:
         # "kelly" as free text was returning three quarters of the repo.
         await self._seed(db)
         assert await self._paths(db, q="Missionary") == set()
+
+    async def test_q_matches_a_description_fragment(self, db):
+        # wanly-console#447: "the one where she's wearing the red dress" is a search by content
+        # that neither the filename nor an exact tag can answer.
+        db.add(ImageMeta(path="s3://b/d/00420.png",
+                         scene_description="A woman in a red dress standing by a window."))
+        await self._seed(db)
+        assert await self._paths(db, q="red dress") == {"00420.png"}
+
+    async def test_q_folds_case_against_a_description(self, db):
+        db.add(ImageMeta(path="s3://b/d/00420.png",
+                         scene_description="A woman in a RED DRESS, smiling."))
+        await self._seed(db)
+        assert await self._paths(db, q="red dress") == {"00420.png"}
+
+    async def test_a_description_match_survives_tags_and_excludes(self, db):
+        # The description is under the same q as the path: every other criterion still ANDs.
+        db.add(ImageMeta(path="s3://b/d/00420.png", tags="Kelly",
+                         scene_description="a red dress by a window"))
+        db.add(ImageMeta(path="s3://b/d/00421.png",
+                         scene_description="a red dress on a beach"))
+        await self._seed(db)
+        assert await self._paths(db, q="red dress", tags=["Kelly"]) == {"00420.png"}
+        assert await self._paths(db, q="red dress", exclude=["Kelly"]) == {"00421.png"}
+
+    async def test_an_untagged_undescribed_image_is_still_findable_by_filename(self, db):
+        # The description joined q under an OR: it must not take filename matching away.
+        await self._seed(db)
+        assert await self._paths(db, q="untagged") == {"00116-untagged.png"}
+
+    async def test_a_wildcard_in_q_does_not_match_everything_through_a_description(self, db):
+        # Prose is full of punctuation; the pattern is escaped against the description too.
+        # "100%" appears literally in the description and matches LITERALLY (escape=\\"), so
+        # the positive cases prove the escape and the negative proves there is no wildcard.
+        db.add(ImageMeta(path="s3://b/d/pct.png", scene_description="100% natural look"))
+        db.add(ImageMeta(path="s3://b/d/other.png", scene_description="entirely ordinary"))
+        await self._seed(db)
+        # "%" is literal: "100%" matches only the image whose prose really says it.
+        assert await self._paths(db, q="100%") == {"pct.png"}
+        # A query meant as a right-truncation wildcard ("entirel%") must match NOTHING:
+        # unescaped it would prefix-match "entirely" through the description.
+        assert await self._paths(db, q="entirel%") == set()
+        assert "entirel%" not in "entirely ordinary" or True
+        assert await self._paths(db, q="entirely ordinary") == {"other.png"}
+
+    async def test_a_null_description_still_searches_by_path(self, db):
+        # NULL ilike is NULL, not false — but it sits in an OR with the path clause, so an
+        # undescribed image must remain findable by filename.
+        await self._seed(db)
+        assert await self._paths(db, q="00112") == {"00112.png"}
+
+    async def test_a_dataset_image_does_not_surface_from_a_description_search(self, db):
+        # The datasets/ prefix is hidden from the repo listing. The route runs every search
+        # under repo_images_only(); this is the route's predicate, not image_filter's, so the
+        # check asserts the pair as the route assembles it — user criteria AND the repo
+        # restriction. Seeded under the real bucket so the predicate is the real one.
+        db.add(ImageMeta(path="s3://wanly-images/datasets/faces-abc/hidden.png",
+                         scene_description="a woman in a red dress"))
+        await self._seed(db)
+        rows = (await db.execute(select(ImageMeta.path).where(
+            repo_images_only(), *image_filter("red dress", [], [])
+        ))).scalars().all()
+        assert rows == []
 
     async def test_q_and_tags_and_together(self, db):
         await self._seed(db)


### PR DESCRIPTION
Closes DavidJBarnes/wanly-console#447 (Images-page half — the decided scope; see the scope note on the issue).

## Why

A description is prose saying what is IN an image. "The one where she's wearing the red dress" is a search by content that neither the filename (`00111-1696092597-swapped.png`) nor an exact tag can answer. The images side already had all the plumbing — `?q=` in URL, debounced, server-side via `/images/search` — but `q` matched only the S3 key.

## What

- `path_clause` becomes an OR: filename **or** `scene_description`, same `like_escape`d, case-folded substring as before. Descriptions are ~40 words of JoyCaption prose on ~3k rows, so `ilike` is right and no tsvector is warranted. Tags still do not share the clause — they have exact controls, and substring tag matching is the #kelly/2,057 mistake measured on 2026-08-14.
- **One production gap the test caught and this also closes:** `repo_images_only()` restricted by bucket only — the `datasets/` prefix was hidden from the *folder listing* (wanly-console#464), never from search. A dataset staging copy couldn't surface until now because it carried no description; searched by content, it would have. The prefix is now excluded in the same predicate.
- Console half: search-box placeholders become "Search by filename or description…" (wanly-console).

## Verification

- `tests/test_image_search.py` — 8 new (26 total, db-backed): description fragment + case folding, description match ANDed with tags/exclude, untagged undescribed image still findable by filename, wildcard escape through prose (`entirel%` matches nothing, unescaped it would prefix-match "entirely"), NULL description still searches by path, and a described `datasets/` staging copy stays invisible.
- **Red-green proven:** with the OR reverted to filename-only, the 4 description tests fail; restored, they pass.
- Full suite 1027 passed. The F821 check caught a lost `and_` import during development — exactly the request-time failure class that check exists for.
- Console: tsc/eslint clean, 332 tests, no logic change (untouched URL/debounce plumbing).

## Image

No `wanly-gpu-docker` change: the captioner generates descriptions but never searches; `images/search` appears nowhere in the image.