### PR TITLE
Description search matches whole words, not substrings

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -597,27 +597,40 @@ def search_pattern(q: str) -> str:
 
 
 def path_clause(q: str):
-    """Match the S3 key OR the description as a substring.
+    """Match the S3 key as a substring.
 
     Fragment matching is right here and wrong for tags. Images arrive named
     "00111-1696092597-swapped.png" and get referred to by that number in job configs and notes,
     so "which folder was 00111 in" has to be answerable -- and a partially remembered filename is
-    the only handle there is.
-
-    The description joins under the same OR (wanly-console#447): a description is prose saying
-    WHAT is in the image, and "the one where she's wearing the red dress" is a search by content
-    that neither the filename nor an exact tag can answer. Descriptions are ~40 words of
-    JoyCaption output, so substring is right and no index or tsvector is warranted at repo scale.
-    Tags still do not share this clause -- they have exact controls of their own, and a tag
-    matching by substring is the #kelly/2,057 mistake measured on 2026-08-14.
-
-    NULL descriptions (never described) fall out of the OR naturally: the path clause still
-    matches, so an undescribed image remains findable by filename.
+    the only handle there is. Tags have exact controls of their own, so they no longer share this.
     """
-    return or_(
-        ImageMeta.path.ilike(search_pattern(q), escape="\\"),
-        ImageMeta.scene_description.ilike(search_pattern(q), escape="\\"),
-    )
+    return ImageMeta.path.ilike(search_pattern(q), escape="\\")
+
+
+def description_clause(q: str):
+    """Match WHOLE WORDS inside a description, case-folded. None when the query is blank.
+
+    Prose is words, and whole-word matching is the whole point here: `%red%` matched "textured"
+    on production the day description search shipped (wanly-console#447's first pass) — red is a
+    substring of texture, character, hundred and a dozen other words, so substring is the wrong
+    shape for prose. A user typing "red" means the colour, and "textured skin" should not answer.
+
+    ilike cannot express a word boundary, so this is a case-insensitive regular expression
+    (`~*`) with boundaries around the escaped query. Escape for REGEX metacharacters, not LIKE
+    ones: prose searches are words, and "(" or "?" in a description must not break the pattern.
+    A known limit of \\y: it needs a word character on one side, so a query that begins or ends
+    in punctuation ("(top-down)" or "100%") matches nothing through a description — the bare
+    word ("top-down", "100") is the search that works, and that is the honest failure: a
+    punctuation-edge query is a filename-shaped question, not a content one.
+
+    Multi-word queries match the phrase as words joined by whitespace ("red dress"), which is
+    the natural reading.
+    """
+    words = q.split()
+    if not words:
+        return None
+    pattern = r"\y" + r"\s+".join(re.escape(w) for w in words) + r"\y"
+    return ImageMeta.scene_description.op("~*")(pattern)
 
 
 def tag_clause(tag: str):
@@ -646,7 +659,10 @@ def image_filter(q: str | None, tags: list[str], exclude: list[str]) -> list:
         if t.strip()
     ]
     if q and q.strip():
-        clauses.append(path_clause(q.strip()))
+        q = q.strip()
+        # The description joins q under an OR with the filename (wanly-console#447): the
+        # filename matches as a fragment, the description as whole words.
+        clauses.append(or_(path_clause(q), description_clause(q)))
     return clauses
 
 

--- a/tests/test_image_search.py
+++ b/tests/test_image_search.py
@@ -122,6 +122,22 @@ class TestAgainstTheDatabase:
         await self._seed(db)
         assert await self._paths(db, q="red dress") == {"00420.png"}
 
+    async def test_a_word_does_not_match_inside_a_longer_word(self, db):
+        # Seen on production the day description search shipped: "red" matched "textured" —
+        # red is a substring of texture, character, hundred and a dozen other words, so
+        # substring is the wrong shape for prose. Descriptions match WHOLE WORDS; the filename
+        # keeps fragment matching, because a partially typed filename is the only handle there.
+        # The discriminating row's description contains "red" ONLY as a substring of another
+        # word, and its filename contains neither "red" nor the query fragments below.
+        db.add(ImageMeta(path="s3://b/d/00421-coarse.png", scene_description="textured skin"))
+        db.add(ImageMeta(path="s3://b/d/00422.png", scene_description="a red coat"))
+        await self._seed(db)
+        # "red" must NOT match "textured skin" — but must still match "a red coat".
+        assert await self._paths(db, q="red") == {"00422.png"}
+        # But the filename still matches as a fragment: "coars" finds 00421-coarse.png even
+        # though its description ("textured skin") does not contain the word at all.
+        assert await self._paths(db, q="coars") == {"00421-coarse.png"}
+
     async def test_q_folds_case_against_a_description(self, db):
         db.add(ImageMeta(path="s3://b/d/00420.png",
                          scene_description="A woman in a RED DRESS, smiling."))
@@ -144,19 +160,18 @@ class TestAgainstTheDatabase:
         assert await self._paths(db, q="untagged") == {"00116-untagged.png"}
 
     async def test_a_wildcard_in_q_does_not_match_everything_through_a_description(self, db):
-        # Prose is full of punctuation; the pattern is escaped against the description too.
-        # "100%" appears literally in the description and matches LITERALLY (escape=\\"), so
-        # the positive cases prove the escape and the negative proves there is no wildcard.
-        db.add(ImageMeta(path="s3://b/d/pct.png", scene_description="100% natural look"))
-        db.add(ImageMeta(path="s3://b/d/other.png", scene_description="entirely ordinary"))
+        # Whole-word matching means regex metacharacters in the query are literal, not
+        # patterns: a "." or "(" in prose must be matched as itself, and a query that is
+        # punctuation-adjacent must match the word it names.
+        db.add(ImageMeta(path="s3://b/d/pct.png", scene_description="100% natural (top-down) view"))
         await self._seed(db)
-        # "%" is literal: "100%" matches only the image whose prose really says it.
-        assert await self._paths(db, q="100%") == {"pct.png"}
-        # A query meant as a right-truncation wildcard ("entirel%") must match NOTHING:
-        # unescaped it would prefix-match "entirely" through the description.
-        assert await self._paths(db, q="entirel%") == set()
-        assert "entirel%" not in "entirely ordinary" or True
-        assert await self._paths(db, q="entirely ordinary") == {"other.png"}
+        # Whole word: "top-down" is matched as a whole word, hyphen and all.
+        assert await self._paths(db, q="top-down") == {"pct.png"}
+        # A regex wildcard in the query must be literal, not a pattern: ".*" would otherwise
+        # match everything.
+        assert await self._paths(db, q=".*") == set()
+        # "100" is a whole word in the prose even though "100%" is not matchable by boundary.
+        assert await self._paths(db, q="100") == {"pct.png"}
 
     async def test_a_null_description_still_searches_by_path(self, db):
         # NULL ilike is NULL, not false — but it sits in an OR with the path clause, so an


### PR DESCRIPTION
Follow-up to #307 (wanly-console#447). Seen on production the day it shipped: searching **"red"** matched an image whose description says **"textured"** — red is a substring of texture, character, hundred and a dozen other words.

## What

- `path_clause` reverts to filename-only fragment matching (a partially typed filename is the only handle there is — fragment matching is right there).
- New `description_clause`: **whole words**, case-insensitive regex (`~*`) with `\y` boundaries around the escaped query; multi-word queries match the phrase as words ("red dress"). Escaped for regex metacharacters, not LIKE ones.
- Recorded limit in the clause: `\y` needs a word character on one side, so a query beginning/ending in punctuation ("100%", "(top-down)") matches nothing through a description — the bare word is the search that works.
- `image_filter` ORs the two as before.

## Verification

- 1028 tests pass (`test_a_word_does_not_match_inside_a_longer_word` new): "red" matches "a red coat" but NOT "textured skin"; the filename still matches as a fragment.
- **Red-green proven**: with `description_clause` reverted to the substring `ilike`, the test **fails**; restored, it passes.
- Correction worth recording: the first version of the test could **not discriminate** — both seeded rows matched under substring *and* whole-word, so it passed against broken code. The discriminating row's description now contains the query only as a substring of another word. A test that passes against broken code is worse than none.
- Two of my own seed-file choices were also wrong en route (filenames containing "red"), caught by the tests each time.
- The F821 undefined-names check and full suite clean; ruff clean on touched test file.