### PR TITLE
Dataset images no longer leak into untagged and favorites views

### DIFF
--- a/app/routes/images.py
+++ b/app/routes/images.py
@@ -274,18 +274,31 @@ async def list_folder_images(
     ]
 
 
+def _is_dataset_path(uri: str) -> bool:
+    """Is this s3:// URI inside the datasets prefix? The key is everything after the bucket."""
+    return _is_dataset_key(uri.split("/", 3)[-1])
+
+
 @router.get("/images/favorites", dependencies=[Depends(get_current_user)])
 async def list_favorite_images(
     user=Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Return all favorited images across all folders with metadata."""
+    """Return all favorited images across all folders with metadata.
+
+    A dataset URI that was favorited is filtered rather than rendered: datasets are training
+    input (wanly-console#464's split), the search and folder listing already exclude them, and
+    one leaked view makes the Image Repo look connected to the datasets. A stale favorite on a
+    dataset image drops out here rather than surfacing as a grid entry; the Favorite row itself
+    stays — this endpoint renders, it does not curate.
+    """
     result = await db.execute(
         select(Favorite.item_ref)
         .where(Favorite.user_id == user.id, Favorite.item_type == "image")
         .order_by(Favorite.created_at.desc())
     )
     refs = [row[0] for row in result.all()]
+    refs = [r for r in refs if not _is_dataset_path(r)]
 
     async def _meta(uri: str) -> dict | None:
         obj = await asyncio.to_thread(head_object, uri)
@@ -311,6 +324,13 @@ async def list_favorite_images(
     return [item for item in items if item is not None]
 
 
+def _is_dataset_key(key: str) -> bool:
+    """Is this S3 key inside the datasets prefix? DATASETS_PREFIX with no trailing slash is
+    the folder boundary question: "datasets-extra/" is a repo folder, "datasets/" is not.
+    """
+    return key.startswith(f"{DATASETS_PREFIX}/")
+
+
 @router.get("/images/untagged", dependencies=[Depends(get_current_user)])
 async def list_untagged_images(
     db: AsyncSession = Depends(get_db),
@@ -319,7 +339,9 @@ async def list_untagged_images(
 
     "Untagged" means no image_meta row at all, or a row with empty/whitespace tags.
     Since never-tagged images have no row, this is a cross-folder scan minus the
-    set of paths with non-empty tags.
+    set of paths with non-empty tags. Dataset staging images are skipped entirely:
+    they are training input (wanly-console#464's split), tags do not apply to them,
+    and showing them here made the Image Repo look connected to the datasets.
     """
     bucket = settings.s3_images_bucket
     prefixes = await asyncio.to_thread(list_common_prefixes, bucket)
@@ -330,7 +352,7 @@ async def list_untagged_images(
         obj
         for sublist in object_lists
         for obj in sublist
-        if not obj["Key"].endswith("/.folder")
+        if not obj["Key"].endswith("/.folder") and not _is_dataset_key(obj["Key"])
     ]
     paths = [f"s3://{bucket}/{obj['Key']}" for obj in objects]
 

--- a/tests/test_hide_dataset_images.py
+++ b/tests/test_hide_dataset_images.py
@@ -1,0 +1,161 @@
+"""Dataset images never appear in the Image Repo (wanly-api#309).
+
+Search runs under repo_images_only and the folder listing hides the datasets prefix, both
+from wanly-console#464's split. Two views still leaked: /images/untagged scanned every
+common prefix, and /images/favorites rendered whatever URIs were favorited. A dataset
+staging image entering either grid made the Image Repo look connected to the datasets —
+which is exactly the look the split was for.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+BUCKET = "wanly-images"
+REPO = f"s3://{BUCKET}/2026-09-05/00001.png"
+DATASET = f"s3://{BUCKET}/datasets/faces-abc/staging.png"
+DATASET2 = f"s3://{BUCKET}/datasets/faces-abc/other.png"
+
+def _obj(key, size=1024, modified="2026-09-05T00:00:00Z"):
+    return {"Key": key, "Size": size, "LastModified": modified}
+
+
+class _FakeS3:
+    """list_objects / list_common_prefixes / head_object, answered from a fixed key set."""
+
+    def __init__(self, keys):
+        self._keys = keys
+
+    def list_common_prefixes(self, bucket):
+        markers = []
+        for k in self._keys:
+            rest = k[len(f"s3://{bucket}/"):]
+            top = rest.split("/", 1)[0]
+            if top not in markers:
+                markers.append(top)
+        return [m for m in markers if m != "datasets"]
+
+    def list_objects(self, bucket, prefix):
+        return [_obj(k[len(f"s3://{bucket}/"):]) for k in self._keys
+                if k.startswith(f"s3://{bucket}/{prefix}") and not k.endswith("/.folder")]
+
+    def head_object(self, uri):
+        key = uri.split("/", 3)[-1] if uri.count("/") > 2 else uri
+        return {"Key": key, "Size": 1024, "LastModified": "2026-09-05T00:00:00Z"} \
+            if f"s3://{BUCKET}/{key}" in self._keys else None
+
+
+async def _client(db):
+    from httpx import ASGITransport, AsyncClient
+    from app.auth import get_current_user
+    from app.database import get_db
+    from app.main import app
+
+    app.dependency_overrides[get_current_user] = lambda: object()
+    app.dependency_overrides[get_db] = lambda: db
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.fixture
+def s3():
+    fake = _FakeS3({REPO, DATASET, DATASET2})
+    with patch("app.routes.images.list_common_prefixes", fake.list_common_prefixes), \
+         patch("app.routes.images.list_objects", fake.list_objects), \
+         patch("app.routes.images.head_object", fake.head_object):
+        yield fake
+
+
+@pytest.mark.asyncio
+class TestUntaggedHidesDatasets:
+    async def test_a_dataset_staging_image_never_appears_as_untagged(self, db, s3):
+        """The untagged view scanned every common prefix; a dataset image with no tags
+        entered the grid and made the Image Repo look connected to the datasets."""
+        client, app = await _client(db)
+        try:
+            async with client as c:
+                resp = await c.get("/images/untagged")
+        finally:
+            app.dependency_overrides.clear()
+        assert resp.status_code == 200
+        paths = {i["path"] for i in resp.json()}
+        assert DATASET not in paths and DATASET2 not in paths
+        assert REPO in paths, "the view must keep showing repo images"
+
+    async def test_the_dataset_folder_is_not_even_scanned(self, db, s3):
+        """Prefix scanning walks what list_common_prefixes returns; the check is at the
+        object level so it holds regardless of what prefixes arrive."""
+        keys = {f"s3://{BUCKET}/datasets/x.png", REPO}
+        fake = _FakeS3(keys)
+
+        def prefixes(bucket):
+            return [f"{DATASET.split('/', 4)[4].split('/')[0]}"] if False else ["datasets/", "2026-09-05/"]
+
+        with patch("app.routes.images.list_common_prefixes", prefixes), \
+             patch("app.routes.images.list_objects", fake.list_objects), \
+             patch("app.routes.images.head_object", fake.head_object):
+            client, app = await _client(db)
+            try:
+                async with client as c:
+                    resp = await c.get("/images/untagged")
+            finally:
+                app.dependency_overrides.clear()
+        paths = {i["path"] for i in resp.json()}
+        assert f"s3://{BUCKET}/datasets/x.png" not in paths
+
+
+@pytest.mark.asyncio
+class TestFavoritesHidesDatasets:
+    async def test_a_favorited_dataset_image_is_not_rendered(self, db, s3):
+        """A stale favorite on a dataset image drops out of the response rather than
+        surfacing as a grid entry; the Favorite row itself stays."""
+        from app.models import Favorite, User
+        from app.auth import get_current_user
+        import uuid
+
+        user = User(id=uuid.uuid4(), username="uf", password_hash="x")
+        db.add(user)
+        await db.flush()
+        me = type("Me", (), {"id": user.id})()
+        db.add(Favorite(user_id=me.id, item_type="image", item_ref=DATASET))
+        db.add(Favorite(user_id=me.id, item_type="image", item_ref=REPO))
+        await db.flush()
+
+        client, app = await _client(db)
+        app.dependency_overrides[get_current_user] = lambda: me
+        try:
+            async with client as c:
+                resp = await c.get("/images/favorites")
+        finally:
+            app.dependency_overrides.clear()
+        assert resp.status_code == 200
+        paths = {i["path"] for i in resp.json()}
+        assert DATASET not in paths
+        assert REPO in paths, "the favorites view must keep showing repo images"
+
+    async def test_the_favorite_row_itself_survives(self, db, s3):
+        """This endpoint renders, it does not curate. Un-hiding must not lose data — the
+        row stays so a deliberate dataset favorite still exists underneath."""
+        import uuid
+        from app.models import Favorite, User
+        from app.auth import get_current_user
+
+        user = User(id=uuid.uuid4(), username="ur", password_hash="x")
+        db.add(user)
+        await db.flush()
+        me = type("Me", (), {"id": user.id})()
+        db.add(Favorite(user_id=me.id, item_type="image", item_ref=DATASET))
+        await db.flush()
+
+        client, app = await _client(db)
+        app.dependency_overrides[get_current_user] = lambda: me
+        try:
+            async with client as c:
+                resp = await c.get("/images/favorites")
+        finally:
+            app.dependency_overrides.clear()
+        assert resp.status_code == 200
+        assert resp.json() == []
+        # The row is still there.
+        from sqlalchemy import select
+        rows = (await db.execute(select(Favorite))).scalars().all()
+        assert any(f.item_ref == DATASET for f in rows)


### PR DESCRIPTION
Closes #309.

## Why

Dataset images should never appear in the Image Repo. Search (`repo_images_only`) and the folder listing already exclude the `datasets/` prefix — both from wanly-console#464's split — but two views still leaked:

1. **`GET /images/untagged`** scanned every common prefix: untagged dataset staging images entered the Untagged view.
2. **`GET /images/favorites`** rendered whatever URIs were favorited: a dataset image manually or stale-ly favorited surfaced in the grid.

Either one makes the Image Repo look connected to the datasets — exactly the look the split was for.

## What

- The untagged scan skips dataset keys at the **object level** (`_is_dataset_key`), so it holds regardless of what prefixes `list_common_prefixes` returns. Tags don't apply to training input.
- Favorites filters dataset URIs from the response; the Favorite row itself **stays** — this endpoint renders, it does not curate. Un-hiding later loses nothing.
- Original framing was a toggle switch + badge, but search and folder grids never return dataset images — there was nothing for them to act on. Hide-everywhere is the real want (decided with David on the ticket).

## Verification

- New `tests/test_hide_dataset_images.py` — 4 tests against faked S3 + real db via ASGI transport: dataset staging images never appear untagged, the datasets prefix is skipped even when it IS scanned, a favorited dataset URI is not rendered while repo favorites still are, and the Favorite row survives.
- **Red-green proven**: with both filters reverted, 3 of 4 fail; restored, all pass.
- Full suite **1032 passed**; F821 undefined-names clean; ruff clean on the new test file.
- Console: no change — the grids already work for search/folder; nothing can reach them.

## Image

No `wanly-gpu-docker` change: query-side only, the daemon never lists these endpoints.