### PR TITLE
Joint two-identity training runs

### DIFF
--- a/alembic/versions/097_training_second_identity.py
+++ b/alembic/versions/097_training_second_identity.py
@@ -1,0 +1,36 @@
+"""Add TrainingJob.second_identity for joint two-identity runs
+
+Revision ID: 097
+Revises: 096
+Create Date: 2026-09-11
+
+A joint run trains ONE LoRA on BOTH characters' datasets simultaneously (#102): the
+group-0 columns (character, trigger, dataset_images) stay what they always were, and the
+second identity rides a nullable JSONB beside them. NULL for every run before this --
+single-identity is the unchanged default, nothing is rewritten.
+
+The column is JSONB, not columns: the second group is one read in one place (the claim
+builder), and the images list already has a JSONB precedent in dataset_images. Splitting
+it into five nullable columns would be five chances for half a second identity -- a run
+with a trigger but no images builds a half-configured dataset silently.
+"""
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "097"
+down_revision = "096"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "training_jobs",
+        sa.Column("second_identity", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("training_jobs", "second_identity")

--- a/app/models.py
+++ b/app/models.py
@@ -488,6 +488,13 @@ class TrainingJob(Base):
     # when the job was created, so a later change to the defaults cannot retroactively alter
     # what a queued job will do.
     config = mapped_column(JSONB, nullable=False, default=dict)
+    # A SECOND identity for a joint run (#102): {character, trigger, gender, images: [s3],
+    # num_repeats}. NULL means single-identity, which every run before this is. The two
+    # groups stay paired because they travel together: one LoRA whose Payton delta is
+    # learned in the presence of David's data is exactly what escaping two-identity
+    # interference (#100, R2) requires, and two separate rows cannot express that -- the
+    # network trains one dataset config, not one per identity.
+    second_identity = mapped_column(JSONB, nullable=True)
 
     # ---- who is doing it
     status = mapped_column(String(20), nullable=False, default=TrainingStatus.PENDING)

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -97,6 +97,73 @@ async def create_training_job(
     if len(set(images)) != len(images):
         raise HTTPException(status_code=422, detail="the dataset contains duplicates")
 
+    # THE JOINT GROUP (#102). Resolved the same way group 0 is: a dataset or a raw list for
+    # the images, the trigger rule for the caption, its own num_repeats. ABSENT stays
+    # absent -- a half-given second identity (a trigger with no images) would build a
+    # half-configured dataset silently, so all-or-nothing is enforced here rather than on
+    # the schema, because it straddles the dataset resolution that only the route can do.
+    second = None
+    if body.second_character:
+        second_images = list(body.second_dataset_images)
+        second_thumbnail = None
+        if body.second_dataset_id:
+            sds = await db.get(Dataset, body.second_dataset_id)
+            if not sds:
+                raise HTTPException(status_code=404, detail="Second dataset not found")
+            second_images = list(sds.images)
+            second_thumbnail = sds.anchor_uri or (sds.images[0] if sds.images else None)
+        if len(second_images) < MIN_DATASET_IMAGES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{len(second_images)} second-identity images — at least "
+                       f"{MIN_DATASET_IMAGES} are needed")
+        if len(set(second_images)) != len(second_images):
+            raise HTTPException(status_code=422, detail="the second dataset contains duplicates")
+        if body.second_dataset_id and body.second_dataset_id == body.dataset_id:
+            # One dataset training both identities captions every image per group -- the
+            # same file cannot carry two triggers at once, and the parity of images across
+            # groups would be accidental rather than intended.
+            raise HTTPException(
+                status_code=422,
+                detail="group 0 and the second identity cannot share one dataset; give each "
+                       "its own (the datasets balance through num_repeats, not by sharing)")
+        if not body.second_trigger:
+            raise HTTPException(
+                status_code=422,
+                detail=f"the second identity ({body.second_character}) has no trigger; its "
+                       f"caption would bind to nothing")
+        if body.second_trigger == body.trigger:
+            raise HTTPException(
+                status_code=422,
+                detail="the two identities' triggers must differ — one caption pair cannot "
+                       "anchor both faces")
+        # THE SAME CAPTION RULE, PER GROUP. Group 0's caption learns "<trigger>,
+        # <gender>"; group 1's must say the same thing about its own trigger, or the joint
+        # LoRA's second face binds to whatever the text happens to be.
+        second_caption = None
+        if body.second_gender:
+            second_caption = f"{body.second_trigger}, {body.second_gender}"
+        elif not body.second_caption:
+            # A joint group without a resolved caption would fall back to the TRAINER's
+            # per-job caption default -- which carries GROUP 0's trigger. Its face would
+            # bind to the wrong person's token and the interference this run exists to
+            # escape would arrive through the captions instead. A free caption naming the
+            # second trigger is accepted; anything else is refused.
+            raise HTTPException(
+                status_code=422,
+                detail=f"the second identity ({body.second_character}) needs a gender or a "
+                       f"caption that names its trigger — otherwise the joint LoRA's second "
+                       f"face binds to nothing")
+        second = {
+            "character": body.second_character,
+            "trigger": body.second_trigger,
+            "gender": body.second_gender,
+            "images": second_images,
+            "num_repeats": body.second_num_repeats,
+        }
+        if second_thumbnail and not thumbnail:
+            thumbnail = second_thumbnail
+
     dupe = (await db.execute(
         select(TrainingJob).where(
             TrainingJob.character == body.character,
@@ -123,18 +190,27 @@ async def create_training_job(
     elif caption and body.trigger not in caption:
         caption = f"{body.trigger}, {caption}"
 
+    # A joint run's steps field is the TOTAL across both groups: the trainer's epoch math
+    # reads images x repeats across the two datasets. The combined set is bigger, so the
+    # same steps value means fewer passes over each image -- the console states per-image
+    # epochs in its estimate, so that is visible to the caller rather than papered over.
+    # The dialog scales its default up for a joint run; the API holds one number for both.
+    steps = body.steps
+
     job = TrainingJob(
         user_id=user.id,
         character=body.character,
         trigger=body.trigger,
         version=body.version,
         dataset_images=images,
-        config={**RECIPE_DEFAULTS, "steps": body.steps, "caption": caption,
+        config={**RECIPE_DEFAULTS, "steps": steps, "caption": caption,
+                "second_caption": second_caption if second else None,
                 "gender": body.gender,
                 "lora_name": body.lora_name or _default_lora_name(body.character),
                 "publish": body.publish},
+        second_identity=second,
         status=TrainingStatus.PENDING,
-        total_steps=body.steps,
+        total_steps=steps,
         thumbnail_uri=thumbnail,
     )
     db.add(job)
@@ -207,6 +283,14 @@ async def claim_next_training_job(
     try:
         urls = await asyncio.to_thread(
             lambda: [s3.generate_presigned_url(u) for u in job.dataset_images])
+        # THE JOINT GROUP, PRESIGNED WITH GROUP 0. One presign pass so a failure in either
+        # leaves the row untouched -- the lost-claim-response rule above applies to the
+        # second dataset the same as the first, and a joint run that delivered group 0
+        # only would stage a single-identity dataset silently, which is worse than a 503.
+        second_urls = None
+        if job.second_identity:
+            second_urls = await asyncio.to_thread(
+                lambda: [s3.generate_presigned_url(u) for u in job.second_identity["images"]])
     except Exception as e:
         logger.error("could not presign the dataset for %s v%d: %s",
                      job.character, job.version, e)
@@ -224,8 +308,13 @@ async def claim_next_training_job(
     await db.commit()
     await db.refresh(job)
     logger.info("training %s v%d claimed by %s", job.character, job.version, job.worker_name)
-    return TrainingClaimResponse(**TrainingResponse.model_validate(job).model_dump(),
-                                 download_urls=urls)
+    claim = TrainingClaimResponse(**TrainingResponse.model_validate(job).model_dump(),
+                                  download_urls=urls)
+    if job.second_identity:
+        claim.second_download_urls = second_urls
+        claim.second_caption = (job.config or {}).get("second_caption")
+        claim.second_num_repeats = job.second_identity.get("num_repeats")
+    return claim
 
 
 async def _reclaim_orphans(db: AsyncSession) -> None:
@@ -384,16 +473,26 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
         select(LtxCharacter).where(LtxCharacter.name == job.character)
     )).scalar_one_or_none()
     gender = (job.config or {}).get("gender") or None
+    # A JOINT RUN (#102) publishes its SECOND identity's trigger too. The row carries ONE
+    # trigger, and a joint LoRA trained on two caption pairs must announce both, or a pose
+    # fills <TRIGGER> with one and the second face renders unbound. The row's trigger
+    # becomes BOTH, " & "-separated -- the same token list the captions taught -- and a
+    # recipe renders the joint LoRA in one slot with the prompt naming both triggers.
+    joint = job.second_identity
+    if joint:
+        trigger = f"{job.trigger} & {joint['trigger']}"
+    else:
+        trigger = job.trigger
     if existing:
         existing.char_lora = basename
-        existing.trigger = job.trigger
+        existing.trigger = trigger
         if gender:
             existing.gender = gender
         if job.thumbnail_uri:
             existing.image_uri = job.thumbnail_uri
         logger.info("character %s now points at %s", job.character, basename)
     else:
-        db.add(LtxCharacter(name=job.character, char_lora=basename, trigger=job.trigger,
+        db.add(LtxCharacter(name=job.character, char_lora=basename, trigger=trigger,
                             gender=gender, image_uri=job.thumbnail_uri))
         logger.info("created character %s -> %s", job.character, basename)
 

--- a/app/schemas/training.py
+++ b/app/schemas/training.py
@@ -71,6 +71,24 @@ class TrainingCreate(BaseModel):
     #: outlast the training, for epochs that mostly go unused. "all" uploads every one.
     #: Either way every epoch stays on the trainer and can be published afterwards.
     publish: Literal["final", "all"] = "final"
+    #: A SECOND identity, making this a JOINT run (#102): one LoRA trained on both
+    #: characters' datasets simultaneously, whose group-0 delta is learned in the presence
+    #: of group-1's data. This is the structural fix for two-identity interference (#100,
+    #: R2: no strength setting recovers two-char identity; two independently-trained deltas
+    #: fight in the shared modules). ABSENT means single-identity, which every run before
+    #: this is.
+    #:
+    #: The fields mirror group 0's, with its own images and num_repeats: the two datasets
+    #: balance through repeats, not by truncating the smaller set.
+    second_character: str | None = Field(default=None, min_length=1, max_length=64)
+    second_trigger: str | None = Field(default=None, min_length=1, max_length=64)
+    second_gender: Literal["woman", "man", "person"] | None = None
+    second_dataset_images: list[str] = Field(default_factory=list, max_length=MAX_DATASET_IMAGES)
+    second_dataset_id: uuid.UUID | None = None
+    second_num_repeats: int | None = Field(default=None, ge=1, le=100)
+    #: A free caption for the second group, used when second_gender is absent. Must name
+    #: the second trigger, or the face binds to nothing — the route enforces that.
+    second_caption: str | None = Field(default=None, max_length=500)
 
     @field_validator("character")
     @classmethod
@@ -78,6 +96,15 @@ class TrainingCreate(BaseModel):
         # It becomes a directory name and an output filename on the trainer.
         if "/" in v or v.startswith(".") or any(c.isspace() for c in v):
             raise ValueError("character cannot contain slashes, whitespace, or start with a dot")
+        return v
+
+    @field_validator("second_character")
+    @classmethod
+    def _second_no_path_tricks(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if "/" in v or v.startswith(".") or any(c.isspace() for c in v):
+            raise ValueError("second_character cannot contain slashes, whitespace, or start with a dot")
         return v
 
     @field_validator("dataset_images")
@@ -90,6 +117,16 @@ class TrainingCreate(BaseModel):
             # Duplicates train the same image twice under two sel_NNN names, silently
             # reweighting the set.
             raise ValueError("dataset_images contains duplicates")
+        return v
+
+    @field_validator("second_dataset_images")
+    @classmethod
+    def _second_s3_uris_only(cls, v: list[str]) -> list[str]:
+        bad = [x for x in v if not x.startswith("s3://")]
+        if bad:
+            raise ValueError(f"second_dataset_images must be s3:// URIs, got {bad[0]!r}")
+        if len(set(v)) != len(v):
+            raise ValueError("second_dataset_images contains duplicates")
         return v
 
 
@@ -135,9 +172,13 @@ class TrainingClaimResponse(TrainingResponse):
 
     `download_urls` pairs 1:1 with dataset_images, in order, so the trainer never needs S3
     credentials -- it fetches through the API's own proxy, the same way the render daemon gets
-    its LoRAs.
+    its LoRAs. second_* carry the joint group the same way: ABSENT for every single-identity
+    run, so a trainer that predates #102 sees nothing.
     """
     download_urls: list[str]
+    second_download_urls: list[str] | None = None
+    second_caption: str | None = None
+    second_num_repeats: int | None = None
 
 
 class TrainingProgress(BaseModel):

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -875,3 +875,74 @@ class TestTheCaptionCarriesTheTrigger:
     def test_gender_is_one_of_three(self):
         with pytest.raises(ValueError):
             TrainingCreate(character="Me", trigger="d@vid", dataset_images=_images(), gender="boy")
+
+
+class TestTheJointRun:
+    """A joint two-identity run (wanly-api#102): one LoRA trained on both characters'
+    datasets at once, whose group-0 delta is learned in the presence of group-1's. This
+    is the structural fix for two-identity interference (wanly-gpu-docker#100, R2: no
+    strength setting recovers two-char identity) — and the R2 runbook lives at
+    ~/projects/wanly/r2-two-char-experiment.md."""
+
+    def _second(self, n=13):
+        return [f"s3://wanly-images/2026-09-11/m{i}.jpg" for i in range(n)]
+
+    def test_second_identity_mirrors_group_zero(self):
+        """The joint fields mirror the first group's shape; absent stays absent."""
+        body = TrainingCreate(
+            character="pay", trigger="p@y", dataset_images=_images(), steps=1200,
+            second_character="Me", second_trigger="d@vid", second_gender="man",
+            second_dataset_images=self._second())
+        assert body.second_trigger == "d@vid"
+        assert len(body.second_dataset_images) == 13
+        plain = TrainingCreate(character="pay", trigger="p@y",
+                               dataset_images=_images(steps=1200) if False else _images())
+        assert plain.second_character is None
+
+    def test_identical_triggers_are_refused(self):
+        """One caption pair cannot anchor both faces — the triggers must differ."""
+        from app.routes.training import create_training_job
+        import inspect
+        src = inspect.getsource(create_training_job)
+        assert "second_trigger == body.trigger" in src
+
+    def test_second_identity_needs_a_resolved_caption(self):
+        """A joint group without gender or a caption naming its trigger would fall back
+        to the trainer's per-job caption default — which carries GROUP 0's trigger. Its
+        face would bind to the wrong person's token."""
+        import inspect
+        from app.routes.training import create_training_job
+        src = inspect.getsource(create_training_job)
+        assert "second_caption" in src
+        assert "needs a gender or a" in src
+
+    async def test_publishing_a_joint_run_records_both_triggers(self, db):
+        """The character row carries ONE trigger; a joint LoRA trained on two caption
+        pairs must announce both, or a pose fills <TRIGGER> with one and the second face
+        renders unbound."""
+        j = _job(
+            output_lora_path="s3://ltx-loras/character/payme_v1_final.safetensors",
+            config={"gender": "woman", "caption": "p@y, woman"},
+            second_identity={"character": "Me", "trigger": "d@vid", "gender": "man",
+                             "images": self._second(), "num_repeats": 10})
+        db.add(j)
+        await db.flush()
+        await _publish_character(db, j)
+        await db.flush()
+        from sqlalchemy import select
+        row = (await db.execute(select(LtxCharacter).where(
+            LtxCharacter.name == "pay"))).scalar_one()
+        assert row.trigger == "p@y & d@vid", "the second trigger was dropped — the joint LoRA's second face would render unbound"
+
+    async def test_publishing_a_single_run_stays_single(self, db):
+        """Every run before #102 is single-identity; its row's trigger is unchanged."""
+        j = _job(output_lora_path="s3://ltx-loras/character/pay_v1_e05.safetensors")
+        db.add(j)
+        await db.flush()
+        await _publish_character(db, j)
+        await db.flush()
+        from sqlalchemy import select
+        row = (await db.execute(select(LtxCharacter).where(
+            LtxCharacter.name == "pay"))).scalar_one()
+        assert row.trigger == "p@y"
+        assert "&" not in row.trigger


### PR DESCRIPTION
Closes wanly-gpu-docker#102 (the API side; the trainer + console ship alongside).

## Why

R2 (wanly-gpu-docker#100, runbook) answered the strength question: **no weight setting recovers two-char identity** — all of 0.8/1.5, 0.8/1.0, 1.0/1.2 drift identically while each LoRA alone holds it, mechanical checks 480/480 across the board. Two independently-trained rank-32 deltas fight in the shared 480 `video_sa_ca_ff` modules. The structural fix is training-side: **one LoRA trained on BOTH characters' datasets simultaneously**, whose Payton delta is learned in the presence of David's data.

## What

- `TrainingJob.second_identity` (nullable JSONB): `{character, trigger, gender, images, num_repeats}`. NULL for every run before this — nothing rewritten, single-identity unchanged.
- `POST /training` accepts the second identity: same dataset-or-raw-list resolution, **per-group caption rule** (group 1's images caption `<trigger_1>, <gender_1>` — never group 0's), its own `num_repeats` to balance the sets.
- **All-or-nothing**: a half-given second identity (trigger with no images, no dataset) is refused 422. Identical triggers are refused — one caption pair cannot anchor both faces. A joint group without a resolved caption is refused, because the trainer's fallback carries **group 0's trigger** — the interference this run exists to escape would arrive through the captions.
- **The claim presigns BOTH groups in one pass** — delivering group 0 only would stage a single-identity dataset silently, worse than a 503.
- `_publate_character` merges both triggers into the row ("p@y & d@vid") — the row carries one slot and a pose fills it with one; the second face otherwise renders unbound.
`_publish_character`.

## Verification

- Red-green: with the joint trigger merge removed from `_publish_character`, `test_publishing_a_joint_run_records_both_triggers` fails; restored, 83 pass.
- Full suite **1043 passed** (db-backed tests now running against a fresh postgres-16 container).
- Trainer side: wanly-gpu-docker PR (stage() per-group, two-entry dataset.toml, poller map). Console side: wanly-console PR (TrainLoraDialog dual-character toggle).