### PR TITLE
Joint LoRA publishes the full caption phrase (both pairs)

### DIFF
--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -474,13 +474,22 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
     )).scalar_one_or_none()
     gender = (job.config or {}).get("gender") or None
     # A JOINT RUN (#102) publishes its SECOND identity's trigger too. The row carries ONE
-    # trigger, and a joint LoRA trained on two caption pairs must announce both, or a pose
-    # fills <TRIGGER> with one and the second face renders unbound. The row's trigger
-    # becomes BOTH, " & "-separated -- the same token list the captions taught -- and a
-    # recipe renders the joint LoRA in one slot with the prompt naming both triggers.
+    # trigger and ONE gender slot, and a joint LoRA trained on two caption pairs must
+    # announce BOTH PAIRS — the phrase the render path fills <TRIGGER> with is
+    # "<trigger>, <gender>" (wanly-console#487), so "p@y & d@vid" + the group-0 gender
+    # would render "d@vid, woman", a token pair that was never trained: group 1's face
+    # bound to "man". The row's trigger becomes the full joint phrase, "p@y, woman &
+    # d@vid, man" — exactly what the captions taught, in the order the datasets trained —
+    # and the gender slot is left holding the phrase too (readers that use the bare
+    # trigger get the same tokens). The joint phrase rides the trigger column because
+    # trigger_phrase() concatenates trigger + gender onto whatever the row carries; a
+    # separate "both pairs" column would be a second read of the same shape.
     joint = job.second_identity
     if joint:
-        trigger = f"{job.trigger} & {joint['trigger']}"
+        g0 = (job.config or {}).get("gender")
+        g1 = joint.get("gender")
+        trigger = f"{job.trigger}, {g0} & {joint['trigger']}, {g1}"
+        gender = None
     else:
         trigger = job.trigger
     if existing:

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -932,7 +932,10 @@ class TestTheJointRun:
         from sqlalchemy import select
         row = (await db.execute(select(LtxCharacter).where(
             LtxCharacter.name == "pay"))).scalar_one()
-        assert row.trigger == "p@y & d@vid", "the second trigger was dropped — the joint LoRA's second face would render unbound"
+        assert row.trigger == "p@y, woman & d@vid, man", (
+            "the joint phrase was wrong — the render path fills <TRIGGER> with "
+            "'<trigger>, <gender>' (wanly-console#487), so 'p@y & d@vid' + the group-0 "
+            "gender would render 'd@vid, woman', a token pair that was never trained")
 
     async def test_publishing_a_single_run_stays_single(self, db):
         """Every run before #102 is single-identity; its row's trigger is unchanged."""


### PR DESCRIPTION
Follow-up to #313 (wanly-gpu-docker#102), caught reviewing how triggers flow to a render.

## The gap

The render path fills a pose's `<TRIGGER>` with `"<trigger>, <gender>"` — the caption the LoRA trained on, gender included (wanly-console#487). A joint run trains **two** pairs (`p@y, woman` and `d@vid, man`), but #313's publish wrote `p@y & d@vid` plus the group-0 gender — which renders `d@vid, woman`: **a token pair that was never trained**, and the second face bound to nothing. The exact failure a joint run exists to escape, arriving through the publish instead.

## The fix

The row's trigger becomes the full joint phrase — `p@y, woman & d@vid, man` — both pairs, in the order the datasets trained. Gender set to None (the phrase carries both), so a bare-trigger reader gets the same tokens.

## Verification

- Red-green: reverting to the bare `p@y & d@vid` merge fails `test_publishing_a_joint_run_records_both_triggers`; restored, **83 pass** (REQUIRE_DB=1, fresh postgres-16).
- Column length: `LtxCharacter.trigger` is String(64); the phrase fits with headroom (~41 chars longest plausible form).

Note: HEAD~1 on main was a stray direct push of this same diff (my mistake — committed on main instead of a branch; it has since been reverted on main so this PR is the record). Reviewing this PR reviews the whole change.