### PR TITLE
Joint LoRA: split the two triggers across the placeholders

### DIFF
--- a/app/recipe_blob.py
+++ b/app/recipe_blob.py
@@ -22,6 +22,42 @@ TRIGGER2_PLACEHOLDER = "<TRIGGER2>"
 TRIGGER_PLACEHOLDERS = (TRIGGER_PLACEHOLDER, TRIGGER2_PLACEHOLDER)
 MAX_CHARACTERS = len(TRIGGER_PLACEHOLDERS)
 
+#: A JOINT character (wanly-api#102) carries BOTH identities in one trigger: the publish
+#: joins the two caption pairs with this. The render splits it back apart so each pair can
+#: fill its own placeholder.
+#:
+#: " and ", not "&". The phrase reaches the text encoder as a token sequence, and the
+#: captions a joint run trains on never contained "&" -- it is out of distribution in the
+#: exact place the binding happens. "and" is at least language the encoder has seen, and it
+#: reads as the sentence it is: "p@yton, woman and d@vid, man".
+JOINT_SEPARATOR = " and "
+#: What publishes before #314 wrote. Read so a row that already carries one still splits;
+#: never written again.
+_LEGACY_JOINT_SEPARATOR = " & "
+
+
+def split_joint_phrase(phrase: str | None) -> list[str | None]:
+    """One phrase per identity. A joint character's phrase carries TWO, joined by the
+    separator; a single phrase comes back as a one-element list.
+
+    A COMMA IS REQUIRED on top of the separator. The joint phrase is built from caption
+    pairs -- "<trigger>, <gender>" -- so it always carries one; requiring it means a plain
+    trigger that happens to contain " and " (a free-text field) is not mangled. A joint run
+    that recorded no genders at all produces "t0 and t1" and will not split; that is the
+    price of not guessing, and it is visible in the rendered prompt.
+    """
+    if not phrase:
+        return [phrase]
+    if "," not in phrase:
+        return [phrase]
+    for sep in (JOINT_SEPARATOR, _LEGACY_JOINT_SEPARATOR):
+        if sep in phrase:
+            parts = [p.strip() for p in phrase.split(sep) if p.strip()]
+            if len(parts) > 1:
+                return parts
+    return [phrase]
+
+
 
 def recipe_characters(ltx_recipe: dict[str, Any] | None) -> list[dict[str, Any]]:
     """The people in a recipe blob, `[{name, trigger, gender, char_lora, s1, s2}, ...]`.
@@ -78,11 +114,23 @@ def render_prompt(template: str, triggers: str | Sequence[str | None]) -> str:
     placeholder in place: rendering the literal text is bad, but silently dropping the token
     that anchors a character LoRA is worse and much harder to notice. A template with no
     placeholder at all is returned unchanged rather than rejected.
+
+    A JOINT character (#102) carries two caption pairs in one trigger. When the pose has a
+    second placeholder, its phrase is SPLIT so each pair fills its own -- the pose's
+    per-person sentences then put each trigger next to its person, which is the whole point
+    of splitting. A one-person pose keeps the whole phrase in <TRIGGER>: splitting there
+    would leave the second identity's token nowhere to go and DROP it.
     """
     if isinstance(triggers, str):
         triggers = [triggers]
+    if TRIGGER2_PLACEHOLDER in template:
+        expanded: list[str | None] = []
+        for trigger in triggers:
+            expanded.extend(split_joint_phrase(trigger))
+    else:
+        expanded = list(triggers)
     out = template
-    for placeholder, trigger in zip(TRIGGER_PLACEHOLDERS, triggers):
+    for placeholder, trigger in zip(TRIGGER_PLACEHOLDERS, expanded):
         if trigger:
             out = out.replace(placeholder, trigger)
     return out

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -476,19 +476,27 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
     # A JOINT RUN (#102) publishes its SECOND identity's trigger too. The row carries ONE
     # trigger and ONE gender slot, and a joint LoRA trained on two caption pairs must
     # announce BOTH PAIRS — the phrase the render path fills <TRIGGER> with is
-    # "<trigger>, <gender>" (wanly-console#487), so "p@y & d@vid" + the group-0 gender
-    # would render "d@vid, woman", a token pair that was never trained: group 1's face
-    # bound to "man". The row's trigger becomes the full joint phrase, "p@y, woman &
+    # "<trigger>, <gender>" (wanly-console#487), so a bare "p@y and d@vid" + the group-0
+    # gender would render "d@vid, woman", a token pair that was never trained: group 1's
+    # face bound to "man". The row's trigger becomes the full joint phrase, "p@y, woman and
     # d@vid, man" — exactly what the captions taught, in the order the datasets trained —
-    # and the gender slot is left holding the phrase too (readers that use the bare
-    # trigger get the same tokens). The joint phrase rides the trigger column because
-    # trigger_phrase() concatenates trigger + gender onto whatever the row carries; a
-    # separate "both pairs" column would be a second read of the same shape.
+    # and the gender slot is left None (the phrase carries both). The joint phrase rides
+    # the trigger column because trigger_phrase() concatenates trigger + gender onto
+    # whatever the row carries; a separate "both pairs" column would be a second read of
+    # the same shape.
+    #
+    # " and " (JOINT_SEPARATOR) is the split point the render reads back: a two-person pose
+    # fills <TRIGGER> with the first pair and <TRIGGER2> with the second, so each trigger
+    # lands next to its person. Not "&": the captions never contained it.
     joint = job.second_identity
     if joint:
         g0 = (job.config or {}).get("gender")
         g1 = joint.get("gender")
-        trigger = f"{job.trigger}, {g0} & {joint['trigger']}, {g1}"
+        # Each side is the caption pair it trained on, with the gender only when one was
+        # recorded -- never the literal "None".
+        p0 = f"{job.trigger}, {g0}" if g0 else job.trigger
+        p1 = f"{joint['trigger']}, {g1}" if g1 else joint["trigger"]
+        trigger = f"{p0} and {p1}"
         gender = None
     else:
         trigger = job.trigger

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -932,10 +932,11 @@ class TestTheJointRun:
         from sqlalchemy import select
         row = (await db.execute(select(LtxCharacter).where(
             LtxCharacter.name == "pay"))).scalar_one()
-        assert row.trigger == "p@y, woman & d@vid, man", (
+        assert row.trigger == "p@y, woman and d@vid, man", (
             "the joint phrase was wrong — the render path fills <TRIGGER> with "
-            "'<trigger>, <gender>' (wanly-console#487), so 'p@y & d@vid' + the group-0 "
-            "gender would render 'd@vid, woman', a token pair that was never trained")
+            "'<trigger>, <gender>' (wanly-console#487) and SPLITS this phrase on ' and ' "
+            "across <TRIGGER>/<TRIGGER2> for a two-person pose, so each pair lands beside "
+            "its person. '&' is not the separator: the captions never contained it.")
 
     async def test_publishing_a_single_run_stays_single(self, db):
         """Every run before #102 is single-identity; its row's trigger is unchanged."""

--- a/tests/test_two_characters.py
+++ b/tests/test_two_characters.py
@@ -172,3 +172,41 @@ class TestResolveTrigger:
         ]}
         out = await _resolve_trigger(db, "<TRIGGER> and <TRIGGER2>", blob)
         assert out == "p@y, woman and d@vid, man"
+
+
+class TestJointPhrase:
+    """A JOINT character (wanly-api#102) carries BOTH identities in ONE trigger, joined by
+    " and ". The render splits it back apart so each pair fills its own placeholder.
+
+    The bug this fixes: the whole joint phrase landed in <TRIGGER> and <TRIGGER2> was left
+    empty, so a two-person pose read "p@yton, woman and d@vid, man and . <scene>" -- both
+    triggers dumped in one place instead of each beside its person, and the model favoured
+    the first (Payton held, David drifted)."""
+
+    JOINT = "p@yton, woman and d@vid, man"
+
+    def test_a_two_person_pose_splits_each_pair_to_its_own_placeholder(self):
+        out = render_prompt("<TRIGGER> and <TRIGGER2>, a scene", [self.JOINT])
+        assert out == "p@yton, woman and d@vid, man, a scene"
+
+    def test_the_split_places_each_trigger_beside_its_person(self):
+        out = render_prompt("<TRIGGER> grips <TRIGGER2>", [self.JOINT])
+        assert out == "p@yton, woman grips d@vid, man"
+
+    def test_a_one_person_pose_keeps_the_whole_phrase(self):
+        """Splitting here would leave the second identity nowhere to go -- DROPPING it."""
+        out = render_prompt("<TRIGGER>, a scene", [self.JOINT])
+        assert out == "p@yton, woman and d@vid, man, a scene"
+
+    def test_the_legacy_ampersand_phrase_still_splits(self):
+        out = render_prompt("<TRIGGER> and <TRIGGER2>", ["p@yton, woman & d@vid, man"])
+        assert out == "p@yton, woman and d@vid, man"
+
+    def test_a_single_phrase_is_untouched(self):
+        assert render_prompt("<TRIGGER> and <TRIGGER2>", ["p@yton, woman"]) == \
+            "p@yton, woman and <TRIGGER2>"
+
+    def test_a_trigger_containing_and_is_not_mangled(self):
+        """" and " in a normal phrase must not split unless it yields two real parts."""
+        assert render_prompt("<TRIGGER> and <TRIGGER2>", ["rock and roll"]) == \
+            "rock and roll and <TRIGGER2>"


### PR DESCRIPTION
Follow-up to wanly-gpu-docker#102, from a real render: a joint LoRA held Payton and dropped David.

## Why

The joint character's trigger is ONE phrase, `p@yton, woman & d@vid, man`. A two-person pose has `<TRIGGER>` and `<TRIGGER2>`, but the whole phrase went into `<TRIGGER>` and `<TRIGGER2>` was left empty — so the pose's per-person sentences (`<TRIGGER> grips <TRIGGER2>...`) couldn't put each trigger beside its person, and the model favoured the first concept. `&` also never appeared in the training captions — out of distribution in the exact place the binding happens.

## What

- `render_prompt` splits a joint phrase on `JOINT_SEPARATOR` (`" and "`) **when the template has a second placeholder**: `<TRIGGER>` gets `p@yton, woman`, `<TRIGGER2>` gets `d@vid, man`.
- A **one-person pose keeps the whole phrase** — splitting there would leave the second identity nowhere to go and drop it.
- The legacy `&` form is still read, never written. `_publish_character` builds each side from its own gender, writes the natural `"and"`, and never the literal `"None"`.
- A comma is required on top of the separator, so a plain free-text trigger containing `" and "` is not mangled.

## Verification

- Red-green: with the split disabled, 3 `TestJointPhrase` tests fail; restored, all pass.
- Full suite **1049 passed** (REQUIRE_DB=1).
- Console mirror ships in the wanly-console PR (the console renders the submitted prompt, so both sides must agree).
- **Existing `DavidPayton` row updated in place** to `p@yton, woman and d@vid, man` — no re-publish needed.

## Still not fixed (the real one)

This makes the prompt place each trigger correctly; it does not teach the model that both identities appear together. Training images containing **both characters** are the actual fix (David is handling the data). Also worth testing: rank 64, and the R2 two-stacked-LoRA baseline for comparison.