### PR TITLE
Train on N groups, including two-person frames

### DIFF
--- a/alembic/versions/098_training_identities.py
+++ b/alembic/versions/098_training_identities.py
@@ -1,0 +1,57 @@
+"""Generalize TrainingJob.second_identity into an identities list
+
+Revision ID: 098
+Revises: 097
+Create Date: 2026-09-12
+
+#102 gave a joint run ONE second identity. #106 needs a THIRD group -- two-person frames
+trained alongside the solo sets -- and a list is the honest shape for "one or more extra
+groups" rather than a second nullable column that would need a fourth for the next case.
+
+The backfill is the whole reason this is safe: every existing row with a second_identity
+becomes a one-element list, byte-for-byte, before the old column is dropped. A row with
+none stays NULL. Nothing is lost and no reader sees a half-migrated shape.
+"""
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "098"
+down_revision = "097"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "training_jobs",
+        sa.Column("identities", postgresql.JSONB(), nullable=True),
+    )
+    # The group is made SELF-CONTAINED: #102 stored its caption separately in
+    # config.second_caption, and the claim reads each group's own caption. Fold it in, with
+    # the "<trigger>, <gender>" form as the fallback so an old row renders exactly as it did.
+    op.execute(
+        "UPDATE training_jobs SET identities = jsonb_build_array("
+        "  second_identity || jsonb_build_object('caption', COALESCE("
+        "    config->>'second_caption',"
+        "    CASE WHEN second_identity->>'gender' IS NOT NULL"
+        "         THEN (second_identity->>'trigger') || ', ' || (second_identity->>'gender')"
+        "         ELSE second_identity->>'trigger' END)))"
+        "WHERE second_identity IS NOT NULL"
+    )
+    op.drop_column("training_jobs", "second_identity")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "training_jobs",
+        sa.Column("second_identity", postgresql.JSONB(), nullable=True),
+    )
+    # The first element is the second identity #102 meant; a run with more than two groups
+    # cannot round-trip and says so by keeping only the first.
+    op.execute(
+        "UPDATE training_jobs SET second_identity = identities -> 0 "
+        "WHERE identities IS NOT NULL AND jsonb_array_length(identities) > 0"
+    )
+    op.drop_column("training_jobs", "identities")

--- a/app/models.py
+++ b/app/models.py
@@ -488,13 +488,16 @@ class TrainingJob(Base):
     # when the job was created, so a later change to the defaults cannot retroactively alter
     # what a queued job will do.
     config = mapped_column(JSONB, nullable=False, default=dict)
-    # A SECOND identity for a joint run (#102): {character, trigger, gender, images: [s3],
-    # num_repeats}. NULL means single-identity, which every run before this is. The two
-    # groups stay paired because they travel together: one LoRA whose Payton delta is
-    # learned in the presence of David's data is exactly what escaping two-identity
-    # interference (#100, R2) requires, and two separate rows cannot express that -- the
-    # network trains one dataset config, not one per identity.
-    second_identity = mapped_column(JSONB, nullable=True)
+    # ADDITIONAL identity groups for a joint run (#102, #106): a list of
+    # {character, trigger, gender, caption, images: [s3], num_repeats}. Group 0 is the flat
+    # columns above; this holds groups 1..N, so one LoRA can be trained on both solo sets
+    # AND two-person frames -- the frames are what teach the model the two identities
+    # appear TOGETHER, which solo sets alone cannot (#106). NULL or [] means
+    # single-identity, which every run before #102 is.
+    #
+    # A list rather than a second_identity column plus a third: "how many extra groups"
+    # is a property of the experiment, not of the schema.
+    identities = mapped_column(JSONB, nullable=True)
 
     # ---- who is doing it
     status = mapped_column(String(20), nullable=False, default=TrainingStatus.PENDING)

--- a/app/routes/training.py
+++ b/app/routes/training.py
@@ -97,72 +97,86 @@ async def create_training_job(
     if len(set(images)) != len(images):
         raise HTTPException(status_code=422, detail="the dataset contains duplicates")
 
-    # THE JOINT GROUP (#102). Resolved the same way group 0 is: a dataset or a raw list for
-    # the images, the trigger rule for the caption, its own num_repeats. ABSENT stays
-    # absent -- a half-given second identity (a trigger with no images) would build a
-    # half-configured dataset silently, so all-or-nothing is enforced here rather than on
-    # the schema, because it straddles the dataset resolution that only the route can do.
-    second = None
-    if body.second_character:
-        second_images = list(body.second_dataset_images)
-        second_thumbnail = None
-        if body.second_dataset_id:
-            sds = await db.get(Dataset, body.second_dataset_id)
-            if not sds:
-                raise HTTPException(status_code=404, detail="Second dataset not found")
-            second_images = list(sds.images)
-            second_thumbnail = sds.anchor_uri or (sds.images[0] if sds.images else None)
-        if len(second_images) < MIN_DATASET_IMAGES:
+    # THE EXTRA GROUPS (#102, #106). Resolved the same way group 0 is: a dataset or a raw
+    # list for the images, the trigger rule for the caption, its own num_repeats. The list
+    # may hold IDENTITY groups (a trigger -> "<trigger>, <gender>") and COMPOSITION groups
+    # (no trigger -> a free caption naming the people in the frames). The latter is what
+    # teaches the model the identities appear TOGETHER (#106): solo sets alone cannot, and a
+    # run with only solo groups produced a LoRA that held one face and dropped the other.
+    #
+    # The pre-#106 single second identity is folded in as a group when the console has not
+    # shipped the list form yet -- dropping it would silently make a joint run single.
+    extra = list(body.identities)
+    legacy = body.legacy_second_group()
+    if legacy is not None and not extra:
+        extra = [legacy]
+
+    groups: list[dict] = []
+    seen_dataset_ids = {body.dataset_id} if body.dataset_id else set()
+    seen_triggers = {body.trigger}
+    for i, g in enumerate(extra):
+        label = f"identity {i + 2}"  # 1-based: group 0 is the first
+        g_images = list(g.dataset_images)
+        if g.dataset_id:
+            gds = await db.get(Dataset, g.dataset_id)
+            if not gds:
+                raise HTTPException(status_code=404, detail=f"{label}: dataset not found")
+            g_images = list(gds.images)
+            if g.dataset_id in seen_dataset_ids:
+                # One dataset captioned two ways would train every image under both
+                # captions, which is not what any group is asking for.
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"{label}: this dataset is already used by another group; give "
+                           f"each group its own set (repeats balance them, not sharing)")
+            seen_dataset_ids.add(g.dataset_id)
+            if gds.anchor_uri and not thumbnail:
+                thumbnail = gds.anchor_uri
+        if len(g_images) < MIN_DATASET_IMAGES:
             raise HTTPException(
                 status_code=422,
-                detail=f"{len(second_images)} second-identity images — at least "
-                       f"{MIN_DATASET_IMAGES} are needed")
-        if len(set(second_images)) != len(second_images):
-            raise HTTPException(status_code=422, detail="the second dataset contains duplicates")
-        if body.second_dataset_id and body.second_dataset_id == body.dataset_id:
-            # One dataset training both identities captions every image per group -- the
-            # same file cannot carry two triggers at once, and the parity of images across
-            # groups would be accidental rather than intended.
-            raise HTTPException(
-                status_code=422,
-                detail="group 0 and the second identity cannot share one dataset; give each "
-                       "its own (the datasets balance through num_repeats, not by sharing)")
-        if not body.second_trigger:
-            raise HTTPException(
-                status_code=422,
-                detail=f"the second identity ({body.second_character}) has no trigger; its "
-                       f"caption would bind to nothing")
-        if body.second_trigger == body.trigger:
-            raise HTTPException(
-                status_code=422,
-                detail="the two identities' triggers must differ — one caption pair cannot "
-                       "anchor both faces")
-        # THE SAME CAPTION RULE, PER GROUP. Group 0's caption learns "<trigger>,
-        # <gender>"; group 1's must say the same thing about its own trigger, or the joint
-        # LoRA's second face binds to whatever the text happens to be.
-        second_caption = None
-        if body.second_gender:
-            second_caption = f"{body.second_trigger}, {body.second_gender}"
-        elif not body.second_caption:
-            # A joint group without a resolved caption would fall back to the TRAINER's
-            # per-job caption default -- which carries GROUP 0's trigger. Its face would
-            # bind to the wrong person's token and the interference this run exists to
-            # escape would arrive through the captions instead. A free caption naming the
-            # second trigger is accepted; anything else is refused.
-            raise HTTPException(
-                status_code=422,
-                detail=f"the second identity ({body.second_character}) needs a gender or a "
-                       f"caption that names its trigger — otherwise the joint LoRA's second "
-                       f"face binds to nothing")
-        second = {
-            "character": body.second_character,
-            "trigger": body.second_trigger,
-            "gender": body.second_gender,
-            "images": second_images,
-            "num_repeats": body.second_num_repeats,
-        }
-        if second_thumbnail and not thumbnail:
-            thumbnail = second_thumbnail
+                detail=f"{label}: {len(g_images)} images — at least {MIN_DATASET_IMAGES} "
+                       f"are needed")
+        if len(set(g_images)) != len(g_images):
+            raise HTTPException(status_code=422, detail=f"{label}: dataset contains duplicates")
+
+        if g.trigger:
+            # AN IDENTITY GROUP. Its pair joins the published phrase, and the triggers must
+            # differ -- one caption pair cannot anchor two faces.
+            if g.trigger in seen_triggers:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"{label}: trigger {g.trigger!r} is already used by another "
+                           f"group — one caption pair cannot anchor two faces")
+            seen_triggers.add(g.trigger)
+            if g.gender:
+                g_caption = f"{g.trigger}, {g.gender}"
+            elif g.caption:
+                g_caption = g.caption
+            else:
+                # Falls back to the trainer's per-job caption default, which carries GROUP
+                # 0's trigger -- the wrong face's token.
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"{label}: needs a gender or a caption that names its trigger — "
+                           f"otherwise its face binds to nothing")
+        else:
+            # A COMPOSITION GROUP. No trigger: the caption is used verbatim and must name
+            # at least two triggers, or the frames teach nothing the solo sets did not.
+            g_caption = (g.caption or "").strip() or None
+            if not g_caption:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"{label}: no trigger, so it needs a caption naming the people "
+                           f"in its frames (e.g. \"p@yton, woman and d@vid, man\")")
+        groups.append({
+            "character": g.character,
+            "trigger": g.trigger,
+            "gender": g.gender,
+            "caption": g_caption,
+            "images": g_images,
+            "num_repeats": g.num_repeats,
+        })
 
     dupe = (await db.execute(
         select(TrainingJob).where(
@@ -204,11 +218,10 @@ async def create_training_job(
         version=body.version,
         dataset_images=images,
         config={**RECIPE_DEFAULTS, "steps": steps, "caption": caption,
-                "second_caption": second_caption if second else None,
                 "gender": body.gender,
                 "lora_name": body.lora_name or _default_lora_name(body.character),
                 "publish": body.publish},
-        second_identity=second,
+        identities=groups or None,
         status=TrainingStatus.PENDING,
         total_steps=steps,
         thumbnail_uri=thumbnail,
@@ -283,14 +296,22 @@ async def claim_next_training_job(
     try:
         urls = await asyncio.to_thread(
             lambda: [s3.generate_presigned_url(u) for u in job.dataset_images])
-        # THE JOINT GROUP, PRESIGNED WITH GROUP 0. One presign pass so a failure in either
-        # leaves the row untouched -- the lost-claim-response rule above applies to the
-        # second dataset the same as the first, and a joint run that delivered group 0
-        # only would stage a single-identity dataset silently, which is worse than a 503.
-        second_urls = None
-        if job.second_identity:
-            second_urls = await asyncio.to_thread(
-                lambda: [s3.generate_presigned_url(u) for u in job.second_identity["images"]])
+        # THE EXTRA GROUPS, PRESIGNED WITH GROUP 0. One presign pass so a failure anywhere
+        # leaves the row untouched -- the lost-claim-response rule above applies to every
+        # dataset the same as the first, and a joint run that delivered group 0 only would
+        # stage a single-identity dataset silently, which is worse than a 503.
+        group_payload = []
+        for g in (job.identities or []):
+            g_urls = await asyncio.to_thread(
+                lambda imgs=g["images"]: [s3.generate_presigned_url(u) for u in imgs])
+            group_payload.append({
+                "character": g.get("character"),
+                "trigger": g.get("trigger"),
+                "gender": g.get("gender"),
+                "caption": g.get("caption"),
+                "num_repeats": g.get("num_repeats"),
+                "download_urls": g_urls,
+            })
     except Exception as e:
         logger.error("could not presign the dataset for %s v%d: %s",
                      job.character, job.version, e)
@@ -309,11 +330,7 @@ async def claim_next_training_job(
     await db.refresh(job)
     logger.info("training %s v%d claimed by %s", job.character, job.version, job.worker_name)
     claim = TrainingClaimResponse(**TrainingResponse.model_validate(job).model_dump(),
-                                  download_urls=urls)
-    if job.second_identity:
-        claim.second_download_urls = second_urls
-        claim.second_caption = (job.config or {}).get("second_caption")
-        claim.second_num_repeats = job.second_identity.get("num_repeats")
+                                  download_urls=urls, identities=group_payload or None)
     return claim
 
 
@@ -473,30 +490,34 @@ async def _publish_character(db: AsyncSession, job: TrainingJob) -> None:
         select(LtxCharacter).where(LtxCharacter.name == job.character)
     )).scalar_one_or_none()
     gender = (job.config or {}).get("gender") or None
-    # A JOINT RUN (#102) publishes its SECOND identity's trigger too. The row carries ONE
-    # trigger and ONE gender slot, and a joint LoRA trained on two caption pairs must
-    # announce BOTH PAIRS — the phrase the render path fills <TRIGGER> with is
-    # "<trigger>, <gender>" (wanly-console#487), so a bare "p@y and d@vid" + the group-0
-    # gender would render "d@vid, woman", a token pair that was never trained: group 1's
-    # face bound to "man". The row's trigger becomes the full joint phrase, "p@y, woman and
-    # d@vid, man" — exactly what the captions taught, in the order the datasets trained —
-    # and the gender slot is left None (the phrase carries both). The joint phrase rides
-    # the trigger column because trigger_phrase() concatenates trigger + gender onto
-    # whatever the row carries; a separate "both pairs" column would be a second read of
-    # the same shape.
+    # A JOINT RUN (#102, #106) publishes EVERY identity's trigger. The row carries ONE
+    # trigger and ONE gender slot, and a LoRA trained on several caption pairs must announce
+    # them all — the phrase the render path fills <TRIGGER> with is "<trigger>, <gender>"
+    # (wanly-console#487), so a bare "p@y and d@vid" + one gender would render a pair that
+    # was never trained. The row's trigger becomes the full phrase, "p@y, woman and d@vid,
+    # man" — exactly what the captions taught, in the order the groups were given — and the
+    # gender slot is left None (the phrase carries them all).
+    #
+    # Only IDENTITY groups contribute a pair. A COMPOSITION group (#106) has no trigger: its
+    # caption repeats pairs already here, and including it would say the same face twice.
     #
     # " and " (JOINT_SEPARATOR) is the split point the render reads back: a two-person pose
     # fills <TRIGGER> with the first pair and <TRIGGER2> with the second, so each trigger
     # lands next to its person. Not "&": the captions never contained it.
-    joint = job.second_identity
-    if joint:
-        g0 = (job.config or {}).get("gender")
-        g1 = joint.get("gender")
-        # Each side is the caption pair it trained on, with the gender only when one was
-        # recorded -- never the literal "None".
-        p0 = f"{job.trigger}, {g0}" if g0 else job.trigger
-        p1 = f"{joint['trigger']}, {g1}" if g1 else joint["trigger"]
-        trigger = f"{p0} and {p1}"
+    pairs: list[str] = []
+
+    def _add_pair(trig: str | None, gen: str | None) -> None:
+        if not trig:
+            return
+        pair = f"{trig}, {gen}" if gen else trig
+        if pair not in pairs:
+            pairs.append(pair)
+
+    _add_pair(job.trigger, gender)
+    for g in (job.identities or []):
+        _add_pair(g.get("trigger"), g.get("gender"))
+    if len(pairs) > 1:
+        trigger = " and ".join(pairs)
         gender = None
     else:
         trigger = job.trigger

--- a/app/schemas/training.py
+++ b/app/schemas/training.py
@@ -28,6 +28,51 @@ MIN_DATASET_IMAGES = 8
 MAX_DATASET_IMAGES = 400
 
 
+class IdentityGroup(BaseModel):
+    """One EXTRA dataset trained alongside group 0 (wanly-api#102, #106).
+
+    Two shapes, and the difference is whether a trigger is given:
+
+      identity group    character/trigger/gender set -> every image captioned
+                        "<trigger>, <gender>", exactly like group 0. Its pair joins the
+                        published trigger phrase.
+      composition group NO trigger -> `caption` is used verbatim. The images contain BOTH
+                        characters and the caption names both ("p@yton, woman and d@vid,
+                        man"). This is what teaches the model the two identities appear
+                        TOGETHER, which solo sets alone cannot (#106) -- and its caption
+                        repeats triggers the identity groups already carry, so it does NOT
+                        add to the published phrase.
+    """
+    character: str | None = Field(default=None, max_length=64)
+    trigger: str | None = Field(default=None, max_length=64)
+    gender: Literal["woman", "man", "person"] | None = None
+    #: Free caption for a composition group. When a trigger+gender are given this is
+    #: ignored, the same way group 0's `caption` is.
+    caption: str | None = Field(default=None, max_length=500)
+    dataset_images: list[str] = Field(default_factory=list, max_length=MAX_DATASET_IMAGES)
+    dataset_id: uuid.UUID | None = None
+    num_repeats: int | None = Field(default=None, ge=1, le=100)
+
+    @field_validator("character")
+    @classmethod
+    def _no_path_tricks(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if "/" in v or v.startswith(".") or any(c.isspace() for c in v):
+            raise ValueError("character cannot contain slashes, whitespace, or start with a dot")
+        return v
+
+    @field_validator("dataset_images")
+    @classmethod
+    def _s3_uris_only(cls, v: list[str]) -> list[str]:
+        bad = [x for x in v if not x.startswith("s3://")]
+        if bad:
+            raise ValueError(f"dataset_images must be s3:// URIs, got {bad[0]!r}")
+        if len(set(v)) != len(v):
+            raise ValueError("dataset_images contains duplicates")
+        return v
+
+
 class TrainingCreate(BaseModel):
     #: THE LtxCharacter NAME, not a filesystem-safe version of it. `p@y` is correct here.
     #:
@@ -71,23 +116,20 @@ class TrainingCreate(BaseModel):
     #: outlast the training, for epochs that mostly go unused. "all" uploads every one.
     #: Either way every epoch stays on the trainer and can be published afterwards.
     publish: Literal["final", "all"] = "final"
-    #: A SECOND identity, making this a JOINT run (#102): one LoRA trained on both
-    #: characters' datasets simultaneously, whose group-0 delta is learned in the presence
-    #: of group-1's data. This is the structural fix for two-identity interference (#100,
-    #: R2: no strength setting recovers two-char identity; two independently-trained deltas
-    #: fight in the shared modules). ABSENT means single-identity, which every run before
-    #: this is.
-    #:
-    #: The fields mirror group 0's, with its own images and num_repeats: the two datasets
-    #: balance through repeats, not by truncating the smaller set.
+    #: ADDITIONAL groups (wanly-api#102, #106), each an IdentityGroup -- an identity set
+    #: or a composition set. Empty means single-identity. The route resolves and validates
+    #: them the same way it does group 0.
+    identities: list[IdentityGroup] = Field(default_factory=list, max_length=8)
+    #: LEGACY (#102): the one-second-identity fields, before #106 made it a list. Accepted
+    #: so an old console cannot silently drop its second group by sending fields a new API
+    #: no longer reads; folded into `identities` in the route. Never written by the console
+    #: once it ships the list form.
     second_character: str | None = Field(default=None, min_length=1, max_length=64)
     second_trigger: str | None = Field(default=None, min_length=1, max_length=64)
     second_gender: Literal["woman", "man", "person"] | None = None
     second_dataset_images: list[str] = Field(default_factory=list, max_length=MAX_DATASET_IMAGES)
     second_dataset_id: uuid.UUID | None = None
     second_num_repeats: int | None = Field(default=None, ge=1, le=100)
-    #: A free caption for the second group, used when second_gender is absent. Must name
-    #: the second trigger, or the face binds to nothing — the route enforces that.
     second_caption: str | None = Field(default=None, max_length=500)
 
     @field_validator("character")
@@ -106,6 +148,16 @@ class TrainingCreate(BaseModel):
         if "/" in v or v.startswith(".") or any(c.isspace() for c in v):
             raise ValueError("second_character cannot contain slashes, whitespace, or start with a dot")
         return v
+
+    def legacy_second_group(self) -> IdentityGroup | None:
+        """The pre-#106 second identity as an IdentityGroup, or None when absent."""
+        if not self.second_character:
+            return None
+        return IdentityGroup(
+            character=self.second_character, trigger=self.second_trigger,
+            gender=self.second_gender, caption=self.second_caption,
+            dataset_images=list(self.second_dataset_images),
+            dataset_id=self.second_dataset_id, num_repeats=self.second_num_repeats)
 
     @field_validator("dataset_images")
     @classmethod
@@ -172,13 +224,15 @@ class TrainingClaimResponse(TrainingResponse):
 
     `download_urls` pairs 1:1 with dataset_images, in order, so the trainer never needs S3
     credentials -- it fetches through the API's own proxy, the same way the render daemon gets
-    its LoRAs. second_* carry the joint group the same way: ABSENT for every single-identity
-    run, so a trainer that predates #102 sees nothing.
+    its LoRAs.
+
+    `identities` carries the extra groups (#102, #106) the same way: each is
+    {character, trigger, gender, caption, num_repeats, download_urls}. ABSENT for every
+    single-identity run, so a trainer that predates this sees nothing. A COMPOSITION group
+    (#106) has a trigger of None and a caption naming the people in its frames.
     """
     download_urls: list[str]
-    second_download_urls: list[str] | None = None
-    second_caption: str | None = None
-    second_num_repeats: int | None = None
+    identities: list[dict] | None = None
 
 
 class TrainingProgress(BaseModel):

--- a/tests/test_training_jobs.py
+++ b/tests/test_training_jobs.py
@@ -878,53 +878,97 @@ class TestTheCaptionCarriesTheTrigger:
 
 
 class TestTheJointRun:
-    """A joint two-identity run (wanly-api#102): one LoRA trained on both characters'
-    datasets at once, whose group-0 delta is learned in the presence of group-1's. This
-    is the structural fix for two-identity interference (wanly-gpu-docker#100, R2: no
-    strength setting recovers two-char identity) — and the R2 runbook lives at
-    ~/projects/wanly/r2-two-char-experiment.md."""
+    """A joint run (wanly-api#102, #106): one LoRA trained on several groups at once.
 
-    def _second(self, n=13):
-        return [f"s3://wanly-images/2026-09-11/m{i}.jpg" for i in range(n)]
+    #102 was two identities; #106 added COMPOSITION groups -- frames containing BOTH
+    characters, captioned with both triggers. That is the group that teaches the model the
+    identities appear together; a run of solo sets alone produced a LoRA that held one face
+    and dropped the other (wanly-gpu-docker#100/#102)."""
 
-    def test_second_identity_mirrors_group_zero(self):
-        """The joint fields mirror the first group's shape; absent stays absent."""
+    def _imgs(self, prefix, n=13):
+        return [f"s3://wanly-images/2026-09-11/{prefix}{i}.jpg" for i in range(n)]
+
+    def test_the_legacy_second_identity_is_still_accepted(self):
+        """An old console must not silently drop its second group by sending fields a new
+        API no longer reads."""
         body = TrainingCreate(
             character="pay", trigger="p@y", dataset_images=_images(), steps=1200,
             second_character="Me", second_trigger="d@vid", second_gender="man",
-            second_dataset_images=self._second())
-        assert body.second_trigger == "d@vid"
-        assert len(body.second_dataset_images) == 13
-        plain = TrainingCreate(character="pay", trigger="p@y",
-                               dataset_images=_images(steps=1200) if False else _images())
-        assert plain.second_character is None
+            second_dataset_images=self._imgs("m"))
+        g = body.legacy_second_group()
+        assert g is not None and g.trigger == "d@vid" and g.gender == "man"
+        plain = TrainingCreate(character="pay", trigger="p@y", dataset_images=_images())
+        assert plain.legacy_second_group() is None
+
+    def test_identities_take_identity_and_composition_groups(self):
+        body = TrainingCreate(
+            character="pay", trigger="p@y", dataset_images=_images(), steps=1200,
+            identities=[
+                # identity group: a trigger -> caption "<trigger>, <gender>"
+                {"character": "Me", "trigger": "d@vid", "gender": "man",
+                 "dataset_images": self._imgs("m")},
+                # composition group: no trigger, a free caption naming both
+                {"caption": "p@y, woman and d@vid, man",
+                 "dataset_images": self._imgs("c")},
+            ])
+        assert [g.trigger for g in body.identities] == ["d@vid", None]
+        assert body.identities[1].caption == "p@y, woman and d@vid, man"
 
     def test_identical_triggers_are_refused(self):
-        """One caption pair cannot anchor both faces — the triggers must differ."""
-        from app.routes.training import create_training_job
+        """One caption pair cannot anchor two faces -- the triggers must differ."""
         import inspect
+        from app.routes.training import create_training_job
         src = inspect.getsource(create_training_job)
-        assert "second_trigger == body.trigger" in src
+        assert "already used by another" in src
 
-    def test_second_identity_needs_a_resolved_caption(self):
-        """A joint group without gender or a caption naming its trigger would fall back
-        to the trainer's per-job caption default — which carries GROUP 0's trigger. Its
-        face would bind to the wrong person's token."""
+    def test_an_identity_group_needs_a_resolved_caption(self):
+        """A group without gender or a caption naming its trigger would fall back to the
+        trainer's per-job caption default -- which carries GROUP 0's trigger. Its face
+        would bind to the wrong person's token."""
         import inspect
         from app.routes.training import create_training_job
         src = inspect.getsource(create_training_job)
-        assert "second_caption" in src
-        assert "needs a gender or a" in src
+        assert "needs a gender or a caption that names its trigger" in src
+
+    def test_a_composition_group_needs_a_caption(self):
+        """No trigger means the caption is the only thing that can name the people in the
+        frames; without one the group trains nothing the solo sets did not."""
+        import inspect
+        from app.routes.training import create_training_job
+        src = inspect.getsource(create_training_job)
+        assert "needs a caption naming the people" in src
 
     async def test_publishing_a_joint_run_records_both_triggers(self, db):
-        """The character row carries ONE trigger; a joint LoRA trained on two caption
-        pairs must announce both, or a pose fills <TRIGGER> with one and the second face
-        renders unbound."""
+        """The character row carries ONE trigger; a LoRA trained on several caption pairs
+        must announce them all, split across <TRIGGER>/<TRIGGER2> by the render."""
         j = _job(
             output_lora_path="s3://ltx-loras/character/payme_v1_final.safetensors",
             config={"gender": "woman", "caption": "p@y, woman"},
-            second_identity={"character": "Me", "trigger": "d@vid", "gender": "man",
-                             "images": self._second(), "num_repeats": 10})
+            identities=[{"character": "Me", "trigger": "d@vid", "gender": "man",
+                         "caption": "d@vid, man", "images": self._imgs("m"),
+                         "num_repeats": 10}])
+        db.add(j)
+        await db.flush()
+        await _publish_character(db, j)
+        await db.flush()
+        from sqlalchemy import select
+        row = (await db.execute(select(LtxCharacter).where(
+            LtxCharacter.name == "pay"))).scalar_one()
+        assert row.trigger == "p@y, woman and d@vid, man"
+
+    async def test_a_composition_group_does_not_add_a_pair(self, db):
+        """#106: the composition group's caption repeats the identity pairs. Including it
+        in the phrase would say the same face twice."""
+        j = _job(
+            output_lora_path="s3://ltx-loras/character/payme_v1_final.safetensors",
+            config={"gender": "woman"},
+            identities=[
+                {"character": "Me", "trigger": "d@vid", "gender": "man",
+                 "caption": "d@vid, man", "images": self._imgs("m")},
+                # composition: no trigger, caption names both
+                {"character": None, "trigger": None, "gender": None,
+                 "caption": "p@y, woman and d@vid, man", "images": self._imgs("c")},
+            ])
         db.add(j)
         await db.flush()
         await _publish_character(db, j)
@@ -933,10 +977,7 @@ class TestTheJointRun:
         row = (await db.execute(select(LtxCharacter).where(
             LtxCharacter.name == "pay"))).scalar_one()
         assert row.trigger == "p@y, woman and d@vid, man", (
-            "the joint phrase was wrong — the render path fills <TRIGGER> with "
-            "'<trigger>, <gender>' (wanly-console#487) and SPLITS this phrase on ' and ' "
-            "across <TRIGGER>/<TRIGGER2> for a two-person pose, so each pair lands beside "
-            "its person. '&' is not the separator: the captions never contained it.")
+            "the composition group's pair leaked into the phrase")
 
     async def test_publishing_a_single_run_stays_single(self, db):
         """Every run before #102 is single-identity; its row's trigger is unchanged."""
@@ -950,3 +991,32 @@ class TestTheJointRun:
             LtxCharacter.name == "pay"))).scalar_one()
         assert row.trigger == "p@y"
         assert "&" not in row.trigger
+
+
+class TestTheClaimDeliversEveryGroup:
+    """#106: a claim must carry every group's URLs, not just group 0's. A joint run that
+    delivered group 0 only would stage a single-identity dataset silently -- worse than a
+    503, because it trains and reports success."""
+
+    def test_the_presign_loop_covers_every_identity_group(self):
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.claim_next_training_job)
+        assert "for g in (job.identities or [])" in src
+        assert '"download_urls": g_urls' in src
+
+    def test_a_presign_failure_anywhere_aborts_the_whole_claim(self):
+        """All groups presign inside the one try, so a failure leaves the row untouched
+        rather than claiming a job whose second dataset never arrived."""
+        import inspect
+        from app.routes import training as mod
+        src = inspect.getsource(mod.claim_next_training_job)
+        presign = src.index("group_payload = []")
+        mutate = src.index("job.status = TrainingStatus.CLAIMED")
+        assert presign < mutate
+
+    def test_the_claim_response_carries_the_group_list(self):
+        from app.schemas.training import TrainingClaimResponse
+        fields = TrainingClaimResponse.model_fields
+        assert "identities" in fields
+        assert "second_download_urls" not in fields

--- a/tests/test_two_characters.py
+++ b/tests/test_two_characters.py
@@ -5,10 +5,10 @@ and the scalar keys stay mirrored from slot 0 so nothing written before the list
 """
 import pytest
 
-from app.model_requirements import LORA, Artifact, required_artifacts
+from app.model_requirements import LORA, required_artifacts
 from app.models import LtxCharacter
 from app.recipe_blob import (
-    MAX_CHARACTERS, TRIGGER2_PLACEHOLDER, character_phrase, recipe_characters, recipe_problem,
+    MAX_CHARACTERS, character_phrase, recipe_characters, recipe_problem,
     render_prompt, trigger_phrase,
 )
 from app.routes.wildcards import RESERVED_WILDCARD_NAMES


### PR DESCRIPTION
Closes wanly-gpu-docker#106 (API side; trainer + console ship alongside).

## Why

The joint LoRA (#102) held one face and dropped the other. The cause was the **training data**: two *solo* sets, so the network learned two whole-image concepts that compete for one frame. Teaching composition needs **frames containing both characters**, captioned with both triggers — and the run only had room for two groups.

## What

- `TrainingJob.second_identity` (one nullable object) → **`identities` (a list)**. A group is:
  - an **identity** group — a trigger → caption `"<trigger>, <gender>"`, as before; or
  - a **composition** group — **no trigger**, a free `caption` naming the people in its frames.
- `_publish_character` builds the row trigger from the **distinct identity pairs across every group**, so a composition group does not duplicate a pair and three-or-more identities work.
- **Migration 098** makes every existing row self-contained before dropping the old column: `config.second_caption` is folded into the group, with the `"<trigger>, <gender>"` fallback. Verified against rows in both shapes.
- The pre-#106 `second_*` fields are **still accepted** and folded in as a group — an old console cannot silently drop its second identity by sending fields a new API no longer reads.
- The claim presigns **every** group in one pass and delivers them as a list; a failure anywhere leaves the row untouched (rather than claiming a job whose second dataset never arrived).

## Verification

- **1055 passed** (REQUIRE_DB=1, fresh schema).
- New tests: legacy `second_*` folds in; composition-group validation; publishing with a composition group does not duplicate a pair; claim carries the group list; a presign failure aborts the whole claim.
- Migration SQL exercised against a row shaped like the real `DavidPayton` one (both caption shapes → correct `d@vid, man`; NULL stays NULL).